### PR TITLE
Class hierarchy mixins

### DIFF
--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -1,0 +1,31 @@
+--[[
+$module Utility Functions
+
+A library of general Lua utility functions.
+]]
+
+local utils = {}
+
+--[[
+% copy_table(t)
+
+If a table is passed, returns a copy, otherwise returns the passed value.
+
+@ t (mixed)
+: (mixed)
+]]
+function utils.copy_table(t)
+    if type(t) == 'table' then
+        local new = {}
+        for k, v in pairs(t) do
+            new[utils.copy_table(k)] = utils.copy_table(v)
+        end
+        setmetatable(new, utils.copy_table(getmetatable(t)))
+        return new
+    else
+        return t
+    end
+end
+
+
+return utils


### PR DESCRIPTION
First off, apologies for the radio silence. Things have been quite hectic and I anticipate the next week will be even more so. Hopefully things will clear up afterwards.

I will get around to adding some actual mixins when time permits, but I had an idea that it would be good to be able to add mixins at any level in the class hierarchy to reduce unnecessary duplication. So this PR makes the following changes:
- Adds a class_hierarchy module to the library.
- Mixins can now be defined for parent classes, with the usual rules applying regarding global mixins for a child class overriding those for a parent.
- Also adds a utils module to the library for general (ie not Finale-specific) Lua utility functions (it's a bit sparse at the moment but I'd rather add to it as needed).
- Added a couple of missing checks for nil