### PR TITLE
Update repo/docs for RGP Lua

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   persist-credentials: false
                   fetch-depth: 0
-                  repository: Nick-Mazuk/jw-lua-scripts-docs
+                  repository: finale-lua/jw-lua-scripts-docs
                   path: './website'
                   token: ${{ secrets.NICK_PERSONAL_TOKEN }}
             - name: build scripts
@@ -46,7 +46,7 @@ jobs:
                   github_token: ${{ secrets.NICK_PERSONAL_TOKEN }}
                   directory: website
                   branch: main
-                  repository: Nick-Mazuk/jw-lua-scripts-docs
+                  repository: finale-lua/jw-lua-scripts-docs
             - name: Commit & Push docs to this repo
               uses: actions-js/push@v1.3
               with:

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 <p align="center">
- <img width="100px" src="https://www.lua.org/images/powered-by-lua.gif" align="center" alt="JW Lua Scripts" />
- <h1 align="center">JW Lua Scripts</h1>
- <p align="center">A central repository for all JW Lua scripts for Finale.</p>
+ <img width="100px" src="https://www.lua.org/images/powered-by-lua.gif" align="center" alt="Finale Lua Scripts" />
+ <h1 align="center">Finale Lua Scripts</h1>
+ <p align="center">A central repository for all Lua scripts for Finale.</p>
 </p>
 
   <p align="center">
-    <a href="https://jw-lua-scripts-docs.vercel.app">View Docs</a>
+    <a href="https://finalelua.com">View Docs</a>
     ·
-    <a href="https://github.com/Nick-Mazuk/jw-lua-scripts/issues/new/choose">Report Bug</a>
+    <a href="https://github.com/finale-lua/lua-scripts/issues/new/choose">Report Bug</a>
     ·
-    <a href="https://github.com/Nick-Mazuk/jw-lua-scripts/issues/new/choose">Request Feature</a>
+    <a href="https://github.com/finale-lua/lua-scripts/issues/new/choose">Request Feature</a>
   </p>
 </p>
 
 ---
 
-[JW Lua](http://jwmusic.nu/jwplugins/wiki/doku.php?id=jw_lua) allows you to create plugins for Finale. This repo will allow you to easily create and share JW Lua plugins with other Finale users. For developers, this repo even includes a standard library with common functions, drastically improving development time.
+RGP Lua and JW Lua allow you to create plugins for Finale. This repo will allow you to easily create and share Lua plugins with other Finale users. For developers, this repo even includes a standard library with common functions, drastically improving development time.
 
 Table of Contents:
 
@@ -26,13 +26,13 @@ Table of Contents:
 
 ## Usage
 
-To use these scripts, the current best way is to download the entire repository, then add your desired scripts to JW Lua. See https://youtu.be/EFGNuGCEIq4.
+To use these scripts, the current best way is to download the entire repository, then add your desired scripts to RGP Lua or JW Lua. See https://youtu.be/EFGNuGCEIq4.
 
 ## Contribute
 
 We follow the "fork and pull" philosophy. So to make changes, just create a PR. If you need help, check out the [docs](https://jw-lua-scripts-docs.vercel.app/docs/getting-started).
 
-If you've never used JW Lua before, checkout this tutorial series: https://youtu.be/q0pRaD9EwqA
+If you've never used RGP Lua or JW Lua before, checkout this tutorial series: https://youtu.be/q0pRaD9EwqA
 
 ### Become a collaborator
 

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Note: not all requests to become a collaborator will be accepted. You may always
 
 ## License
 
-This project is [CC0](https://github.com/Nick-Mazuk/jw-lua-scripts/blob/master/LICENSE) licensed. Basically, do whatever you want.
+This project is [CC0](https://github.com/finale-lua/lua-scripts/blob/master/LICENSE) licensed. Basically, do whatever you want.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,12 +1,12 @@
 # Getting started
 
-These guides will help you create JW Lua scripts to use with Finale. More specifically, they'll help you create great scripts for the JW Lua Scripts repository. That way, you can build scripts faster, and help other Finale users find them.
+These guides will help you create Lua scripts to use with Finale. More specifically, they'll help you create great scripts for the Lua Scripts repository. That way, you can build scripts faster, and help other Finale users find them.
 
 There are several benefits for contributing to this project:
 
 1. **No need to reinvent the wheel**. We have an extensive and growing [standard library](/docs/library) that includes many of the most common functions you'll need, such as transposition, position calculation, SMuFL font decoding, and much more.
 2. **Easy sharing and distribution**. Just by adding your scripts to the repository, they'll automatically be shared with the rest of the community. Other Finale users will be able to search and download your scripts from this website. You won't need to setup anything.
-3. **See plenty of examples**. There aren't a ton of example scripts out in the wild, but this is the largest open-source collection of JW Lua scripts. You can easily learn how to do almost anything by looking through other's scripts.
+3. **See plenty of examples**. There aren't a ton of example scripts out in the wild, but this is the largest open-source collection of Lua scripts for Finale. You can easily learn how to do almost anything by looking through other's scripts.
 
 As you start contributing, just remember that you can always [get help](/docs/getting-started/getting-help).
 
@@ -16,4 +16,4 @@ If you've never used Git or GitHub before, that's ok. These docs will walk you t
 
 Next, learn how to [add scripts to this repository](/docs/getting-started/adding-scripts).
 
-> Note: All scripts added to the repo will have a CC0 license. See [LICENSE](https://github.com/Nick-Mazuk/jw-lua-scripts/blob/master/LICENSE) for specific terms. This is to encourage widespread use and encourage other JW Lua coders to build off your scripts.
+> Note: All scripts added to the repo will have a CC0 license. See [LICENSE](https://github.com/finale-lua/lua-scripts/blob/master/LICENSE) for specific terms. This is to encourage widespread use and encourage other Finale Lua coders to build off your scripts.

--- a/docs/getting-started/adding-scripts.md
+++ b/docs/getting-started/adding-scripts.md
@@ -50,7 +50,7 @@ And if you get stuck, you can always [get help](/docs/getting-started/getting-he
 
 You will only need to clone the repository once. If you've already cloned it (e.g., you already contributed a script), you can skip this step.
 
-1. Once you've signed into GitHub Desktop, go to the repository on GitHub. [https://github.com/Nick-Mazuk/jw-lua-scripts](https://github.com/Nick-Mazuk/jw-lua-scripts)
+1. Once you've signed into GitHub Desktop, go to the repository on GitHub. [https://github.com/finale-lua/jw-lua](https://github.com/finale-lua/jw-lua)
 2. You should see a bright green button that says "Fork". Click it! Then click "Open with GitHub Desktop."
 3. This will bring up a dialog in GitHub Desktop. Note the folder where it says "Local Path." This is the location GitHub desktop saves your fork of the repository on your computer. You will need this later.
 4. Click "Clone" to fork the repository. This will save a copy of the repository on your computer.

--- a/docs/getting-started/getting-help.md
+++ b/docs/getting-started/getting-help.md
@@ -3,6 +3,6 @@
 There are a few great resources for getting help with JW Lua development:
 
 - [The JW Lua Facebook group](https://www.facebook.com/groups/742277119576336/)
-- [Ask a question in the GitHub repo](https://github.com/Nick-Mazuk/jw-lua-scripts/issues/new?assignees=&labels=help&template=help.md&title=)
+- [Ask a question in the GitHub repo](https://github.com/finale-lua/jw-lua/issues/new?assignees=&labels=help&template=help.md&title=)
 
 If you're having trouble with JW Lua in particular, you should ask a question in the Facebook group first. If you're having trouble with contributing to this project, ask a question in the GitHub repository.

--- a/docs/getting-started/getting-help.md
+++ b/docs/getting-started/getting-help.md
@@ -1,8 +1,8 @@
 # Getting help
 
-There are a few great resources for getting help with JW Lua development:
+There are a few great resources for getting help with Lua development:
 
-- [The JW Lua Facebook group](https://www.facebook.com/groups/742277119576336/)
+- [The Finale Lua Facebook group](https://www.facebook.com/groups/742277119576336/)
 - [Ask a question in the GitHub repo](https://github.com/finale-lua/jw-lua/issues/new?assignees=&labels=help&template=help.md&title=)
 
-If you're having trouble with JW Lua in particular, you should ask a question in the Facebook group first. If you're having trouble with contributing to this project, ask a question in the GitHub repository.
+If you're having trouble with RGP Lua or JW Lua in particular, you should ask a question in the Facebook group first. If you're having trouble with contributing to this project, ask a question in the GitHub repository.

--- a/docs/getting-started/resources.md
+++ b/docs/getting-started/resources.md
@@ -1,11 +1,11 @@
 # Resources
 
-## Learning JW Lua
+## Learning RGP/JW Lua
 
 - [JW Lua start page](http://jwmusic.nu/jwplugins/wiki/doku.php?id=jw_lua) is great if you're new to JW Lua
-- [Script Programming in JW Lua](http://jwmusic.nu/jwplugins/wiki/doku.php?id=jwlua:development) is a great overview to JW Lua development
-- [Finale PDK Framework](http://www.finaletips.nu/frameworkref/), which is how Finale connects to JW Lua
-- [Coding in JW Lua](https://www.youtube.com/playlist?list=PLsFZ0c2Wsoy9ZF6a0ZihC_-SPf3FkOh8o), YouTube videos that introduce you to JW Lua even if you've never coded before
+- [Script Programming in JW Lua](http://jwmusic.nu/jwplugins/wiki/doku.php?id=jwlua:development) is a great overview to Lua development for Finale
+- [Finale PDK Framework](https://pdk.finalelua.com), which is how Finale connects to RGP Lua
+- [Coding in Lua for Finale](https://www.youtube.com/playlist?list=PLsFZ0c2Wsoy9ZF6a0ZihC_-SPf3FkOh8o), YouTube videos that introduce you to RGP/JW Lua even if you've never coded before
 
 ### Learning the underlying PDK framework
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -3,7 +3,7 @@
 This repository includes several pre-made Lua functions that you can use in your code. That way, you can write better scripts, faster.
 
 ```lua
--- use once at top of script file, tells JW Lua where the library modules are saved
+-- use once at top of script file, tells RGP/JW Lua where the library modules are saved
 -- These first few lines will eventually be phased out
 local path = finale.FCString()
 path:SetRunningLuaFolderPath()


### PR DESCRIPTION
Most of this repo was written specifically for JW Lua. Now that RGP Lua is JW Lua's successor, much of the documentation was out of place.

This PR essentially changes all references to JW Lua to ones that are inclusive of both JW Lua and RGP Lua.