### PR TITLE
add comment from original mixins pull request

### DIFF
--- a/src/library/mixin.lua
+++ b/src/library/mixin.lua
@@ -1,5 +1,80 @@
 --[[
 $module Fluid Mixins
+
+Fluid mixins simplify the process of writing plugins and improve code maintainability.
+
+This library does 2 things:
+- Allows mixins to be added to any `FC*` objects
+- Adds a fluid interface for any methods that don't return anything.
+
+By default, it is not possible to override or extend any of the FC* objects in Finale Lua
+because objects that are tied to their underlying C++ implementation are not tables.
+So through a little bit of magic with proxying, this PR enables new methods and properties to be added.
+If needed, the original functionality can always be accessed.
+
+In short:
+- Existing methods can be overridden
+- New methods can be added
+- New properties can be added
+- Existing properties follow original behaviour (eg whether read-only or writable)
+- Original method is always accessible by appending a trailing underscore to the method name, e.g. `SetText_(foo)`
+
+The fluid interface strives to reduce the necessity of duplicate code when writing plugins.
+It works by returning the `this` value from any method that would otherwise return nothing.
+Methods that return nil or false are not affected by this. Only methods that return no values
+have the fluid interface applied.
+
+Here's an example of creating a window with some static text the standard way:
+```
+local window = finale.FCCustomLuaWindow()
+
+local str = finale.FCString()
+str.LuaString = 'this is some text'
+window:CreateStatic(10, 10):SetText(str)
+
+window:ExecuteModal(nil)
+```
+
+Now, if we include the Fluid Mixin library, immediately we have some improvements:
+```
+local window = finale.FCCustomLuaWindow()
+
+window:CreateStatic(10, 10):SetText(finale.FCString():SetLuaString('this is some text'))
+
+window:ExecuteModal(nil)
+```
+
+If we were to then override the `SetText` method so that it accepts plain strings like so:
+```
+mixin.register_default('FCCtrlStatic', 'SetText', function(this, str)
+	if type(str) == 'string' then
+		local temp = str
+		str = finale.FCString():SetLuaString(temp) -- This works because of the fluid interface
+	end
+
+	-- Trailing underscore is used to refer to the original method
+	this:SetText_(str)
+
+	-- By not returning a value (copying the behaviour of the original method), the fluid interface is maintained
+end)
+```
+
+The code could be reduced even further to this:
+```
+local window = finale.FCCustomLuaWindow()
+
+window:CreateStatic(10, 10):SetText('this is some text')
+
+window:ExecuteModal(nil)
+```
+In the example above, the same mixin could also be applied on mass by passing an array of classes and or method names.
+
+
+There are other ways in which this could be used including:
+- Fix methods that have bugs.
+- Where possible, allow methods to accept Lua types (e.g., `string` instead of `FCString`, array of strings instead of `FCStrings`, etc.)
+- Add additional high level functionality. (I have written some of these for dialogs, which was especially useful in reducing boilerplating.)
+- In the absence of the ability to inherit from `FC*` objects, named mixins can be used to create subclasses.
 ]]
 
 local utils = require("library.utils")


### PR DESCRIPTION
This pull request adds a comment to `mixins.lua` that is basically a duplicate of the comment in the original pull request that added it. I have slightly edited it to get rid of headers (because I'm not sure if our auto-documentation engine supports them) and rewording here and there to make it more of a general comment. If this appears to be still accurate, we can at least use it as the starting point for documenting mixins.

@ThistleSifter