### PR TITLE
Rewrite Fluid Mixins

### DIFF
--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -397,6 +397,18 @@ function library.simple_input(title, text)
   end
 end -- function simple_input
 
+--[[
+% is_finale_object(object)
+
+Attempts to determine if an object is a Finale object through ducktyping
+
+@ object (__FCBase)
+: (bool)
+]]
+function library.is_finale_object(object)
+    -- All finale objects implement __FCBase, so just check for the existence of __FCBase methods
+    return object and type(object) == 'userdata' and object.ClassName and object.GetClassID and true or false
+end
 
 
 

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -27,5 +27,15 @@ function utils.copy_table(t)
     end
 end
 
+--[[
+% unpack(t)
+
+Unpacks a table into separate values (for compatibility with Lua <= 5.1).
+
+@ t (table)
+: (mixed)
+]]
+utils.unpack = unpack or table.unpack
+
 
 return utils


### PR DESCRIPTION
Here is the rewrite of the Fluid Mixin library. Most of the important information is in the documentation which I rewrote with more examples. Here's a short summary of the changes
- Mixins are now in their own namespace and the `finale` namespace has been left *almost* untouched*
- Creating an object in the original `finale` namespace does not result in mixins or the fluid interface becoming available**
- New mixin class structure with `FCM` and `FCX` mixin classes.
- Added helper functions to add more control when defining mixins. Using them can add some complexity, but I think it's worth it because it makes using the mixins more user-friendly.
- Rewrote documentation with improved examples, including how to have private properties without a memory leak.

*I added a single property to keep track of which `FC` classes had their metatables modified.
** The only scenario in which an `FC` object could be unintentionally converted to an `FCM` object is if the `FC` object is passed to an `FCM` method which then returns that same object, as mixins are activated on the return of an `FC` object from an `FCM` method. But this is quite a small catch and I doubt it will cause any problems.

Also note that when accessing a method statically (eg `finalemix.FCMControl.SetText`), the proxied method will be returned, not the original (proxying takes care of automatically promoting all returned `FC` objects to `FCM` and handles the fluid interface). This was mainly to ensure consistency of return behaviour across all mixin methods, regardless of context.