### PR TITLE
Small Mixin Update

### DIFF
--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -27,15 +27,5 @@ function utils.copy_table(t)
     end
 end
 
---[[
-% unpack(t)
-
-Unpacks a table into separate values (for compatibility with Lua <= 5.1).
-
-@ t (table)
-: (mixed)
-]]
-utils.unpack = unpack or table.unpack
-
 
 return utils


### PR DESCRIPTION
This is a quick follow-up that addresses three issues and adds a new function.


1) Bad argument errors
I mentioned in an earlier PR that all bad argument errors for colon function calls were off by one.
~~Yesterday I realised that it's now possible to address this to some extent.~~
EDIT: It now works properly in all cases!

The example below covers the various scenarios.

```lua
local dialog = finalemix.FCMCustomLuaWindow()
local static = dialog:CreateStatic(10, 10)

-- Assuming there is a mixin method SetText...

-- Current result
static:SetText(true) -- bad argument #2
finalemix.FCMControl.SetText(static, true) -- bad argument #2
static['SetText'](static, true) -- bad argument #2

-- New result
static:SetText(true) -- bad argument #1
finalemix.FCMControl.SetText(static, true) -- bad argument #2
static['SetText'](static, true) -- bad argument #2
```



2) Removed public `catch_and_rethrow`
It seemed like a nice idea, but in reality, especially when factoring in static calls mixed with object calls, it's turning into more of a headache than it's worth.


3) Added `assert_argument` function
This enables mixin methods to assert an argument's type. It throws a bad argument error if the assertion fails.
At this stage it doesn't allow parent classes to be specified as a type. If the need arises I could add that in the future.


4) It seems that `utils.unpack` isn't actually needed



After this is sorted out, I have some mixins ready to go.