### PR TITLE
Allow use of personal scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ script_settings
 node_modules
 coverage
 mobdebug.lua
+
+src/personal*


### PR DESCRIPTION
Occasionally, developers (cough, cough, me) may wish to write scripts that aren't appropriate to publish in this repo. That could be because they are highly specific to a particular user's workflow, or perhaps they are still very rough and not yet ready to publish.

However, it could still be very useful to use the standard library and/or put those scripts inside this repository folder on their local machine.

This PR adds a line to the gitignore to ignore these personal scripts. So, any script that begins with `personal` will be ignored by Git (e.g., `personal_script.lua`).