### PR TITLE
update documentation generator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
                   source: ./lua/src
                   output: ./website/src/lib/lib/script-data.json
             - name: Generate the docs
-              uses: nick-mazuk/lua-docs-generator@v1.0.6
+              uses: nick-mazuk/lua-docs-generator@v1.1.0
               with:
                   input: './lua/src/library'
                   output: './lua/docs/library'


### PR DESCRIPTION
When working on https://github.com/finale-lua/lua-scripts/pull/151, I noticed that several library functions' documentation was out of date. Specifically, I noticed the arguments included in the call signature did not always match up with the arguments defined with the `@ argName (type) description` structure. For instance:

```lua
--[[
% copy(source_layer, destination_layer)

Duplicates the notes from the source layer to the destination. The source layer remains untouched.

@ region (FCMusicRegion) the region to be copied
@ source_layer number the number (1-4) of the layer to duplicate
@ destination_layer number the number (1-4) of the layer to be copied to
]]
```

Now it's understandable why this discrepancy happens—the args are defined in two places, but a developer things their job is done after updating the args in one spot.

To fix this, I updated the documentation generator. Check out the release notes:

https://github.com/finale-lua/lua-docs-generator/releases/tag/1.1.0

Essentially, this PR will now let you write this:

```lua
--[[
% copy
]]
```

And all args will be automatically added to the call signature for you. This should help us keep the docs more up to date.

> Oh, and I rewrote the entire docs generator from scratch to support this. And one consequence of that rewrite is that it's a lot more forgiving to developers. So the syntax does not need to be as perfect and it will still understand everything. Though this part is minor enough that we may not see its effects at all in this codebase.