### PR TITLE
Cleanup library doc comments

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -18,7 +18,7 @@ The docs for the individual functions are automatically created from the multili
 
 ```lua
 --[[
-% stem_sign(entry)
+% stem_sign
 
 This is useful for many x,y positioning fields in Finale that mirror +/-
 based on stem direction.

--- a/src/library/articulation.lua
+++ b/src/library/articulation.lua
@@ -1,13 +1,12 @@
 --[[
 $module Articulation
-]]
-
+]] --
 local articulation = {}
 
 local note_entry = require("library.note_entry")
 
 --[[
-% delete_from_entry_by_char_num(entry, char_num)
+% delete_from_entry_by_char_num
 
 Removes any articulation assignment that has the specified character as its above-character.
 
@@ -25,7 +24,7 @@ function articulation.delete_from_entry_by_char_num(entry, char_num)
 end
 
 --[[
-% is_note_side(artic, curr_pos)
+% is_note_side
 
 Uses `FCArticulation.CalcMetricPos` to determine if the input articulation is on the note-side.
 
@@ -47,19 +46,18 @@ function articulation.is_note_side(artic, curr_pos)
     end
     if entry:CalcStemUp() then
         local bot_pos = note_entry.get_bottom_note_position(entry)
-        bot_pos = math.floor(((10000*bot_pos)/cell_metrics.StaffScaling) + 0.5)
+        bot_pos = math.floor(((10000 * bot_pos) / cell_metrics.StaffScaling) + 0.5)
         return curr_pos.Y <= bot_pos
     else
         local top_pos = note_entry.get_top_note_position(entry)
-        top_pos = math.floor(((10000*top_pos)/cell_metrics.StaffScaling) + 0.5)
+        top_pos = math.floor(((10000 * top_pos) / cell_metrics.StaffScaling) + 0.5)
         return curr_pos.Y >= top_pos
     end
     return false
 end
 
-
 --[[
-% calc_main_character_dimensions(artic)
+% calc_main_character_dimensions
 
 Uses `FCTextMetrics:LoadArticulation` to determine the dimensions of the main character
 

--- a/src/library/configuration.lua
+++ b/src/library/configuration.lua
@@ -1,6 +1,5 @@
 --  Author: Robert Patterson
 --  Date: March 5, 2021
-
 --[[
 $module Configuration
 
@@ -35,8 +34,7 @@ right_dynamic_cushion		= -6		--evpus
 Configuration files must be placed in a subfolder called `script_settings` within
 the folder of the calling script. Each script that has a configuration file
 defines its own configuration file name.
-]]
-
+]] --
 local configuration = {}
 
 local script_settings_dir = "script_settings" -- the parent of this directory is the running lua path
@@ -45,7 +43,7 @@ local parameter_delimiter = "="
 local path_delimiter = "/"
 
 local file_exists = function(file_path)
-    local f = io.open(file_path,"r")
+    local f = io.open(file_path, "r")
     if nil ~= f then
         io.close(f)
         return true
@@ -53,7 +51,7 @@ local file_exists = function(file_path)
     return false
 end
 
-local strip_leading_trailing_whitespace = function (str)
+local strip_leading_trailing_whitespace = function(str)
     return str:match("^%s*(.-)%s*$") -- lua pattern magic taken from the Internet
 end
 
@@ -61,7 +59,7 @@ local parse_parameter -- forward function declaration
 
 local parse_table = function(val_string)
     local ret_table = {}
-    for element in val_string:gmatch('[^,%s]+') do  -- lua pattern magic taken from the Internet
+    for element in val_string:gmatch("[^,%s]+") do -- lua pattern magic taken from the Internet
         local parsed_element = parse_parameter(element)
         table.insert(ret_table, parsed_element)
     end
@@ -69,11 +67,11 @@ local parse_table = function(val_string)
 end
 
 parse_parameter = function(val_string)
-    if '"' == val_string:sub(1,1) and '"' == val_string:sub(#val_string,#val_string) then -- double-quote string
-        return string.gsub(val_string, '"(.+)"', "%1") -- lua pattern magic: "(.+)" matches all characters between two double-quote marks (no escape chars)
-    elseif "'" == val_string:sub(1,1) and "'" == val_string:sub(#val_string,#val_string) then -- single-quote string
+    if "\"" == val_string:sub(1, 1) and "\"" == val_string:sub(#val_string, #val_string) then -- double-quote string
+        return string.gsub(val_string, "\"(.+)\"", "%1") -- lua pattern magic: "(.+)" matches all characters between two double-quote marks (no escape chars)
+    elseif "'" == val_string:sub(1, 1) and "'" == val_string:sub(#val_string, #val_string) then -- single-quote string
         return string.gsub(val_string, "'(.+)'", "%1") -- lua pattern magic: '(.+)' matches all characters between two single-quote marks (no escape chars)
-    elseif "{" == val_string:sub(1,1) and "}" == val_string:sub(#val_string,#val_string) then
+    elseif "{" == val_string:sub(1, 1) and "}" == val_string:sub(#val_string, #val_string) then
         return parse_table(string.gsub(val_string, "{(.+)}", "%1"))
     elseif "true" == val_string then
         return true
@@ -96,21 +94,21 @@ local get_parameters_from_file = function(file_name)
     for line in io.lines(file_path) do
         local comment_at = string.find(line, comment_marker, 1, true) -- true means find raw string rather than lua pattern
         if nil ~= comment_at then
-            line = string.sub(line, 1, comment_at-1)
+            line = string.sub(line, 1, comment_at - 1)
         end
         local delimiter_at = string.find(line, parameter_delimiter, 1, true)
         if nil ~= delimiter_at then
-            local name = strip_leading_trailing_whitespace(string.sub(line, 1, delimiter_at-1))
-            local val_string = strip_leading_trailing_whitespace(string.sub(line, delimiter_at+1))
+            local name = strip_leading_trailing_whitespace(string.sub(line, 1, delimiter_at - 1))
+            local val_string = strip_leading_trailing_whitespace(string.sub(line, delimiter_at + 1))
             parameters[name] = parse_parameter(val_string)
         end
     end
-    
+
     return parameters
 end
 
 --[[
-% get_parameters(file_name, parameter_list)
+% get_parameters
 
 Searches for a file with the input filename in the `script_settings` directory and replaces the default values in `parameter_list` with any that are found in the config file.
 

--- a/src/library/enigma_string.lua
+++ b/src/library/enigma_string.lua
@@ -1,8 +1,7 @@
 --[[
 $module Enigma String
-]]
+]] --
 local enigma_string = {}
-
 local starts_with_font_command = function(string)
     local text_cmds = {"^font", "^Font", "^fontMus", "^fontTxt", "^fontNum", "^size", "^nfx"}
     for i, text_cmd in ipairs(text_cmds) do
@@ -23,7 +22,7 @@ functions that can replace only font, only size, only style, or all three togeth
 ]]
 
 --[[
-% trim_first_enigma_font_tags(string)
+% trim_first_enigma_font_tags
 
 Trims the first font tags and returns the result as an instance of FCFontInfo.
 
@@ -45,7 +44,7 @@ function enigma_string.trim_first_enigma_font_tags(string)
         if string:SplitAt(end_of_tag, font_tag, nil, true) then
             font_info:ParseEnigmaCommand(font_tag)
         end
-        string:DeleteCharactersAt(0, end_of_tag+1)
+        string:DeleteCharactersAt(0, end_of_tag + 1)
         found_tag = true
     end
     if found_tag then
@@ -55,7 +54,7 @@ function enigma_string.trim_first_enigma_font_tags(string)
 end
 
 --[[
-% change_first_string_font (string, font_info)
+% change_first_string_font
 
 Replaces the first enigma font tags of the input enigma string.
 
@@ -63,19 +62,19 @@ Replaces the first enigma font tags of the input enigma string.
 @ font_info (FCFontInfo) replacement font info
 : (boolean) true if success
 ]]
-function enigma_string.change_first_string_font (string, font_info)
+function enigma_string.change_first_string_font(string, font_info)
     local final_text = font_info:CreateEnigmaString(nil)
     local current_font_info = enigma_string.trim_first_enigma_font_tags(string)
     if (current_font_info == nil) or not font_info:IsIdenticalTo(current_font_info) then
         final_text:AppendString(string)
-        string:SetString (final_text)
+        string:SetString(final_text)
         return true
     end
     return false
 end
 
 --[[
-% change_first_text_block_font (text_block, font_info)
+% change_first_text_block_font
 
 Replaces the first enigma font tags of input text block.
 
@@ -83,7 +82,7 @@ Replaces the first enigma font tags of input text block.
 @ font_info (FCFontInfo) replacement font info
 : (boolean) true if success
 ]]
-function enigma_string.change_first_text_block_font (text_block, font_info)
+function enigma_string.change_first_text_block_font(text_block, font_info)
     local new_text = text_block:CreateRawTextString()
     if enigma_string.change_first_string_font(new_text, font_info) then
         text_block:SaveRawTextString(new_text)
@@ -92,51 +91,53 @@ function enigma_string.change_first_text_block_font (text_block, font_info)
     return false
 end
 
---These implement a complete font replacement using the PDK Framework's
---built-in TrimEnigmaFontTags() function.
- 
+-- These implement a complete font replacement using the PDK Framework's
+-- built-in TrimEnigmaFontTags() function.
+
 --[[
-% change_string_font (string, font_info)
+% change_string_font
 
 Changes the entire enigma string to have the input font info.
 
 @ string (FCString) this is both the input and the modified output result
 @ font_info (FCFontInfo) replacement font info
 ]]
-function enigma_string.change_string_font (string, font_info)
+function enigma_string.change_string_font(string, font_info)
     local final_text = font_info:CreateEnigmaString(nil)
     string:TrimEnigmaFontTags()
     final_text:AppendString(string)
-    string:SetString (final_text)
+    string:SetString(final_text)
 end
 
 --[[
-% change_text_block_font (text_block, font_info)
+% change_text_block_font
 
 Changes the entire text block to have the input font info.
 
 @ text_block (FCTextBlock) this is both the input and the modified output result
 @ font_info (FCFontInfo) replacement font info
 ]]
-function enigma_string.change_text_block_font (text_block, font_info)
+function enigma_string.change_text_block_font(text_block, font_info)
     local new_text = text_block:CreateRawTextString()
     enigma_string.change_string_font(new_text, font_info)
     text_block:SaveRawTextString(new_text)
 end
 
 --[[
-% remove_inserts (fcstring, replace_with_generic)
+% remove_inserts
 
-Removes text inserts other than font commands and replaces them with 
+Removes text inserts other than font commands and replaces them with
 
 @ fcstring (FCString) this is both the input and the modified output result
 @ replace_with_generic (boolean) if true, replace the insert with the text of the enigma command
 ]]
-function enigma_string.remove_inserts (fcstring, replace_with_generic)
+function enigma_string.remove_inserts(fcstring, replace_with_generic)
     -- so far this just supports page-level inserts. if this ever needs to work with expressions, we'll need to
     -- add the last three items in the (Finale 26) text insert menu, which are playback inserts not available to page text
-    local text_cmds = {"^arranger", "^composer", "^copyright", "^date", "^description", "^fdate", "^filename",
-                        "^lyricist", "^page", "^partname", "^perftime", "^subtitle", "^time", "^title", "^totpages"}
+    local text_cmds = {
+        "^arranger", "^composer", "^copyright", "^date", "^description", "^fdate", "^filename", "^lyricist", "^page",
+        "^partname", "^perftime", "^subtitle", "^time", "^title", "^totpages",
+    }
     local lua_string = fcstring.LuaString
     for i, text_cmd in ipairs(text_cmds) do
         local starts_at = string.find(lua_string, text_cmd, 1, true) -- true: do a plain search
@@ -145,14 +146,14 @@ function enigma_string.remove_inserts (fcstring, replace_with_generic)
             if replace_with_generic then
                 replace_with = string.sub(text_cmd, 2)
             end
-            local after_text_at = starts_at+string.len(text_cmd)
+            local after_text_at = starts_at + string.len(text_cmd)
             local next_at = string.find(lua_string, ")", after_text_at, true)
             if nil ~= next_at then
                 next_at = next_at + 1
             else
                 next_at = starts_at
             end
-            lua_string = string.sub(lua_string, 1, starts_at-1) .. replace_with .. string.sub(lua_string, next_at)
+            lua_string = string.sub(lua_string, 1, starts_at - 1) .. replace_with .. string.sub(lua_string, next_at)
             starts_at = string.find(lua_string, text_cmd, 1, true)
         end
     end
@@ -160,7 +161,7 @@ function enigma_string.remove_inserts (fcstring, replace_with_generic)
 end
 
 --[[
-% expand_value_tag(fcstring, value_num)
+% expand_value_tag
 
 Expands the value tag to the input value_num.
 
@@ -168,12 +169,12 @@ Expands the value tag to the input value_num.
 @ value_num (number) the value number to replace the tag with
 ]]
 function enigma_string.expand_value_tag(fcstring, value_num)
-    value_num = math.floor(value_num +0.5) -- in case value_num is not an integer
+    value_num = math.floor(value_num + 0.5) -- in case value_num is not an integer
     fcstring.LuaString = fcstring.LuaString:gsub("%^value%(%)", tostring(value_num))
 end
 
 --[[
-% calc_text_advance_width(inp_string)
+% calc_text_advance_width
 
 Calculates the advance width of the input string taking into account all font and style changes within the string.
 

--- a/src/library/expression.lua
+++ b/src/library/expression.lua
@@ -1,6 +1,6 @@
 --[[
 $module Expression
-]]
+]] --
 local expression = {}
 
 local library = require("library.general_library")
@@ -8,7 +8,7 @@ local note_entry = require("library.note_entry")
 local enigma_string = require("library.enigma_string")
 
 --[[
-% get_music_region(exp_assign)
+% get_music_region
 
 Returns a music region corresponding to the input expression assignment.
 
@@ -31,7 +31,7 @@ function expression.get_music_region(exp_assign)
 end
 
 --[[
-% get_associated_entry(exp_assign)
+% get_associated_entry
 
 Returns the note entry associated with the input expression assignment, if any.
 
@@ -54,7 +54,7 @@ function expression.get_associated_entry(exp_assign)
 end
 
 --[[
-% calc_handle_offset_for_smart_shape(exp_assign)
+% calc_handle_offset_for_smart_shape
 
 Returns the horizontal EVPU offset for a smart shape endpoint to align exactly with the handle of the input expression, given that they both have the same EDU position.
 
@@ -89,7 +89,7 @@ function expression.calc_handle_offset_for_smart_shape(exp_assign)
 end
 
 --[[
-% calc_text_width(expression_def, expand_tags)
+% calc_text_width
 
 Returns the text advance width of the input expression definition.
 
@@ -108,7 +108,7 @@ function expression.calc_text_width(expression_def, expand_tags)
 end
 
 --[[
-% is_for_current_part(exp_assign, current_part)
+% is_for_current_part
 
 Returns true if the expression assignment is assigned to the current part or score.
 

--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -1,10 +1,10 @@
 --[[
 $module Library
-]]
+]] --
 local library = {}
 
 --[[
-% finale_version(major, minor, build)
+% finale_version
 
 Returns a raw Finale version from major, minor, and (optional) build parameters. For 32-bit Finale
 this is the internal major Finale version, not the year.
@@ -23,7 +23,7 @@ function library.finale_version(major, minor, build)
 end
 
 --[[
-% group_overlaps_region(staff_group, region)
+% group_overlaps_region
 
 Returns true if the input staff group overlaps with the input music region, otherwise false.
 
@@ -54,7 +54,7 @@ function library.group_overlaps_region(staff_group, region)
 end
 
 --[[
-% group_is_contained_in_region(staff_group, region)
+% group_is_contained_in_region
 
 Returns true if the entire input staff group is contained within the input music region.
 If the start or end staff are not visible in the region, it returns false.
@@ -74,7 +74,7 @@ function library.group_is_contained_in_region(staff_group, region)
 end
 
 --[[
-% staff_group_is_multistaff_instrument(staff_group)
+% staff_group_is_multistaff_instrument
 
 Returns true if the entire input staff group is a multistaff instrument.
 
@@ -93,7 +93,7 @@ function library.staff_group_is_multistaff_instrument(staff_group)
 end
 
 --[[
-% get_selected_region_or_whole_doc()
+% get_selected_region_or_whole_doc
 
 Returns a region that contains the selected region if there is a selection or the whole document if there isn't.
 SIDE-EFFECT WARNING: If there is no selected region, this function also changes finenv.Region() to the whole document.
@@ -109,7 +109,7 @@ function library.get_selected_region_or_whole_doc()
 end
 
 --[[
-% get_first_cell_on_or_after_page(page_num)
+% get_first_cell_on_or_after_page
 
 Returns the first FCCell at the top of the input page. If the page is blank, it returns the first cell after the input page.
 
@@ -120,7 +120,7 @@ function library.get_first_cell_on_or_after_page(page_num)
     local curr_page_num = page_num
     local curr_page = finale.FCPage()
     local got1 = false
-    --skip over any blank pages
+    -- skip over any blank pages
     while curr_page:Load(curr_page_num) do
         if curr_page:GetFirstSystem() > 0 then
             got1 = true
@@ -133,14 +133,14 @@ function library.get_first_cell_on_or_after_page(page_num)
         staff_sys:Load(curr_page:GetFirstSystem())
         return finale.FCCell(staff_sys.FirstMeasure, staff_sys.TopStaff)
     end
-    --if we got here there were nothing but blank pages left at the end
+    -- if we got here there were nothing but blank pages left at the end
     local end_region = finale.FCMusicRegion()
     end_region:SetFullDocument()
     return finale.FCCell(end_region.EndMeasure, end_region.EndStaff)
 end
 
 --[[
-% get_top_left_visible_cell()
+% get_top_left_visible_cell
 
 Returns the topmost, leftmost visible FCCell on the screen, or the closest possible estimate of it.
 
@@ -156,7 +156,7 @@ function library.get_top_left_visible_cell()
 end
 
 --[[
-% get_top_left_selected_or_visible_cell()
+% get_top_left_selected_or_visible_cell
 
 If there is a selection, returns the topmost, leftmost cell in the selected region.
 Otherwise returns the best estimate for the topmost, leftmost currently visible cell.
@@ -172,7 +172,7 @@ function library.get_top_left_selected_or_visible_cell()
 end
 
 --[[
-% is_default_measure_number_visible_on_cell (meas_num_region, cell, staff_system, current_is_part)
+% is_default_measure_number_visible_on_cell
 
 Returns true if measure numbers for the input region are visible on the input cell for the staff system.
 
@@ -182,7 +182,7 @@ Returns true if measure numbers for the input region are visible on the input ce
 @ current_is_part (boolean) true if the current view is a linked part, otherwise false
 : (boolean)
 ]]
-function library.is_default_measure_number_visible_on_cell (meas_num_region, cell, staff_system, current_is_part)
+function library.is_default_measure_number_visible_on_cell(meas_num_region, cell, staff_system, current_is_part)
     local staff = finale.FCCurrentStaffSpec()
     if not staff:LoadForCell(cell, 0) then
         return false
@@ -200,7 +200,7 @@ function library.is_default_measure_number_visible_on_cell (meas_num_region, cel
 end
 
 --[[
-% is_default_number_visible_and_left_aligned (meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest)
+% is_default_number_visible_and_left_aligned
 
 Returns true if measure number for the input cell is visible and left-aligned.
 
@@ -211,7 +211,8 @@ Returns true if measure number for the input cell is visible and left-aligned.
 @ is_for_multimeasure_rest (boolean) true if the current cell starts a multimeasure rest
 : (boolean)
 ]]
-function library.is_default_number_visible_and_left_aligned (meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest)
+function library.is_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part,
+                                                            is_for_multimeasure_rest)
     if meas_num_region.UseScoreInfoForParts then
         current_is_part = false
     end
@@ -234,11 +235,11 @@ function library.is_default_number_visible_and_left_aligned (meas_num_region, ce
             return false
         end
     end
-    return library.is_default_measure_number_visible_on_cell (meas_num_region, cell, system, current_is_part)
+    return library.is_default_measure_number_visible_on_cell(meas_num_region, cell, system, current_is_part)
 end
 
 --[[
-% update_layout(from_page, unfreeze_measures)
+% update_layout
 
 Updates the page layout.
 
@@ -255,7 +256,7 @@ function library.update_layout(from_page, unfreeze_measures)
 end
 
 --[[
-% get_current_part()
+% get_current_part
 
 Returns the currently selected part or score.
 
@@ -268,7 +269,7 @@ function library.get_current_part()
 end
 
 --[[
-% get_page_format_prefs()
+% get_page_format_prefs
 
 Returns the default page format prefs for score or parts based on which is currently selected.
 
@@ -287,7 +288,7 @@ function library.get_page_format_prefs()
 end
 
 --[[
-% get_smufl_metadata_file(font_info)
+% get_smufl_metadata_file
 
 @ [font_info] (FCFontInfo) if non-nil, the font to search for; if nil, search for the Default Music Font
 : (file handle|nil)
@@ -316,13 +317,13 @@ function library.get_smufl_metadata_file(font_info)
 
     local smufl_json_system_prefix = "/Library/Application Support"
     if finenv.UI():IsOnWindows() then
-        smufl_json_system_prefix = os.getenv("COMMONPROGRAMFILES") 
+        smufl_json_system_prefix = os.getenv("COMMONPROGRAMFILES")
     end
     return try_prefix(smufl_json_system_prefix, font_info)
 end
 
 --[[
-% is_font_smufl_font(font_info)
+% is_font_smufl_font
 
 @ [font_info] (FCFontInfo) if non-nil, the font to check; if nil, check the Default Music Font
 : (boolean)
@@ -332,13 +333,13 @@ function library.is_font_smufl_font(font_info)
         font_info = finale.FCFontInfo()
         font_info:LoadFontPrefs(finale.FONTPREF_MUSIC)
     end
-    
+
     if finenv.RawFinaleVersion >= library.finale_version(27, 1) then
         if nil ~= font_info.IsSMuFLFont then -- if this version of the lua interpreter has the IsSMuFLFont property (i.e., RGP Lua 0.59+)
             return font_info.IsSMuFLFont
         end
     end
-    
+
     local smufl_metadata_file = library.get_smufl_metadata_file(font_info)
     if nil ~= smufl_metadata_file then
         io.close(smufl_metadata_file)
@@ -348,7 +349,7 @@ function library.is_font_smufl_font(font_info)
 end
 
 --[[
-% simple_input(title, text)
+% simple_input
 
 Creates a simple dialog box with a single 'edit' field for entering values into a script, similar to the old UserValueInput command. Will automatically resize the width to accomodate longer strings.
 
@@ -357,48 +358,52 @@ Creates a simple dialog box with a single 'edit' field for entering values into 
 : string
 ]]
 function library.simple_input(title, text)
-  local return_value = finale.FCString()
-  return_value.LuaString = ""
-  local str = finale.FCString()
-  local min_width = 160
-  --
-  function format_ctrl(ctrl, h, w, st)
-      ctrl:SetHeight(h)
-      ctrl:SetWidth(w)
-      str.LuaString = st
-      ctrl:SetText(str)
-  end -- function format_ctrl
-  --
-  title_width = string.len(title) * 6 + 54
-  if title_width > min_width then min_width = title_width end
-  text_width = string.len(text) * 6
-  if text_width > min_width then min_width = text_width end
-  --
-  str.LuaString = title
-  local dialog = finale.FCCustomLuaWindow()
-  dialog:SetTitle(str)
-  local descr = dialog:CreateStatic(0, 0)
-  format_ctrl(descr, 16, min_width, text)
-  local input = dialog:CreateEdit(0, 20)
-  format_ctrl(input, 20, min_width, "") -- edit "" for defualt value
-  dialog:CreateOkButton()
-  dialog:CreateCancelButton()
-  --
-  function callback(ctrl)
-  end -- callback
-  --
-  dialog:RegisterHandleCommand(callback)
-  --
-  if dialog:ExecuteModal(nil) == finale.EXECMODAL_OK then
-    return_value.LuaString = input:GetText(return_value)
-    --print(return_value.LuaString)
-    return return_value.LuaString
-  -- OK button was pressed
-  end
+    local return_value = finale.FCString()
+    return_value.LuaString = ""
+    local str = finale.FCString()
+    local min_width = 160
+    --
+    function format_ctrl(ctrl, h, w, st)
+        ctrl:SetHeight(h)
+        ctrl:SetWidth(w)
+        str.LuaString = st
+        ctrl:SetText(str)
+    end -- function format_ctrl
+    --
+    title_width = string.len(title) * 6 + 54
+    if title_width > min_width then
+        min_width = title_width
+    end
+    text_width = string.len(text) * 6
+    if text_width > min_width then
+        min_width = text_width
+    end
+    --
+    str.LuaString = title
+    local dialog = finale.FCCustomLuaWindow()
+    dialog:SetTitle(str)
+    local descr = dialog:CreateStatic(0, 0)
+    format_ctrl(descr, 16, min_width, text)
+    local input = dialog:CreateEdit(0, 20)
+    format_ctrl(input, 20, min_width, "") -- edit "" for defualt value
+    dialog:CreateOkButton()
+    dialog:CreateCancelButton()
+    --
+    function callback(ctrl)
+    end -- callback
+    --
+    dialog:RegisterHandleCommand(callback)
+    --
+    if dialog:ExecuteModal(nil) == finale.EXECMODAL_OK then
+        return_value.LuaString = input:GetText(return_value)
+        -- print(return_value.LuaString)
+        return return_value.LuaString
+        -- OK button was pressed
+    end
 end -- function simple_input
 
 --[[
-% is_finale_object(object)
+% is_finale_object
 
 Attempts to determine if an object is a Finale object through ducktyping
 
@@ -407,10 +412,7 @@ Attempts to determine if an object is a Finale object through ducktyping
 ]]
 function library.is_finale_object(object)
     -- All finale objects implement __FCBase, so just check for the existence of __FCBase methods
-    return object and type(object) == 'userdata' and object.ClassName and object.GetClassID and true or false
+    return object and type(object) == "userdata" and object.ClassName and object.GetClassID and true or false
 end
-
-
-
 
 return library

--- a/src/library/layer.lua
+++ b/src/library/layer.lua
@@ -4,13 +4,13 @@ $module Layer
 local layer = {}
 
 --[[
-% copy(source_layer, destination_layer)
+% copy
 
 Duplicates the notes from the source layer to the destination. The source layer remains untouched.
 
 @ region (FCMusicRegion) the region to be copied
-@ source_layer number the number (1-4) of the layer to duplicate
-@ destination_layer number the number (1-4) of the layer to be copied to
+@ source_layer (number) the number (1-4) of the layer to duplicate
+@ destination_layer (number) the number (1-4) of the layer to be copied to
 ]]
 function layer.copy(region, source_layer, destination_layer)
     local start = region.StartMeasure
@@ -32,12 +32,12 @@ function layer.copy(region, source_layer, destination_layer)
 end -- function layer_copy
 
 --[[
-% clear(layer_to_clear)
+% clear
 
 Clears all entries from a given layer.
 
 @ region (FCMusicRegion) the region to be cleared
-@ layer_to_clear number the number (1-4) of the layer to clear
+@ layer_to_clear (number) the number (1-4) of the layer to clear
 ]]
 function layer.clear(region, layer_to_clear)
     layer_to_clear = layer_to_clear - 1 -- Turn 1 based layer to 0 based layer
@@ -54,13 +54,13 @@ function layer.clear(region, layer_to_clear)
 end
 
 --[[
-% swap(swap_a, swap_b)
+% swap
 
 Swaps the entries from two different layers (e.g. 1-->2 and 2-->1).
 
 @ region (FCMusicRegion) the region to be swapped
-@ swap_a number the number (1-4) of the first layer to be swapped
-@ swap_b number the number (1-4) of the second layer to be swapped
+@ swap_a (number) the number (1-4) of the first layer to be swapped
+@ swap_b (number) the number (1-4) of the second layer to be swapped
 ]]
 function layer.swap(region, swap_a, swap_b)
     local start = region.StartMeasure

--- a/src/library/measurement.lua
+++ b/src/library/measurement.lua
@@ -1,7 +1,27 @@
--- A measurement of helpful JW Lua scripts
--- Simply import this file to another Lua script to use any of these scripts
+--[[
+$module measurement
+]] --
 local measurement = {}
 
+--[[
+% convert_to_EVPUs
+
+Converts the specified string into EVPUs. Like text boxes in Finale, this supports
+the usage of units at the end of the string. The following are a few examples:
+
+- `12s` => 288 (12 spaces is 288 EVPUs)
+- `8.5i` => 2448 (8.5 inches is 2448 EVPUs)
+- `10cm` => 1133 (10 centimeters is 1133 EVPUs)
+- `10mm` => 113 (10 millimeters is 113 EVPUs)
+- `1pt` => 4 (1 point is 4 EVPUs)
+- `2.5p` => 120 (2.5 picas is 120 EVPUs)
+
+Read the [Finale User Manual](https://usermanuals.finalemusic.com/FinaleMac/Content/Finale/def-equivalents.htm#overriding-global-measurement-units)
+for more details about measurement units in Finale.
+
+@ text (string) the string to convert
+: (number) the converted number of EVPUs
+]]
 function measurement.convert_to_EVPUs(text)
     local str = finale.FCString()
     str.LuaString = text

--- a/src/library/note_entry.lua
+++ b/src/library/note_entry.lua
@@ -1,10 +1,10 @@
 --[[
 $module Note Entry
-]]
+]] --
 local note_entry = {}
 
 --[[
-% get_music_region(entry)
+% get_music_region
 
 Returns an intance of `FCMusicRegion` that corresponds to the metric location of the input note entry.
 
@@ -23,8 +23,8 @@ function note_entry.get_music_region(entry)
     return exp_region
 end
 
---entry_metrics can be omitted, in which case they are constructed and released here
---return entry_metrics, loaded_here
+-- entry_metrics can be omitted, in which case they are constructed and released here
+-- return entry_metrics, loaded_here
 local use_or_get_passed_in_entry_metrics = function(entry, entry_metrics)
     if nil ~= entry_metrics then
         return entry_metrics, false
@@ -37,7 +37,7 @@ local use_or_get_passed_in_entry_metrics = function(entry, entry_metrics)
 end
 
 --[[
-% get_evpu_notehead_height(entry)
+% get_evpu_notehead_height
 
 Returns the calculated height of the notehead rectangle.
 
@@ -53,7 +53,7 @@ function note_entry.get_evpu_notehead_height(entry)
 end
 
 --[[
-% get_top_note_position(entry, entry_metrics)
+% get_top_note_position
 
 Returns the vertical page coordinate of the top of the notehead rectangle, not including the stem.
 
@@ -74,7 +74,7 @@ function note_entry.get_top_note_position(entry, entry_metrics)
         local cell_metrics = finale.FCCell(entry.Measure, entry.Staff):CreateCellMetrics()
         if nil ~= cell_metrics then
             local evpu_height = note_entry.get_evpu_notehead_height(entry)
-            local scaled_height = math.floor(((cell_metrics.StaffScaling*evpu_height)/10000) + 0.5)
+            local scaled_height = math.floor(((cell_metrics.StaffScaling * evpu_height) / 10000) + 0.5)
             retval = entry_metrics.BottomPosition + scaled_height
             cell_metrics:FreeMetrics()
         end
@@ -86,7 +86,7 @@ function note_entry.get_top_note_position(entry, entry_metrics)
 end
 
 --[[
-% get_bottom_note_position(entry, entry_metrics)
+% get_bottom_note_position
 
 Returns the vertical page coordinate of the bottom of the notehead rectangle, not including the stem.
 
@@ -107,7 +107,7 @@ function note_entry.get_bottom_note_position(entry, entry_metrics)
         local cell_metrics = finale.FCCell(entry.Measure, entry.Staff):CreateCellMetrics()
         if nil ~= cell_metrics then
             local evpu_height = note_entry.get_evpu_notehead_height(entry)
-            local scaled_height = math.floor(((cell_metrics.StaffScaling*evpu_height)/10000) + 0.5)
+            local scaled_height = math.floor(((cell_metrics.StaffScaling * evpu_height) / 10000) + 0.5)
             retval = entry_metrics.TopPosition - scaled_height
             cell_metrics:FreeMetrics()
         end
@@ -119,7 +119,7 @@ function note_entry.get_bottom_note_position(entry, entry_metrics)
 end
 
 --[[
-% calc_widths(entry)
+% calc_widths
 
 Get the widest left-side notehead width and widest right-side notehead width.
 
@@ -151,7 +151,7 @@ end
 -- with the primary notehead rectangle.
 
 --[[
-% calc_left_of_all_noteheads(entry)
+% calc_left_of_all_noteheads
 
 Calculates the handle offset for an expression with "Left of All Noteheads" horizontal positioning.
 
@@ -167,7 +167,7 @@ function note_entry.calc_left_of_all_noteheads(entry)
 end
 
 --[[
-% calc_left_of_primary_notehead(entry)
+% calc_left_of_primary_notehead
 
 Calculates the handle offset for an expression with "Left of Primary Notehead" horizontal positioning.
 
@@ -179,7 +179,7 @@ function note_entry.calc_left_of_primary_notehead(entry)
 end
 
 --[[
-% calc_center_of_all_noteheads(entry)
+% calc_center_of_all_noteheads
 
 Calculates the handle offset for an expression with "Center of All Noteheads" horizontal positioning.
 
@@ -196,7 +196,7 @@ function note_entry.calc_center_of_all_noteheads(entry)
 end
 
 --[[
-% calc_center_of_primary_notehead(entry)
+% calc_center_of_primary_notehead
 
 Calculates the handle offset for an expression with "Center of Primary Notehead" horizontal positioning.
 
@@ -212,7 +212,7 @@ function note_entry.calc_center_of_primary_notehead(entry)
 end
 
 --[[
-% calc_stem_offset(entry)
+% calc_stem_offset
 
 Calculates the offset of the stem from the left edge of the notehead rectangle. Eventually the PDK Framework may be able to provide this instead.
 
@@ -228,7 +228,7 @@ function note_entry.calc_stem_offset(entry)
 end
 
 --[[
-% calc_right_of_all_noteheads(entry)
+% calc_right_of_all_noteheads
 
 Calculates the handle offset for an expression with "Right of All Noteheads" horizontal positioning.
 
@@ -244,7 +244,7 @@ function note_entry.calc_right_of_all_noteheads(entry)
 end
 
 --[[
-% calc_note_at_index(entry, note_index)
+% calc_note_at_index
 
 This function assumes `for note in each(note_entry)` always iterates in the same direction.
 (Knowing how the Finale PDK works, it probably iterates from bottom to top note.)
@@ -265,7 +265,7 @@ function note_entry.calc_note_at_index(entry, note_index)
 end
 
 --[[
-% stem_sign(entry)
+% stem_sign
 
 This is useful for many x,y positioning fields in Finale that mirror +/-
 based on stem direction.
@@ -281,7 +281,7 @@ function note_entry.stem_sign(entry)
 end
 
 --[[
-% duplicate_note(note)
+% duplicate_note
 
 @ note (FCNote)
 : (FCNote | nil) reference to added FCNote or `nil` if not success
@@ -298,7 +298,7 @@ function note_entry.duplicate_note(note)
 end
 
 --[[
-% delete_note(note)
+% delete_note
 
 Removes the specified FCNote from its associated FCNoteEntry.
 
@@ -318,13 +318,13 @@ function note_entry.delete_note(note)
     finale.FCNoteheadMod():EraseAt(note)
     finale.FCPercussionNoteMod():EraseAt(note)
     finale.FCTablatureNoteMod():EraseAt(note)
-    --finale.FCTieMod():EraseAt(note)  -- FCTieMod is not currently lua supported, but leave this here in case it ever is
+    -- finale.FCTieMod():EraseAt(note)  -- FCTieMod is not currently lua supported, but leave this here in case it ever is
 
     return entry:DeleteNote(note)
 end
 
 --[[
-% calc_spans_number_of_octaves(entry)
+% calc_spans_number_of_octaves
 
 Calculates the numer of octaves spanned by a chord (considering only staff positions, not accidentals).
 
@@ -340,7 +340,7 @@ function note_entry.calc_spans_number_of_octaves(entry)
 end
 
 --[[
-% add_augmentation_dot(entry)
+% add_augmentation_dot
 
 Adds an augentation dot to the entry. This works even if the entry already has one or more augmentation dots.
 
@@ -352,7 +352,7 @@ function note_entry.add_augmentation_dot(entry)
 end
 
 --[[
-% get_next_same_v(entry)
+% get_next_same_v
 
 Returns the next entry in the same V1 or V2 as the input entry.
 If the input entry is V2, only the current V2 launch is searched.
@@ -378,23 +378,23 @@ function note_entry.get_next_same_v(entry)
 end
 
 --[[
-% hide_stem(entry)
+% hide_stem
 
 Hides the stem of the entry by replacing it with Shape 0.
 
 @ entry (FCNoteEntry) the entry to process
 ]]
 function note_entry.hide_stem(entry)
-    local stem = finale.FCCustomStemMod()        
+    local stem = finale.FCCustomStemMod()
     stem:SetNoteEntry(entry)
     stem:UseUpStemData(entry:CalcStemUp())
     if stem:LoadFirst() then
-        stem.ShapeID = 0    
+        stem.ShapeID = 0
         stem:Save()
     else
         stem.ShapeID = 0
         stem:SaveNew()
-    end   
+    end
 end
 
 return note_entry

--- a/src/library/notehead.lua
+++ b/src/library/notehead.lua
@@ -1,8 +1,6 @@
 --[[
 $module Notehead
 ]] --
--- A collection of helpful JW Lua notehead scripts
--- Simply import this file to another Lua script to use any of these scripts
 local notehead = {}
 
 local configuration = require("library.configuration")
@@ -25,7 +23,7 @@ end
 configuration.get_parameters("notehead.config.txt", config)
 
 --[[
-% change_shape(note, shape)
+% change_shape
 
 Changes the given notehead to a specified notehead descriptor string. Currently only supports "diamond".
 

--- a/src/library/score.lua
+++ b/src/library/score.lua
@@ -48,7 +48,7 @@ KEY_MAP.cb = 7 -- Cb, just lowercase
 KEY_MAP.fb = 8 -- Fb, just lowercase
 
 --[[
-% create_default_config()
+% create_default_config
 
 Many of the "create ensemble" plugins use the same configuration. This function
 creates that configuration object.
@@ -74,7 +74,7 @@ function score.create_default_config()
 end
 
 --[[
-% delete_all_staves()
+% delete_all_staves
 
 Deletes all staves in the current document.
 ]]
@@ -88,7 +88,7 @@ function score.delete_all_staves()
 end
 
 --[[
-% reset_and_clear_score()
+% reset_and_clear_score
 
 Resets and clears the score to begin creating a new ensemble
 ]]
@@ -97,7 +97,7 @@ function score.reset_and_clear_score()
 end
 
 --[[
-% set_show_staff_time_signature(staff_id, show_time_signature)
+% set_show_staff_time_signature
 
 Sets whether or not to show the time signature on the staff.
 
@@ -119,7 +119,7 @@ function score.set_show_staff_time_signature(staff_id, show_time_signature)
 end
 
 --[[
-% set_show_all_staves_time_signature(show_time_signature)
+% set_show_all_staves_time_signature
 
 Sets whether or not to show the time signature on the staff.
 
@@ -134,7 +134,7 @@ function score.set_show_all_staves_time_signature(show_time_signature)
 end
 
 --[[
-% set_staff_transposition(staff_id, key, interval, clef)
+% set_staff_transposition
 
 Sets the transposition for a staff. Used for instruments that are not concert pitch (e.g., Bb Clarinet or F Horn)
 
@@ -159,7 +159,7 @@ function score.set_staff_transposition(staff_id, key, interval, clef)
 end
 
 --[[
-% set_staff_allow_hiding(staff_id, allow_hiding)
+% set_staff_allow_hiding
 
 Sets whether the staff is allowed to hide when it is empty.
 
@@ -177,7 +177,7 @@ function score.set_staff_allow_hiding(staff_id, allow_hiding)
 end
 
 --[[
-% set_staff_keyless(staff_id, is_keyless)
+% set_staff_keyless
 
 Sets whether or not the staff is keyless.
 
@@ -195,7 +195,7 @@ function score.set_staff_keyless(staff_id, is_keyless)
 end
 
 --[[
-% set_staff_keyless(is_keyless)
+% set_staff_keyless
 
 Sets whether or not all staves are keyless.
 
@@ -210,7 +210,7 @@ function score.set_all_staves_keyless(is_keyless)
 end
 
 --[[
-% set_staff_show_default_whole_rests(staff_id, show_whole_rests)
+% set_staff_show_default_whole_rests
 
 Sets whether to show default whole rests on a particular staff.
 
@@ -228,7 +228,7 @@ function score.set_staff_show_default_whole_rests(staff_id, show_whole_rests)
 end
 
 --[[
-% set_all_staves_show_default_whole_rests(show_whole_rests)
+% set_all_staves_show_default_whole_rests
 
 Sets whether or not all staves show default whole rests.
 
@@ -243,7 +243,7 @@ function score.set_all_staves_show_default_whole_rests(show_whole_rests)
 end
 
 --[[
-% add_space_above_staff(staff_id)
+% add_space_above_staff
 
 This is the equivalent of "Add Vertical Space" in the Setup Wizard. It adds space above the staff as well as adds the staff to Staff List 1, which allows it to show tempo markings.
 
@@ -271,7 +271,7 @@ function score.add_space_above_staff(staff_id)
 end
 
 --[[
-% set_staff_full_name(staff, full_name, double)
+% set_staff_full_name
 
 Sets the full name for the staff.
 
@@ -296,7 +296,7 @@ function score.set_staff_full_name(staff, full_name, double)
 end
 
 --[[
-% set_staff_short_name(staff, short_name, double)
+% set_staff_short_name
 
 Sets the abbreviated name for the staff.
 
@@ -321,7 +321,7 @@ function score.set_staff_short_name(staff, short_name, double)
 end
 
 --[[
-% create_staff(full_name, short_name, type, clef, double)
+% create_staff
 
 Creates a staff at the end of the score.
 
@@ -358,7 +358,7 @@ function score.create_staff(full_name, short_name, type, clef, double)
 end
 
 --[[
-% create_staff_spaced(full_name, short_name, type, clef, double)
+% create_staff_spaced
 
 Creates a staff at the end of the score with a space above it. This is equivalent to using `score.create_staff` then `score.add_space_above_staff`.
 
@@ -377,7 +377,7 @@ function score.create_staff_spaced(full_name, short_name, type, clef)
 end
 
 --[[
-% create_staff_percussion(full_name, short_name, type, clef)
+% create_staff_percussion
 
 Creates a percussion staff at the end of the score.
 
@@ -396,7 +396,7 @@ function score.create_staff_percussion(full_name, short_name)
 end
 
 --[[
-% create_group(start_staff, end_staff, brace_name, has_barline, level, full_name, short_name)
+% create_group
 
 Creates a percussion staff at the end of the score.
 
@@ -459,7 +459,7 @@ function score.create_group(start_staff, end_staff, brace_name, has_barline, lev
 end
 
 --[[
-% create_group_primary(start_staff, end_staff, full_name, short_name)
+% create_group_primary
 
 Creates a primary group with the "curved_chorus" bracket.
 
@@ -473,7 +473,7 @@ function score.create_group_primary(start_staff, end_staff, full_name, short_nam
 end
 
 --[[
-% create_group_secondary(start_staff, end_staff, full_name, short_name)
+% create_group_secondary
 
 Creates a primary group with the "desk" bracket.
 
@@ -487,9 +487,14 @@ function score.create_group_secondary(start_staff, end_staff, full_name, short_n
 end
 
 --[[
-% calc_system_scalings(systems_per_page)
+% calc_system_scalings
+
+_EXPERIMENTAL_
 
 Calculates the system scaling to fit the desired number of systems on each page.
+
+Currently produces the incorrect values. Should not be used in any production-ready
+scripts.
 
 @ systems_per_page (number) the number of systems that should fit on each page
 
@@ -527,7 +532,7 @@ function score.calc_system_scalings(systems_per_page)
 end
 
 --[[
-% set_global_system_scaling(scaling)
+% set_global_system_scaling
 
 Sets the system scaling for every system in the score.
 
@@ -548,7 +553,7 @@ function score.set_global_system_scaling(scaling)
 end
 
 --[[
-% set_global_system_scaling(scaling)
+% set_global_system_scaling
 
 Sets the system scaling for a specific system in the score.
 
@@ -566,7 +571,7 @@ function score.set_single_system_scaling(system_number, scaling)
 end
 
 --[[
-% set_large_time_signatures_settings()
+% set_large_time_signatures_settings
 
 Updates the document settings for large time signatures.
 ]]
@@ -585,7 +590,7 @@ function score.set_large_time_signatures_settings()
 end
 
 --[[
-% use_large_time_signatures(uses_large_time_signatures, staves_with_time_signatures)
+% use_large_time_signatures
 
 Sets the system scaling for a specific system in the score.
 
@@ -604,7 +609,7 @@ function score.use_large_time_signatures(uses_large_time_signatures, staves_with
 end
 
 --[[
-% use_large_measure_numbers(distance)
+% use_large_measure_numbers
 
 Adds large measure numbers below every measure in the score.
 
@@ -657,7 +662,7 @@ function score.use_large_measure_numbers(distance)
 end
 
 --[[
-% set_max_measures_per_system(width)
+% set_max_measures_per_system
 
 Sets the maximum number of measures per system.
 
@@ -687,7 +692,7 @@ function score.set_max_measures_per_system(max_measures_per_system)
 end
 
 --[[
-% set_score_page_size(width, height)
+% set_score_page_size
 
 Sets the score page size.
 
@@ -711,7 +716,7 @@ function score.set_score_page_size(width, height)
 end
 
 --[[
-% set_all_parts_page_size(width, height)
+% set_all_parts_page_size
 
 Sets the page size for all parts.
 
@@ -742,7 +747,7 @@ function score.set_all_parts_page_size(width, height)
 end
 
 --[[
-% apply_config(width, options)
+% apply_config
 
 When creating an ensemble, this function is used to apply the configuration.
 

--- a/src/library/transposition.lua
+++ b/src/library/transposition.lua
@@ -9,13 +9,13 @@ of a configuration file called "custom_key_sig.config.txt" in the
 can read the correct custom key signature information directly from
 Finale. Therefore, when you run this script with RGP Lua 0.58+, the configuration file
 is ignored.
-]] -- 
+]] --
 -- Structure
 -- 1. Helper functions
 -- 2. Diatonic Transposition
 -- 3. Enharmonic Transposition
 -- 3. Chromatic Transposition
--- 
+--
 local transposition = {}
 
 local configuration = require("library.configuration")
@@ -37,9 +37,9 @@ local custom_key_sig_config = {
 
 configuration.get_parameters("custom_key_sig.config.txt", custom_key_sig_config)
 
--- 
+--
 -- HELPER functions
--- 
+--
 
 local sign = function(n)
     if n < 0 then
@@ -140,12 +140,12 @@ local simplify_spelling = function(note, min_abs_alteration)
     return true
 end
 
--- 
+--
 -- DIATONIC transposition (affect only Displacement)
--- 
+--
 
 --[[
-% diatonic_transpose(note, interval)
+% diatonic_transpose
 
 Transpose the note diatonically by the given interval displacement.
 
@@ -157,7 +157,7 @@ function transposition.diatonic_transpose(note, interval)
 end
 
 --[[
-% change_octave(note, number_of_octaves)
+% change_octave
 
 Transpose the note by the given number of octaves.
 
@@ -173,7 +173,7 @@ end
 --
 
 --[[
-% enharmonic_transpose(note, direction, ignore_error)
+% enharmonic_transpose
 
 Transpose the note enharmonically in the given direction. In some microtone systems this yields a different result than transposing by a diminished 2nd.
 Failure occurs if the note's `RaiseLower` value exceeds an absolute value of 7. This is a hard-coded limit in Finale.
@@ -203,12 +203,12 @@ function transposition.enharmonic_transpose(note, direction, ignore_error)
     return true
 end
 
--- 
+--
 -- CHROMATIC transposition (affect Displacement and RaiseLower)
--- 
+--
 
 --[[
-% chromatic_transpose(note, interval, alteration, simplify)
+% chromatic_transpose
 
 Transposes a note chromatically by the input chromatic interval. Supports custom key signatures
 and microtone systems by means of a `custom_key_sig.config.txt` file. In Finale, chromatic intervals
@@ -252,7 +252,7 @@ function transposition.chromatic_transpose(note, interval, alteration, simplify)
 end
 
 --[[
-% stepwise_transpose(note, number_of_steps)
+% stepwise_transpose
 
 Transposes the note by the input number of steps and simplifies the spelling.
 For predefined key signatures, each step is a half-step.
@@ -276,7 +276,7 @@ function transposition.stepwise_transpose(note, number_of_steps)
 end
 
 --[[
-% chromatic_major_third_down(note)
+% chromatic_major_third_down
 
 Transpose the note down by a major third.
 
@@ -287,7 +287,7 @@ function transposition.chromatic_major_third_down(note)
 end
 
 --[[
-% chromatic_perfect_fourth_up(note)
+% chromatic_perfect_fourth_up
 
 Transpose the note up by a perfect fourth.
 
@@ -298,7 +298,7 @@ function transposition.chromatic_perfect_fourth_up(note)
 end
 
 --[[
-% chromatic_perfect_fifth_down(note)
+% chromatic_perfect_fifth_down
 
 Transpose the note down by a perfect fifth.
 

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -2,12 +2,11 @@
 $module Utility Functions
 
 A library of general Lua utility functions.
-]]
-
+]] --
 local utils = {}
 
 --[[
-% copy_table(t)
+% copy_table
 
 If a table is passed, returns a copy, otherwise returns the passed value.
 
@@ -15,7 +14,7 @@ If a table is passed, returns a copy, otherwise returns the passed value.
 : (mixed)
 ]]
 function utils.copy_table(t)
-    if type(t) == 'table' then
+    if type(t) == "table" then
         local new = {}
         for k, v in pairs(t) do
             new[utils.copy_table(k)] = utils.copy_table(v)
@@ -26,6 +25,5 @@ function utils.copy_table(t)
         return t
     end
 end
-
 
 return utils


### PR DESCRIPTION
- Cleans up library documentation to go with new docs generator.
- Fixes the few cases where the doc comments weren't properly written
- Did not change `library/mixins.lua` to prevent future merge conficts
- Added docs for `measurement.convert_to_EVPUs`
- Several little formatting fixes due to my auto-formatter

If this all looks good, feel free to merge