### PR TITLE
Add recommended VS Code settings and extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ jwlua.fxt
 jwluatagfile.xml
 SciLexer.dll
 jwlua64.fxtco
-.vscode
 
 # ignore Finale files (used for testing)
 *.mus
@@ -22,3 +21,6 @@ coverage
 mobdebug.lua
 
 src/personal*
+
+.vscode/settings.json
+*/**/.vscode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["Koihik.vscode-lua-format", "sumneko.lua"]
+}

--- a/.vscode/recommended_settings.json
+++ b/.vscode/recommended_settings.json
@@ -1,0 +1,21 @@
+{
+    "Lua.diagnostics.globals": [
+        "finale",
+        "finenv",
+        "finaleplugin",
+        "each",
+        "eachentrysaved",
+        "eachbackwards",
+        "eachentry",
+        "pairsbykeys",
+        "loadall",
+        "bit32"
+    ],
+    "editor.formatOnSave": true,
+    "Lua.diagnostics.disable": ["lowercase-global", "luadoc-miss-cate-name"],
+    "vscode-lua-format.configPath": "./luaconfig.config",
+    "[lua]": {
+        "editor.defaultFormatter": "Koihik.vscode-lua-format"
+    },
+    "Lua.runtime.version": "Lua 5.2"
+}


### PR DESCRIPTION
Because of the ongoing efforts to resolve https://github.com/finale-lua/lua-scripts/issues/5, I decided to add my current VS Code settings and extensions to the `.vscode` folder.

In theory, this does two things:

1. New users will get notified to install the recommended extensions
2. All users will be working with the same VS Code settings (e.g., code formatting, linting, etc.)

That means we can help make everyone's development environment consistent. And aside from pressing the button to "download recommended extensions", developers won't need to do anything to setup VS Code.

To be honest, I've never done this before so it may not work as expected. But it's potentially worth a shot. At the very least, it might resolve the existing [VS Code code formatting issue](https://github.com/finale-lua/lua-scripts/issues/5) since we'll share the same settings and extensions.

The may drawback is that if anyone has a `.vscode` folder in their local version of the repo, their settings may also get unintentionally added.