### PR TITLE
[WIP] Add code format checker to CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Check code format
+
+on: ['push']
+
+jobs:
+    check-format:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout this repository
+              uses: actions/checkout@v3
+              with:
+                fetch-depth: 0
+            - uses: Ana06/get-changed-files@v2.1.0
+              with:
+                filter: '*.lua'
+
+            - uses: leafo/gh-actions-lua@v9
+            - uses: leafo/gh-actions-luarocks@v4
+            - name: Install LuaFormat
+              run: |
+                luarocks install --server=https://luarocks.org/dev luaformatter
+            - name: Check formatting
+              run: |
+                ./lua-format {{ steps.files.outputs.added_modified }} -c ./luaconfig.config --check


### PR DESCRIPTION
This PR adds a GitHub action to check code formatting on every commit.

That will allow us to check if code is formatted correctly before merging into the master branch.

I'm considering this a draft PR for now for two reasons:

1. I don't know if it will work as intended
2. I plan to use this PR to test the GitHub action

Since my last couple commits have included many miscellaneous auto-formatting fixes, my hope is that by checking code formatting _before_ merging those miscellaneous fixes won't happen in the future.

How I plan for this action to work:

1. On every commit to every PR, it will check the code formatting for only the added or modified `.lua` files using the same `luaconfig.config` at the root of this repository
2. If all the files are properly formatted, the status check will pass (this will be clearly visible on every PR)
3. If not, the action logs will include a diff on what needs to be changed
4. Once this action works, I'll add a branch protection rule preventing code from being merged if it's not formatted correctly

Hopefully this in conjunction with the VS Code auto-formatting settings PR https://github.com/finale-lua/lua-scripts/pull/156 could help make code formatting issues a thing of the past.

I do not plan on merging this PR before https://github.com/finale-lua/lua-scripts/pull/156 is  merged and https://github.com/finale-lua/lua-scripts/issues/5 is closed. That way there's an easy fix for formatting code. It would be a real pain to go through and manually format every single character of code just to merge it into this repo.