### PR TITLE
Measurement Unit Mixins

### DIFF
--- a/src/library/measurement.lua
+++ b/src/library/measurement.lua
@@ -3,6 +3,33 @@ $module measurement
 ]] --
 local measurement = {}
 
+local unit_names = {
+    [finale.MEASUREMENTUNIT_EVPUS] = "EVPUs",
+    [finale.MEASUREMENTUNIT_INCHES] = "Inches",
+    [finale.MEASUREMENTUNIT_CENTIMETERS] = "Centimeters",
+    [finale.MEASUREMENTUNIT_POINTS] = "Points",
+    [finale.MEASUREMENTUNIT_PICAS] = "Picas",
+    [finale.MEASUREMENTUNIT_SPACES] = "Spaces",
+}
+
+local unit_suffixes = {
+    [finale.MEASUREMENTUNIT_EVPUS] = "e",
+    [finale.MEASUREMENTUNIT_INCHES] = "i",
+    [finale.MEASUREMENTUNIT_CENTIMETERS] = "c",
+    [finale.MEASUREMENTUNIT_POINTS] = "pt",
+    [finale.MEASUREMENTUNIT_PICAS] = "p",
+    [finale.MEASUREMENTUNIT_SPACES] = "s",
+}
+
+local unit_abbreviations = {
+    [finale.MEASUREMENTUNIT_EVPUS] = "ev",
+    [finale.MEASUREMENTUNIT_INCHES] = "in",
+    [finale.MEASUREMENTUNIT_CENTIMETERS] = "cm",
+    [finale.MEASUREMENTUNIT_POINTS] = "pt",
+    [finale.MEASUREMENTUNIT_PICAS] = "",
+    [finale.MEASUREMENTUNIT_SPACES] = "sp",
+}
+
 --[[
 % convert_to_EVPUs
 
@@ -26,6 +53,107 @@ function measurement.convert_to_EVPUs(text)
     local str = finale.FCString()
     str.LuaString = text
     return str:GetMeasurement(finale.MEASUREMENTUNIT_DEFAULT)
+end
+
+--[[
+% get_unit_name
+
+Returns the name of a measurement unit.
+
+@ unit (number) A finale MEASUREMENTUNIT constant.
+: (string)
+]]
+function measurement.get_unit_name(unit)
+    if unit == finale.MEASUREMENTUNIT_DEFAULT then
+        unit = measurement.get_real_default_unit()
+    end
+
+    return unit_names[unit]
+end
+
+--[[
+% get_unit_suffix
+
+Returns the measurement unit's suffix. Suffixes can be used to force the text value (eg in `FCString` or `FCCtrlEdit`) to be treated as being from a particular measurement unit
+Note that although this method returns a "p" for Picas, the fractional part goes after the "p" (eg `1p6`), so in practice it may be that no suffix is needed.
+
+@ unit (number) A finale MEASUREMENTUNIT constant.
+: (string)
+]]
+function measurement.get_unit_suffix(unit)
+    if unit == finale.MEASUREMENTUNIT_DEFAULT then
+        unit = measurement.get_real_default_unit()
+    end
+
+    return unit_suffixes[unit]
+end
+
+--[[
+% get_unit_abbreviation
+
+Returns measurement unit abbreviations that are more human-readable than Finale's internal suffixes.
+Abbreviations are also compatible with the internal ones because Finale discards everything after the first letter that isn't part of the suffix.
+
+For example:
+```lua
+local str_internal = finale.FCString()
+str.LuaString = "2i"
+
+local str_display = finale.FCString()
+str.LuaString = "2in"
+
+print(str_internal:GetMeasurement(finale.MEASUREMENTUNIT_DEFAULT) == str_display:GetMeasurement(finale.MEASUREMENTUNIT_DEFAULT)) -- true
+```
+
+@ unit (number) A finale MEASUREMENTUNIT constant.
+: (string)
+]]
+function measurement.get_unit_abbreviation(unit)
+    if unit == finale.MEASUREMENTUNIT_DEFAULT then
+        unit = measurement.get_real_default_unit()
+    end
+
+    return unit_abbreviations[unit]
+end
+
+--[[
+% is_valid_unit
+
+Checks if a number is equal to one of the finale MEASUREMENTUNIT constants.
+
+@ unit (number) The unit to check.
+: (boolean) `true` if valid, `false` if not.
+]]
+function measurement.is_valid_unit(unit)
+    return unit_names[unit] and true or false
+end
+
+--[[
+% get_real_default_unit
+
+Resolves `finale.MEASUREMENTUNIT_DEFAULT` to the value of one of the other `MEASUREMENTUNIT` constants.
+
+: (number)
+]]
+function measurement.get_real_default_unit()
+    local str = finale.FCString()
+    finenv.UI():GetDecimalSeparator(str)
+    local separator = str.LuaString
+    str:SetMeasurement(72, finale.MEASUREMENTUNIT_DEFAULT)
+
+    if str.LuaString == "72" then
+        return finale.MEASUREMENTUNIT_EVPUS
+    elseif str.LuaString == "0" .. separator .. "25" then
+        return finale.MEASUREMENTUNIT_INCHES
+    elseif str.LuaString == "0" .. separator .. "635" then
+        return finale.MEASUREMENTUNIT_CENTIMETERS
+    elseif str.LuaString == "18" then
+        return finale.MEASUREMENTUNIT_POINTS
+    elseif str.LuaString == "1p6" then
+        return finale.MEASUREMENTUNIT_PICAS
+    elseif str.LuaString == "3" then
+        return finale.MEASUREMENTUNIT_SPACES
+    end
 end
 
 return measurement

--- a/src/library/mixin_helper.lua
+++ b/src/library/mixin_helper.lua
@@ -1,12 +1,10 @@
 --  Author: Edward Koltun
 --  Date: April 3, 2022
-
 --[[
 $module Mixin Helper
 
 A library of helper functions to improve code reuse in mixins.
-]]
-local utils = require("library.utils")
+]] local utils = require("library.utils")
 local mixin = require("library.mixin")
 
 local mixin_helper = {}
@@ -42,7 +40,7 @@ function mixin_helper.create_standard_control_event(name)
     local callbacks = setmetatable({}, {__mode = "k"})
     local windows = setmetatable({}, {__mode = "k"})
 
-    local handler = function(control, ...)
+    local dispatcher = function(control, ...)
         if not callbacks[control] then
             return
         end
@@ -57,16 +55,18 @@ function mixin_helper.create_standard_control_event(name)
             return
         end
 
-        window["Add" .. name](window, handler)
+        window["Add" .. name](window, dispatcher)
 
         windows[window] = true
     end
 
     local function add_func(control, callback)
-        mixin.assert_argument(callback, "function", 2)
+        mixin.assert_argument(callback, "function", 3)
         local window = control:GetParent()
         mixin.assert(window, "Cannot add handler to control with no parent window.")
-        mixin.assert((window.MixinBase or window.MixinClass) == "FCMCustomLuaWindow", "Handlers can only be added if parent window is an instance of FCMCustomLuaWindow")
+        mixin.assert(
+            (window.MixinBase or window.MixinClass) == "FCMCustomLuaWindow",
+            "Handlers can only be added if parent window is an instance of FCMCustomLuaWindow")
 
         init_window(window)
         callbacks[control] = callbacks[control] or {}
@@ -74,9 +74,9 @@ function mixin_helper.create_standard_control_event(name)
     end
 
     local function remove_func(control, callback)
-        mixin.assert_argument(callback, "function", 2)
+        mixin.assert_argument(callback, "function", 3)
 
-        utils.table_remove_first(private[self].HandleCommand, callback)
+        utils.table_remove_first(callbacks[control], callback)
     end
 
     return add_func, remove_func
@@ -92,163 +92,99 @@ local function unpack_arguments(values, ...)
     return table.unpack(args)
 end
 
---[[
-% create_custom_control_change_event
+local function get_event_value(target, func)
+    if type(func) == "string" then
+        return target[func](target)
+    else
+        return func(target)
+    end
+end
 
-Helper function for creating a custom change event for a control.
-Custom events are bootstrapped to InitWindow and HandleCommand, in addition be being able to be triggered manually.
-For example usage, refer to the source for the `FCMCtrlPopup` mixin.
-
-Parameters:
-This function accepts as multiple arguments, a table for each parameter that will be passed to event handlers. Each table should have the following properties:
-- `name`: The name of the parameter.
-- `get`: The function or the string name of a control method to get the current value of the parameter. It should accept one argument which is the control itself. (eg `mixin.FCMControl.GetText` or `"GetSelectedItem_"`)
-- `initial`: The initial value of the parameter (ie before the window has been created)
-
-This function returns 4 values which are all functions:
-1. Public method for adding a handler.
-2. Public method for removing a handler.
-3. Private static function for triggering the event on a control. Accepts one argument which is the control.
-4. Private static function for iterating over the sets of last values to enable modification if needed. Each iteration returns a table with event handler paramater names and values.
-]]
-function mixin_helper.create_custom_control_change_event(...)
+local function create_change_event(...)
     local callbacks = setmetatable({}, {__mode = "k"})
-    local windows = setmetatable({}, {__mode = "k"})
     local params = {...} -- Store varargs in table so that it's accessible by inner functions
 
-    -- Bootstraps the custom event to InitWindow and HandleCommand events on the window object
-    local handler = function(control)
-        if not callbacks[control] then
+    local event = {}
+    function event.dispatcher(target)
+        if not callbacks[target] then
             return
         end
 
         -- Get current values for event handler parameters
         local current = {}
         for _, p in ipairs(params) do
-            if type(p.get) == "string" then
-                current[p.name] = control[p.get](control)
-            else
-                current[p.name] = p.get(control)
-            end
+            current[p.name] = get_event_value(target, p.get)
         end
 
-        for _, cb in ipairs(callbacks[control].order) do
+        for _, cb in ipairs(callbacks[target].order) do
             -- If any of the last values are not equal to the current ones, call the handler
+            local called = false
             for k, v in pairs(current) do
-                if current[k] ~= callbacks[control].history[cb][k] then
-                    cb(control, unpack_arguments(callbacks[control].history[cb], table.unpack(params)))
-
-                    -- Update current values in case they have changed
-                    for _, p in ipairs(params) do
-                        if type(p.get) == "string" then
-                            current[p.name] = control[p.get](control)
-                        else
-                            current[p.name] = p.get(control)
-                        end
-                    end
-
-                    -- Update the stored last value
-                    -- Doing this after the values are updated prevents the same handler being triggered for any changes within the handler, which also reduces the possibility of infinite handler loops
-                    callbacks[control].history[cb] = utils.copy_table(current)
-
+                if current[k] ~= callbacks[target].history[cb][k] then
+                    cb(target, unpack_arguments(callbacks[target].history[cb], table.unpack(params)))
+                    called = true
                     goto continue
                 end
             end
-
             ::continue::
-        end
-    end
 
-    local function init_window(window)
-        if windows[window] then
-            return
-        end
-
-        window:AddInitWindow(function()
-            -- This will go through the controls in random order but unless it becomes an issue, it's not worth doing anything about
-            for control in pairs(callbacks) do
-                handler(control)
+            -- Update current values in case they have changed
+            for _, p in ipairs(params) do
+                current[p.name] = get_event_value(target, p.get)
             end
-        end)
 
-        window:AddHandleCommand(handler)
+            -- Update the stored last value
+            -- Doing this after the values are updated prevents the same handler being triggered for any changes within the handler, which also reduces the possibility of infinite handler loops
+            if called then
+                callbacks[target].history[cb] = utils.copy_table(current)
+            end
+        end
     end
 
-    -- Method for adding event handlers
-    local function add_func(self, callback)
-        mixin.assert_argument(callback, "function", 2)
-        local window = self:GetParent()
-        mixin.assert(window, "Cannot add handler to self with no parent window.")
-        mixin.assert((window.MixinBase or window.MixinClass) == "FCMCustomLuaWindow", "Handlers can only be added if parent window is an instance of FCMCustomLuaWindow")
-        mixin.force_assert(not callbacks[self] or callbacks[self].history[callback] == nil, "The callback has already been added as a change handler.")
-
-        init_window(window)
+    function event.add(target, callback, initial)
+        callbacks[target] = callbacks[target] or {order = {}, history = {}}
 
         local history = {}
         for _, p in ipairs(params) do
-            history[p.name] = window:WindowExists_() and p.get(self) or p.initial
-        end
-
-        callbacks[self] = callbacks[self] or {order = {}, history = {}}
-        callbacks[self].history[callback] = history
-        table.insert(callbacks[self].order, callback)
-    end
-
-    -- Method for removing event handlers
-    local function remove_func(self, callback)
-        mixin.assert_argument(callback, "function", 2)
-
-        if not callbacks[self] then
-            return
-        end
-
-        utils.table_remove_first(callbacks[self].order, callback)
-        callbacks[self].history[callback] = nil
-    end
-
-    local function trigger_helper(control)
-        if not callbacks[control] or callbacks[control].is_queued then
-            return
-        end
-
-        local window = control:GetParent()
-
-        if window:WindowExists_() then
-            window:QueueHandleCustom(function()
-                callbacks[control].is_queued = false
-                handler(control)
-            end)
-
-            callbacks[control].is_queued = true
-        end
-    end
-
-    -- Function for triggering the custom event on a control
-    -- If control is boolean true, then will trigger dispatcher for all controls.
-    -- If immediate is true, will trigger dispatchers immediately. This can have unintended consequences, so use with caution.
-    local function trigger_func(control, immediate)
-        if type(control) == 'boolean' and control then
-            for ctrl in pairs(callbacks) do
-                if immediate then
-                    handler(ctrl)
+            if initial then
+                if type(p.initial) == "function" then
+                    history[p.name] = p.initial(target)
                 else
-                    trigger_helper(ctrl)
+                    history[p.name] = p.initial
                 end
-            end
-        else
-            if immediate then
-                handler(control)
             else
-                trigger_helper(control)
+                history[p.name] = get_event_value(target, p.get)
             end
         end
+
+        callbacks[target].history[callback] = history
+        table.insert(callbacks[target].order, callback)
+    end
+
+    function event.remove(target, callback)
+        if not callbacks[target] then
+            return
+        end
+
+        callbacks[target].history[callback] = nil
+        table.insert(callbacks[target].order, callback)
+    end
+
+    function event.callback_exists(target, callback)
+        return callbacks[target] and callbacks[target].history[callback] and true or false
+    end
+
+    function event.has_callbacks(target)
+        return callbacks[target] and #callbacks[target].order > 0 or false
     end
 
     -- Function for iterating over history
-    local function history_iterator(control)
+    function event.history_iterator(control)
         local cb = callbacks[control]
-        if not cb then
-            return function() return nil end
+        if not cb or #cb.order == 0 then
+            return function()
+                return nil
+            end
         end
 
         local i = 0
@@ -265,8 +201,176 @@ function mixin_helper.create_custom_control_change_event(...)
         return iterator
     end
 
-    return add_func, remove_func, trigger_func, history_iterator
+    function event.target_iterator()
+        return utils.iterate_keys(callbacks)
+    end
+
+    return event
 end
 
+--[[
+% create_custom_control_change_event
+
+Helper function for creating a custom event for a control.
+Custom events are bootstrapped to InitWindow and HandleCommand, in addition be being able to be triggered manually.
+For example usage, refer to the source for the `FCMCtrlPopup` mixin.
+
+Parameters:
+This function accepts as multiple arguments, a table for each parameter that will be passed to event handlers. Each table should have the following properties:
+- `name`: The name of the parameter.
+- `get`: The function or the string name of a control method to get the current value of the parameter. It should accept one argument which is the control itself. (eg `mixin.FCMControl.GetText` or `"GetSelectedItem_"`)
+- `initial`: The initial value of the parameter (ie before the window has been created)
+
+This function returns 4 values which are all functions:
+1. Public method for adding a handler.
+2. Public method for removing a handler.
+3. Private static function for triggering the event on a control. Accepts one argument which is the control.
+4. Private static function for iterating over the sets of last values to enable modification if needed. Each iteration returns a table with event handler paramater names and values.
+
+@ ... (table)
+]]
+function mixin_helper.create_custom_control_change_event(...)
+    local event = create_change_event(...)
+    local windows = setmetatable({}, {__mode = "k"})
+    local queued = setmetatable({}, {__mode = "k"})
+
+    local function init_window(window)
+        if windows[window] then
+            return
+        end
+
+        window:AddInitWindow(
+            function()
+                -- This will go through the controls in random order but unless it becomes an issue, it's not worth doing anything about
+                for control in event.target_iterator() do
+                    event.dispatcher(control)
+                end
+            end)
+
+        window:AddHandleCommand(event.dispatcher)
+    end
+
+    local function add_func(self, callback)
+        mixin.assert_argument(callback, "function", 2)
+        local window = self:GetParent()
+        mixin.assert(window, "Cannot add handler to self with no parent window.")
+        mixin.assert(
+            (window.MixinBase or window.MixinClass) == "FCMCustomLuaWindow",
+            "Handlers can only be added if parent window is an instance of FCMCustomLuaWindow")
+        mixin.force_assert(
+            not event.callback_exists(self, callback), "The callback has already been added as a handler.")
+
+        init_window(window)
+        event.add(self, callback, not window:WindowExists_())
+    end
+
+    local function remove_func(self, callback)
+        mixin.assert_argument(callback, "function", 2)
+
+        event.remove(self, callback)
+    end
+
+    local function trigger_helper(control)
+        if not event.has_callbacks(control) or queued[control] then
+            return
+        end
+
+        local window = control:GetParent()
+
+        if window:WindowExists_() then
+            window:QueueHandleCustom(
+                function()
+                    queued[control] = nil
+                    event.dispatcher(control)
+                end)
+
+            queued[control] = true
+        end
+    end
+
+    -- Function for triggering the custom event on a control
+    -- If control is boolean true, then will trigger dispatcher for all controls.
+    -- If immediate is true, will trigger dispatchers immediately. This can have unintended consequences, so use with caution.
+    local function trigger_func(control, immediate)
+        if type(control) == "boolean" and control then
+            for ctrl in event.target_iterator() do
+                if immediate then
+                    event.dispatcher(ctrl)
+                else
+                    trigger_helper(ctrl)
+                end
+            end
+        else
+            if immediate then
+                event.dispatcher(control)
+            else
+                trigger_helper(control)
+            end
+        end
+    end
+
+    return add_func, remove_func, trigger_func, event.history_iterator
+end
+
+--[[
+% create_custom_window_change_event
+
+Creates a custom change event for a window class. For details, see the documentation for `create_custom_control_change_event`, which works in exactly the same way as this function except for controls.
+
+@ ... (table)
+]]
+function mixin_helper.create_custom_window_change_event(...)
+    local event = create_change_event(...)
+    local queued = setmetatable({}, {__mode = "k"})
+
+    local function add_func(self, callback)
+        mixin.assert_argument(self, "FCMCustomLuaWindow", 1)
+        mixin.assert_argument(callback, "function", 2)
+        mixin.force_assert(
+            not event.callback_exists(self, callback), "The callback has already been added as a handler.")
+
+        event.add(self, callback)
+    end
+
+    local function remove_func(self, callback)
+        mixin.assert_argument(callback, "function", 2)
+
+        event.remove(self, callback)
+    end
+
+    local function trigger_helper(window)
+        if not event.has_callbacks(window) or queued[window] or not window:WindowExists_() then
+            return
+        end
+
+        window:QueueHandleCustom(
+            function()
+                queued[window] = nil
+                event.dispatcher(window)
+            end)
+
+        queued[window] = true
+    end
+
+    local function trigger_func(window, immediate)
+        if type(window) == "boolean" and window then
+            for win in event.target_iterator() do
+                if immediate then
+                    event.dispatcher(window)
+                else
+                    trigger_helper(window)
+                end
+            end
+        else
+            if immediate then
+                event.dispatcher(window)
+            else
+                trigger_helper(window)
+            end
+        end
+    end
+
+    return add_func, remove_func, trigger_func, event.history_iterator
+end
 
 return mixin_helper

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -43,5 +43,33 @@ function utils.table_remove_first(t, value)
     end
 end
 
+--[[
+% iterate_keys
+
+Returns an unordered iterator for the keys in a table.
+
+@ t (table)
+: (function)
+]]
+function utils.iterate_keys(t)
+    local a, b, c = pairs(t)
+
+    return function()
+        c = a(b, c)
+        return c
+    end
+end
+
+--[[
+% round
+
+Rounds a number to the nearest whole integer.
+
+@ num (number)
+: (number)
+]]
+function utils.round(num)
+    return math.floor(num + 0.5)
+end
 
 return utils

--- a/src/mixin/FCMControl.lua
+++ b/src/mixin/FCMControl.lua
@@ -1,6 +1,5 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMControl
 
@@ -9,8 +8,7 @@ Summary of modifications:
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
 - Ported `GetParent` from PDK to allow the parent window to be accessed from a control.
 - Handlers for the `Command` event can now be set on a control.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
@@ -19,7 +17,6 @@ local parent = setmetatable({}, {__mode = "kv"})
 local props = {}
 
 local temp_str = finale.FCString()
-
 
 --[[
 % GetParent
@@ -116,7 +113,6 @@ Removes a handler added with `AddHandleCommand`.
 @ self (FCMControl)
 @ callback (function)
 ]]
-props.AddHandleCommand, props.RemoveHandleCommand = mixin_helper.create_standard_control_event('HandleCommand')
-
+props.AddHandleCommand, props.RemoveHandleCommand = mixin_helper.create_standard_control_event("HandleCommand")
 
 return props

--- a/src/mixin/FCMCtrlButton.lua
+++ b/src/mixin/FCMCtrlButton.lua
@@ -1,6 +1,5 @@
 --  Author: Edward Koltun
 --  Date: April 3, 2022
-
 --[[
 $module FCMCtrlButton
 
@@ -9,14 +8,11 @@ The following methods have been disabled from `FCMCtrlCheckbox`:
 - `RemoveHandleCheckChange`
 
 To handle button presses, use `AddHandleCommand` inherited from `FCMControl`.
-]]
-
+]] --
 local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
-
 mixin_helper.disable_methods(props, "AddHandleCheckChange", "RemoveHandleCheckChange")
-
 
 return props

--- a/src/mixin/FCMCtrlCheckbox.lua
+++ b/src/mixin/FCMCtrlCheckbox.lua
@@ -1,13 +1,11 @@
 --  Author: Edward Koltun
 --  Date: April 2, 2022
-
 --[[
 $module FCMCtrlCheckbox
 
 Summary of modifications:
 - Added `CheckChange` custom control event.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
@@ -15,7 +13,6 @@ local props = {}
 
 local trigger_check_change
 local each_last_check_change
-
 
 --[[
 % SetCheck
@@ -66,11 +63,10 @@ Removes a handler added with `AddHandleCheckChange`.
 @ self (FCMCtrlCheckbox)
 @ callback (function)
 ]]
-props.AddHandleCheckChange, props.RemoveHandleCheckChange, trigger_check_change, each_last_check_change = mixin_helper.create_custom_control_change_event(
-    -- initial could be set to -1 to force the event to fire on InitWindow, but unlike other controls, -1 is not a valid checkstate.
-    -- If it becomes necessary to force this event to fire when the window is created, change to -1
-    {name = 'last_check', get = "GetCheck_", initial = 0}
-)
-
+props.AddHandleCheckChange, props.RemoveHandleCheckChange, trigger_check_change, each_last_check_change =
+    mixin_helper.create_custom_control_change_event(
+        -- initial could be set to -1 to force the event to fire on InitWindow, but unlike other controls, -1 is not a valid checkstate.
+        -- If it becomes necessary to force this event to fire when the window is created, change to -1
+        {name = "last_check", get = "GetCheck_", initial = 0})
 
 return props

--- a/src/mixin/FCMCtrlDataList.lua
+++ b/src/mixin/FCMCtrlDataList.lua
@@ -1,22 +1,18 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMCtrlDataList
 
 Summary of modifications:
 - Setters that accept `FCString` now also accept Lua `string` and `number`.
 - Handlers for the `DataListCheck` and `DataListSelect` events can now be set on a control.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
 local temp_str = finale.FCString()
-
-
 
 --[[
 % AddColumn
@@ -32,7 +28,7 @@ function props:AddColumn(title, columnwidth)
     mixin.assert_argument(title, {"string", "number", "FCString"}, 2)
     mixin.assert_argument(columnwidth, "number", 3)
 
-    if type(str) ~= "userdata" then
+    if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)
         title = temp_str
     end
@@ -54,7 +50,7 @@ function props:SetColumnTitle(columnindex, title)
     mixin.assert_argument(columnindex, "number", 2)
     mixin.assert_argument(title, {"string", "number", "FCString"}, 3)
 
-    if type(str) ~= "userdata" then
+    if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)
         title = temp_str
     end
@@ -81,7 +77,7 @@ Removes a handler added with `AddHandleCheck`.
 @ self (FCMCtrlDataList)
 @ callback (function)
 ]]
-props.AddHandleCheck, props.RemoveHandleCheck = mixin_helper.create_standard_control_event('HandleDataListCheck')
+props.AddHandleCheck, props.RemoveHandleCheck = mixin_helper.create_standard_control_event("HandleDataListCheck")
 
 --[[
 % AddHandleSelect
@@ -102,7 +98,6 @@ Removes a handler added with `AddHandleSelect`.
 @ self (FCMControl)
 @ callback (function)
 ]]
-props.AddHandleSelect, props.RemoveHandleSelect = mixin_helper.create_standard_control_event('HandleDataListSelect')
-
+props.AddHandleSelect, props.RemoveHandleSelect = mixin_helper.create_standard_control_event("HandleDataListSelect")
 
 return props

--- a/src/mixin/FCMCtrlEdit.lua
+++ b/src/mixin/FCMCtrlEdit.lua
@@ -1,13 +1,11 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMCtrlEdit
 
 Summary of modifications:
 - Added `Change` custom control event.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
@@ -16,6 +14,107 @@ local props = {}
 local trigger_change
 local each_last_change
 
+--[[
+% SetInteger
+
+**[Fluid] [Override]**
+Ensures that `Change` event is triggered.
+
+@ self (FCMCtrlEdit)
+@ anint (number)
+]]
+function props:SetInteger(anint)
+    mixin.assert_argument(anint, "number", 2)
+
+    self:SetInteger_(anint)
+    trigger_change(self)
+end
+
+--[[
+% SetText
+
+**[Fluid] [Override]**
+Ensures that `Change` event is triggered.
+
+@ self (FCMCtrlEdit)
+@ str (FCString|string|number)
+]]
+function props:SetText(str)
+    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+
+    mixin.FCMControl.SetText(self, str)
+    trigger_change(self)
+end
+
+--[[
+% SetMeasurement
+
+**[Fluid] [Override]**
+Ensures that `Change` event is triggered.
+
+@ self (FCMCtrlEdit)
+@ value (number)
+@ measurementunit (number)
+]]
+function props:SetMeasurement(value, measurementunit)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(measurementunit, "number", 3)
+
+    self:SetMeasurement_(value, measurementunit)
+    trigger_change(self)
+end
+
+--[[
+% SetMeasurementEfix
+
+**[Fluid] [Override]**
+Ensures that `Change` event is triggered.
+
+@ self (FCMCtrlEdit)
+@ value (number)
+@ measurementunit (number)
+]]
+function props:SetMeasurementEfix(value, measurementunit)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(measurementunit, "number", 3)
+
+    self:SetMeasurementEfix_(value, measurementunit)
+    trigger_change(self)
+end
+
+--[[
+% SetMeasurementInteger
+
+**[Fluid] [Override]**
+Ensures that `Change` event is triggered.
+
+@ self (FCMCtrlEdit)
+@ value (number)
+@ measurementunit (number)
+]]
+function props:SetMeasurementInteger(value, measurementunit)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(measurementunit, "number", 3)
+
+    self:SetMeasurementInteger_(value, measurementunit)
+    trigger_change(self)
+end
+
+--[[
+% SetFloat
+
+**[Fluid] [Override]**
+Ensures that `Change` event is triggered.
+
+@ self (FCMCtrlEdit)
+@ value (number)
+]]
+function props:SetFloat(value)
+    mixin.assert_argument(value, "number", 2)
+
+    self:SetFloat_(value)
+    trigger_change(self)
+end
 
 --[[
 % HandleChange
@@ -49,9 +148,8 @@ Removes a handler added with `AddHandleChange`.
 @ self (FCMCtrlEdit)
 @ callback (function)
 ]]
-props.AddHandleChange, props.RemoveHandleChange, trigger_change, each_last_change = mixin_helper.create_custom_control_change_event(
-    {name = 'last_value', get = mixin.FCMControl.GetText, initial = ""}
-)
-
+props.AddHandleChange, props.RemoveHandleChange, trigger_change, each_last_change =
+    mixin_helper.create_custom_control_change_event(
+        {name = "last_value", get = mixin.FCMControl.GetText, initial = ""})
 
 return props

--- a/src/mixin/FCMCtrlListBox.lua
+++ b/src/mixin/FCMCtrlListBox.lua
@@ -1,6 +1,5 @@
 --  Author: Edward Koltun
 --  Date: April 4, 2022
-
 --[[
 $module FCMCtrlListBox
 
@@ -10,8 +9,7 @@ Summary of modifications:
 - Setters that accept `FCStrings` now also accept multiple arguments of `FCString`, Lua `string`, or `number`.
 - Numerous additional methods for accessing and modifying listbox items.
 - Added `SelectionChange` custom control event.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local library = require("library.general_library")
@@ -23,7 +21,6 @@ local props = {}
 local trigger_selection_change
 local each_last_selection_change
 local temp_str = finale.FCString()
-
 
 --[[
 % Init
@@ -242,7 +239,7 @@ function props:SetItemText(index, str)
         temp_str.LuaString = private[self][index + 1]
         self:SetItemText_(index, temp_str)
 
-    -- Otherwise, use a polyfill
+        -- Otherwise, use a polyfill
     else
         local strs = finale.FCStrings()
         for _, v in ipairs(private[self]) do
@@ -352,7 +349,7 @@ function props:InsertItem(index, str)
 
     for v in each_last_selection_change(self) do
         if v.last_item >= index then
-            v.last_item = v.last_item+ 1
+            v.last_item = v.last_item + 1
         end
     end
 end
@@ -445,10 +442,20 @@ Removes a handler added with `AddHandleSelectionChange`.
 @ self (FCMCtrlListBox)
 @ callback (function) Handler to remove.
 ]]
-props.AddHandleSelectionChange, props.RemoveHandleSelectionChange, trigger_selection_change, each_last_selection_change = mixin_helper.create_custom_control_change_event(
-    {name = 'last_item', get = "GetSelectedItem_", initial = -1},
-    {name = 'last_item_text', get = function(ctrl) return mixin.FCMCtrlListBox.GetSelectedString(ctrl) or "" end, initial = ""},
-    {name = 'is_deleted', get = function() return false end, initial = false}
-)
+props.AddHandleSelectionChange, props.RemoveHandleSelectionChange, trigger_selection_change, each_last_selection_change =
+    mixin_helper.create_custom_control_change_event(
+        {name = "last_item", get = "GetSelectedItem_", initial = -1}, {
+            name = "last_item_text",
+            get = function(ctrl)
+                return mixin.FCMCtrlListBox.GetSelectedString(ctrl) or ""
+            end,
+            initial = "",
+        }, {
+            name = "is_deleted",
+            get = function()
+                return false
+            end,
+            initial = false,
+        })
 
 return props

--- a/src/mixin/FCMCtrlSlider.lua
+++ b/src/mixin/FCMCtrlSlider.lua
@@ -1,6 +1,5 @@
 --  Author: Edward Koltun
 --  Date: April 3, 2022
-
 --[[
 $module FCMCtrlSlider
 
@@ -11,8 +10,7 @@ Summary of modifications:
 Command events do not fire for `FCCtrlSlider` controls, so a workaround is used to make the `ThumbPositionChange` events work.
 If using JW/RGPLua version 0.55 or lower, then the event dispatcher will run with the next Command event for a different control. In these versions the event is unreliable as the user will need to interact with another control for the change in thumb position to be registered.
 If using version 0.56 or later, then the dispatcher will run every 1 second. This is more reliable than in earlier versions but it still will not fire immediately.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
@@ -29,7 +27,7 @@ local function bootstrap_command()
     trigger_thumb_position_change(true)
 end
 
-local function bootstrap_timer()
+local function bootstrap_timer(timerid, window)
     -- We're in the root of an event handler, so it is safe to trigger immediately
     trigger_thumb_position_change(true, true)
 end
@@ -44,7 +42,6 @@ bootstrap_timer_first = function(timerid, window)
 
     bootstrap_timer(timerid, window)
 end
-
 
 --[[
 % RegisterParent
@@ -153,9 +150,8 @@ Removes a handler added with `AddHandleThumbPositionChange`.
 @ self (FCMCtrlSlider)
 @ callback (function)
 ]]
-props.AddHandleThumbPositionChange, props.RemoveHandleThumbPositionChange, trigger_thumb_position_change, each_last_thumb_position_change = mixin_helper.create_custom_control_change_event(
-    {name = 'last_position', get = "GetThumbPosition_", initial = -1}
-)
-
+props.AddHandleThumbPositionChange, props.RemoveHandleThumbPositionChange, trigger_thumb_position_change, each_last_thumb_position_change =
+    mixin_helper.create_custom_control_change_event(
+        {name = "last_position", get = "GetThumbPosition_", initial = -1})
 
 return props

--- a/src/mixin/FCMCtrlSwitcher.lua
+++ b/src/mixin/FCMCtrlSwitcher.lua
@@ -1,6 +1,5 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMCtrlSwitcher
 
@@ -8,7 +7,7 @@ Summary of modifications:
 - Setters that accept `FCString` now also accept Lua `string` and `number`.
 - Additional methods for accessing and adding pages and page titles.
 - Added `PageChange` custom control event.
-]]
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local library = require("library.general_library")
@@ -19,7 +18,6 @@ local props = {}
 local trigger_page_change
 local each_last_page_change
 local temp_str = finale.FCString()
-
 
 --[[
 % Init
@@ -93,7 +91,7 @@ function props:AttachControlByTitle(control, title)
         end
     end
 
-    mixin.force_assert(index ~= -1, "No page titled '" .. title .."'")
+    mixin.force_assert(index ~= -1, "No page titled '" .. title .. "'")
 
     return self:AttachControl_(control, index)
 end
@@ -135,7 +133,7 @@ function props:SetSelectedPageByTitle(title)
         end
     end
 
-    error("No page titled '" .. title  .. "'", 2)
+    error("No page titled '" .. title .. "'", 2)
 end
 
 --[[
@@ -192,7 +190,6 @@ function props:GetPageTitle(index, str)
     return text
 end
 
-
 --[[
 % HandlePageChange
 
@@ -226,10 +223,15 @@ Removes a handler added with `AddHandlePageChange`.
 @ self (FCMCtrlSwitcher)
 @ callback (function)
 ]]
-props.AddHandlePageChange, props.RemoveHandlePageChange, trigger_page_change, each_last_page_change = mixin_helper.create_custom_control_change_event(
-    {name = 'last_page', get = "GetSelectedPage_", initial = -1},
-    {name = 'last_page_title', get = function(ctrl) return mixin.FCMCtrlSwitcher.GetSelectedPageTitle(ctrl) end, initial = ""} -- Wrap get in function to prevent infinite recursion
-)
-
+props.AddHandlePageChange, props.RemoveHandlePageChange, trigger_page_change, each_last_page_change =
+    mixin_helper.create_custom_control_change_event(
+        {name = "last_page", get = "GetSelectedPage_", initial = -1}, {
+            name = "last_page_title",
+            get = function(ctrl)
+                return mixin.FCMCtrlSwitcher.GetSelectedPageTitle(ctrl)
+            end,
+            initial = "",
+        } -- Wrap get in function to prevent infinite recursion
+    )
 
 return props

--- a/src/mixin/FCMCtrlTree.lua
+++ b/src/mixin/FCMCtrlTree.lua
@@ -1,19 +1,16 @@
 --  Author: Edward Koltun
 --  Date: April 6, 2022
-
 --[[
 $module FCMCtrlTree
 
 Summary of modifications:
 - Methods that accept `FCString` now also accept Lua `string` and `number`.
-]]
-
+]] --
 local mixin = require("library.mixin")
 
 local props = {}
 
 local temp_str = finale.FCString()
-
 
 --[[
 % AddNode
@@ -39,6 +36,5 @@ function props:AddNode(parentnode, iscontainer, text)
 
     return self:AddNode_(parentnode, iscontainer, text)
 end
-
 
 return props

--- a/src/mixin/FCMCtrlUpDown.lua
+++ b/src/mixin/FCMCtrlUpDown.lua
@@ -1,20 +1,17 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMCtrlUpDown
 
 Summary of modifications:
 - `GetConnectedEdit` returns the original control object.
 - Handlers for the `UpDownPressed` event can now be set on a control.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
 local private = setmetatable({}, {__mode = "k"})
 local props = {}
-
 
 --[[
 % Init
@@ -109,7 +106,6 @@ Removes a handler added with `AddHandlePress`.
 @ self (FCMCtrlUpDown)
 @ callback (function)
 ]]
-props.AddHandlePress, props.RemoveHandlePress = mixin_helper.create_standard_control_event('HandleUpDownPressed')
-
+props.AddHandlePress, props.RemoveHandlePress = mixin_helper.create_standard_control_event("HandleUpDownPressed")
 
 return props

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -1,6 +1,5 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMCustomWindow
 
@@ -8,13 +7,11 @@ Summary of modifications:
 - `Create*` methods have an additional optional parameter for specifying a control name. Named controls can be retrieved via `GetControl`.
 - Cache original control objects to preserve mixin data and override control getters to return the original objects.
 - Added `Each` method for iterating over controls by class name.
-]]
-
+]] --
 local mixin = require("library.mixin")
 
 local private = setmetatable({}, {__mode = "k"})
 local props = {}
-
 
 --[[
 % Init
@@ -26,7 +23,6 @@ local props = {}
 function props:Init()
     private[self] = private[self] or {Controls = {}, NamedControls = {}}
 end
-
 
 --[[
 % CreateCancelButton
@@ -73,7 +69,6 @@ for _, f in ipairs({"CancelButton", "OkButton"}) do
         return control
     end
 end
-
 
 --[[
 % CreateButton
@@ -218,7 +213,10 @@ Add optional `control_name` parameter.
 : (FCMCtrlUpDown)
 ]]
 
-for _, f in ipairs({"Button", "Checkbox", "DataList", "Edit", "ListBox", "Popup", "Slider", "Static", "Switcher", "Tree", "UpDown"}) do
+for _, f in ipairs(
+                {
+        "Button", "Checkbox", "DataList", "Edit", "ListBox", "Popup", "Slider", "Static", "Switcher", "Tree", "UpDown",
+    }) do
     props["Create" .. f] = function(self, x, y, control_name)
         mixin.assert_argument(x, "number", 2)
         mixin.assert_argument(y, "number", 3)
@@ -346,7 +344,7 @@ function props:Each(class_filter)
         return v
     end
 
-    return iterator 
+    return iterator
 end
 
 --[[
@@ -376,7 +374,6 @@ Add optional `control_name` parameter.
 @ [control_name] (FCString|string) Optional name to allow access from `GetControl` method.
 : (FCMCtrlButton)
 ]]
-
 if finenv.MajorVersion > 0 or finenv.MinorVersion >= 56 then
     function props.CreateCloseButton(self, x, y, control_name)
         mixin.assert_argument(x, "number", 2)
@@ -401,5 +398,34 @@ if finenv.MajorVersion > 0 or finenv.MinorVersion >= 56 then
     end
 end
 
+--[[
+% GetParent
+
+**[PDK Port]**
+Returns the parent window. The parent will only be available while the window is showing.
+
+@ self (FCMCustomWindow)
+: (FCMCustomWindow|nil) `nil` if no parent
+]]
+function props:GetParent()
+    return private[self].Parent
+end
+
+--[[
+% ExecuteModal
+
+**[Override]**
+Stores the parent window to make it available via `GetParent`.
+
+@ self (FCMCustomWindow)
+@ parent (FCCustomWindow|FCMCustomWindow|nil)
+: (number)
+]]
+function props:ExecuteModal(parent)
+    private[self].Parent = parent
+    local ret = self:ExecuteModal_(parent)
+    private[self].Parent = nil
+    return ret
+end
 
 return props

--- a/src/mixin/FCMStrings.lua
+++ b/src/mixin/FCMStrings.lua
@@ -1,21 +1,18 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module FCMStrings
 
 Summary of modifications:
 - Methods that accept `FCString` now also accept Lua `string` and `number` (except for folder loading methods which do not accept `number`).
 - Setters that accept `FCStrings` now also accept multiple arguments of `FCString`, Lua `string`, or `number`.
-]]
-
+]] --
 local mixin = require("library.mixin")
 local library = require("library.general_library")
 
 local props = {}
 
 local temp_str = finale.FCString()
-
 
 --[[
 % AddCopy
@@ -162,7 +159,7 @@ Accepts Lua `string` in addition to `FCString`.
 function props:LoadFolderFiles(folderstring)
     mixin.assert_argument(folderstring, {"string", "FCString"}, 2)
 
-    if type(str) ~= "userdata" then
+    if type(folderstring) ~= "userdata" then
         temp_str.LuaString = tostring(folderstring)
         folderstring = temp_str
     end
@@ -183,7 +180,7 @@ Accepts Lua `string` in addition to `FCString`.
 function props:LoadSubfolders(folderstring)
     mixin.assert_argument(folderstring, {"string", "FCString"}, 2)
 
-    if type(str) ~= "userdata" then
+    if type(folderstring) ~= "userdata" then
         temp_str.LuaString = tostring(folderstring)
         folderstring = temp_str
     end
@@ -214,6 +211,5 @@ if finenv.MajorVersion > 0 or finenv.MinorVersion >= 59 then
         self:InsertStringAt_(str, index)
     end
 end
-
 
 return props

--- a/src/mixin/FCMTreeNode.lua
+++ b/src/mixin/FCMTreeNode.lua
@@ -1,19 +1,17 @@
 --  Author: Edward Koltun
 --  Date: April 6, 2022
-
 --[[
 $module FCMTreeNode
 
 Summary of modifications:
 - Setters that accept `FCString` now also accept Lua `string` and `number`.
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
-]]
+]] --
 local mixin = require("library.mixin")
 
 local props = {}
 
 local temp_str = finale.FCString()
-
 
 --[[
 % GetText
@@ -56,6 +54,5 @@ function props:SetText(str)
 
     self:SetText_(str)
 end
-
 
 return props

--- a/src/mixin/FCMUI.lua
+++ b/src/mixin/FCMUI.lua
@@ -1,0 +1,37 @@
+--  Author: Edward Koltun
+--  Date: April 13, 2021
+--[[
+$module FCMUI
+
+Summary of modifications:
+- In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
+]] --
+local mixin = require("library.mixin")
+
+local props = {}
+
+local temp_str = finale.FCString()
+
+--[[
+% GetDecimalSeparator
+
+**[Override]**
+Returns a Lua `string` and makes passing an `FCString` optional.
+
+@ self (FCMUI)
+@ [str] (FCString)
+: (string)
+]]
+function props:GetDecimalSeparator(str)
+    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+
+    if not str then
+        str = temp_str
+    end
+
+    self:GetDecimalSeparator_(str)
+
+    return str.LuaString
+end
+
+return props

--- a/src/mixin/FCXCtrlMeasurementEdit.lua
+++ b/src/mixin/FCXCtrlMeasurementEdit.lua
@@ -1,0 +1,419 @@
+--  Author: Edward Koltun
+--  Date: April 11, 2022
+--[[
+$module FCXCtrlMeasurementEdit
+
+*Extends `FCMCtrlEdit`*
+
+Summary of modifications:
+- Parent window must be an instance of `FCXCustomLuaWindow`
+- Displayed measurement unit will be automatically updated with the parent window
+- Measurement edits can be set to one of three types which correspond to the `GetMeasurement*`, `SetMeasurement*` and *GetRangeMeasurement*` methods. The type affects which methods are used for changing measurement units, for events, and for interacting with an `FCXCtrlUpDown` control.
+- All measurement get and set methods no longer accept a measurement unit as this is taken from the parent window.
+- `Change` event has been overridden to pass a measurement.
+]] --
+local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
+local utils = require("library.utils")
+
+local private = setmetatable({}, {__mode = "k"})
+local props = {MixinParent = "FCMCtrlEdit"}
+
+local trigger_change
+local each_last_change
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCXCtrlMeasurementEdit)
+]]
+function props:Init()
+    local parent = self:GetParent()
+    mixin.assert(
+        mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"),
+        "FCXCtrlMeasurementEdit must have a parent window that is an instance of FCXCustomLuaWindow")
+
+    private[self] = private[self] or
+                        {Type = "MeasurementInteger", LastMeasurementUnit = self:GetParent():GetMeasurementUnit()}
+end
+
+--[[
+% SetText
+
+**[Fluid] [Override]**
+Ensures that the overridden `Change` event is triggered.
+
+@ self (FCXCtrlMeasurementEdit)
+@ str (FCString|string|number)
+]]
+function props:SetText(str)
+    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+
+    mixin.FCMControl.SetText(self, str)
+    trigger_change(self)
+end
+
+--[[
+% SetInteger
+
+**[Fluid] [Override]**
+Ensures that the overridden `Change` event is triggered.
+
+@ self (FCXCtrlMeasurementEdit)
+@ anint (number)
+]]
+function props:SetInteger(anint)
+    mixin.assert_argument(anint, "number", 2)
+
+    self:SetInteger_(anint)
+    trigger_change(self)
+end
+
+--[[
+% SetFloat
+
+**[Fluid] [Override]**
+Ensures that the overridden `Change` event is triggered.
+
+@ self (FCXCtrlMeasurementEdit)
+@ value (number)
+]]
+function props:SetFloat(value)
+    mixin.assert_argument(value, "number", 2)
+
+    self:SetFloat_(value)
+    trigger_change(self)
+end
+
+--[[
+% GetMeasurement
+
+**[Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+@ self (FCXCtrlMeasurementEdit)
+: (number)
+]]
+function props:GetMeasurement()
+    return self:GetMeasurement_(private[self].LastMeasurementUnit)
+end
+
+--[[
+% SetMeasurement
+
+**[Fluid] [Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+Also ensures that the overridden `Change` event is triggered.
+
+@ self (FCXCtrlMeasurementEdit)
+@ value (number)
+]]
+function props:SetMeasurement(value)
+    mixin.assert_argument(value, "number", 2)
+
+    self:SetMeasurement_(value, private[self].LastMeasurementUnit)
+    trigger_change(self)
+end
+
+--[[
+% GetMeasurementInteger
+
+**[Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+@ self (FCXCtrlMeasurementEdit)
+: (number)
+]]
+function props:GetMeasurementInteger()
+    return self:GetMeasurementInteger_(private[self].LastMeasurementUnit)
+end
+
+--[[
+% SetMeasurementInteger
+
+**[Fluid] [Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+Also ensures that the overridden `Change` event is triggered.
+
+@ self (FCXCtrlMeasurementEdit)
+@ value (number)
+]]
+function props:SetMeasurementInteger(value)
+    mixin.assert_argument(value, "number", 2)
+
+    self:SetMeasurementInteger_(value, private[self].LastMeasurementUnit)
+    trigger_change(self)
+end
+
+--[[
+% GetMeasurementEfix
+
+**[Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+@ self (FCXCtrlMeasurementEdit)
+: (number)
+]]
+function props:GetMeasurementEfix()
+    return self:GetMeasurementEfix_(private[self].LastMeasurementUnit)
+end
+
+--[[
+% SetMeasurementEfix
+
+**[Fluid] [Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+Also ensures that the overridden `Change` event is triggered.
+
+@ self (FCXCtrlMeasurementEdit)
+@ value (number)
+]]
+function props:SetMeasurementEfix(value)
+    mixin.assert_argument(value, "number", 2)
+
+    self:SetMeasurementEfix_(value, private[self].LastMeasurementUnit)
+    trigger_change(self)
+end
+
+--[[
+% GetRangeMeasurement
+
+**[Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+@ self (FCXCtrlMeasurementEdit)
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurement(minimum, maximum)
+    mixin.assert_argument(minimum, "number", 2)
+    mixin.assert_argument(maximum, "number", 3)
+
+    return self:GetRangeMeasurement_(minimum, maximum, private[self].LastMeasurementUnit)
+end
+
+--[[
+% GetRangeMeasurementInteger
+
+**[Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+@ self (FCXCtrlMeasurementEdit)
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurementInteger(minimum, maximum)
+    mixin.assert_argument(minimum, "number", 2)
+    mixin.assert_argument(maximum, "number", 3)
+
+    return self:GetRangeMeasurementInteger_(minimum, maximum, private[self].LastMeasurementUnit)
+end
+
+--[[
+% GetRangeMeasurementEfix
+
+**[Override]**
+Removes the measurement unit parameter, taking it instead from the parent window.
+
+@ self (FCXCtrlMeasurementEdit)
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurementEfix(minimum, maximum)
+    mixin.assert_argument(minimum, "number", 2)
+    mixin.assert_argument(maximum, "number", 3)
+
+    return self:GetRangeMeasurementEfix_(minimum, maximum, private[self].LastMeasurementUnit)
+end
+
+--[[
+% SetTypeMeasurement
+
+**[Fluid]**
+Sets the type to `"Measurement"`.
+This means that the setters & getters used in events, measurement unit changes, and up down controls are `GetMeasurement`, `GetRangeMeasurement`, and `SetMeasurement`.
+
+@ self (FCXCtrlMeasurementEdit)
+]]
+function props:SetTypeMeasurement()
+    if private[self].Type == "Measurement" then
+        return
+    end
+
+    if private[self].Type == "MeasurementEfix" then
+        for v in each_last_change(self) do
+            v.last_value = v.last_value / 64
+        end
+    end
+
+    private[self].Type = "Measurement"
+end
+
+--[[
+% SetTypeMeasurementInteger
+
+**[Fluid]**
+Sets the type to `"MeasurementInteger"`. This is the default type.
+This means that the setters & getters used in events, measurement unit changes, and up down controls are `GetMeasurementInteger`, `GetRangeMeasurementInteger`, and `SetMeasurementInteger`.
+
+@ self (FCXCtrlMeasurementEdit)
+]]
+function props:SetTypeMeasurementInteger()
+    if private[self].Type == "MeasurementInteger" then
+        return
+    end
+
+    if private[self].Type == "Measurement" then
+        for v in each_last_change(self) do
+            v.last_value = utils.round(v.last_value)
+        end
+    elseif private[self].Type == "MeasurementEfix" then
+        for v in each_last_change(self) do
+            v.last_value = utils.round(v.last_value / 64)
+        end
+    end
+
+    private[self].Type = "MeasurementInteger"
+end
+
+--[[
+% SetTypeMeasurementEfix
+
+**[Fluid]**
+Sets the type to `"MeasurementEfix"`.
+This means that the setters & getters used in events, measurement unit changes, and up down controls are `GetMeasurementEfix`, `GetRangeMeasurementEfix`, and `SetMeasurementEfix`.
+
+@ self (FCXCtrlMeasurementEdit)
+]]
+function props:SetTypeMeasurementEfix()
+    if private[self].Type == "MeasurementEfix" then
+        return
+    end
+
+    for v in each_last_change(self) do
+        v.last_value = v.last_value * 64
+    end
+
+    private[self].Type = "MeasurementEfix"
+end
+
+--[[
+Returns the measurement edit's type. Can also be appended to `"Get"`, `"GetRange"`, or `"Set"` to use type-specific methods.
+
+@ self (FCXCtrlMeasurementEdit)
+: (string) `"Measurement"`, `"MeasurementInteger"`, or `"MeasurementEfix"`
+]]
+function props:GetType()
+    return private[self].Type
+end
+
+--[[
+% IsTypeMeasurement
+
+Checks if the type is `"Measurement"`.
+
+@ self (FCXCtrlMeasurementEdit)
+: (boolean) 
+]]
+function props:IsTypeMeasurement()
+    return private[self].Type == "Measurement"
+end
+
+--[[
+% IsTypeMeasurementInteger
+
+Checks if the type is `"MeasurementInteger"`.
+
+@ self (FCXCtrlMeasurementEdit)
+: (boolean) 
+]]
+function props:IsTypeMeasurementInteger()
+    return private[self].Type == "MeasurementInteger"
+end
+
+--[[
+% IsTypeMeasurementEfix
+
+Checks if the type is `"MeasurementEfix"`.
+
+@ self (FCXCtrlMeasurementEdit)
+: (boolean) 
+]]
+function props:IsTypeMeasurementEfix()
+    return private[self].Type == "MeasurementEfix"
+end
+
+--[[
+% UpdateMeasurementUnit
+
+**[Fluid] [Internal]**
+Checks the parent window for a change in measurement unit and updates the control if needed.
+
+@ self (FCXCtrlMeasurementEdit)
+]]
+function props:UpdateMeasurementUnit()
+    local new_unit = self:GetParent():GetMeasurementUnit()
+
+    if private[self].LastMeasurementUnit ~= new_unit then
+        local val = self["Get" .. private[self].Type](self)
+        private[self].LastMeasurementUnit = new_unit
+        self["Set" .. private[self].Type](self, val)
+    end
+end
+
+--[[
+% HandleChange
+
+**[Callback Template] [Override]**
+The type and unit of `last_value` will change depending on the measurement edit's type. The possibilities are:
+- `"Measurement"` => EVPUs (with fractional part)
+- `"MeasurementInteger"` => whole EVPUs (without fractional part)
+- `"MeasurementEfix"` => EFIXes (1 EFIX is 1/64th of an EVPU)
+
+@ control (FCXCtrlMeasurementEdit) The control that was changed.
+@ last_value (number) The previous measurement value of the control.
+]]
+
+--[[
+% AddHandleChange
+
+**[Fluid] [Override]**
+Adds a handler for when the value of the control changes.
+The even will fire when:
+- The window is created (if the value of the control is not an empty string)
+- The value of the control is changed by the user
+- The value of the control is changed programmatically (if the value of the control is changed within a handler, that *same* handler will not be called again for that change.)
+- A measurement unit change will only trigger the event if the underlying measurement value has changed.
+
+@ self (FCXCtrlMeasurementEdit)
+@ callback (function) See `HandleChange` for callback signature.
+]]
+
+--[[
+% RemoveHandleChange
+
+**[Fluid] [Override]**
+Removes a handler added with `AddHandleChange`.
+
+@ self (FCXCtrlMeasurementEdit)
+@ callback (function)
+]]
+props.AddHandleChange, props.RemoveHandleChange, trigger_change, each_last_change =
+    mixin_helper.create_custom_control_change_event(
+        {
+            name = "last_value",
+            get = function(ctrl)
+                return mixin.FCXCtrlMeasurementEdit["Get" .. private[ctrl].Type](ctrl)
+            end,
+            initial = 0,
+        })
+
+return props

--- a/src/mixin/FCXCtrlMeasurementUnitPopup.lua
+++ b/src/mixin/FCXCtrlMeasurementUnitPopup.lua
@@ -1,0 +1,87 @@
+--  Author: Edward Koltun
+--  Date: April 5, 2022
+--[[
+$module FCXCtrlMeasurementUnitPopup
+
+*Extends `FCMCtrlPopup`.*
+
+This mixin defines a popup that can be used to change the window's measurement unit (eg like the one at the bottom of the settings dialog). It is largely internal, and other than setting the position and size, it runs automatically.
+Programmatic changes of measurement unit should be handled at the parent window, not the control.
+
+The following inherited methods have been disabled:
+- `Clear`
+- `AddString`
+- `AddStrings`
+- `SetStrings`
+- `GetSelectedItem`
+- `SetSelectedItem`
+- `InsertString`
+- `DeleteItem`
+- `AddHandleSelectionChange`
+- `RemoveHandleSelectionChange`
+
+Event listeners for changes of measurement should be added to the parent window.
+]] --
+local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
+local measurement = require("library.measurement")
+
+local props = {MixinParent = "FCMCtrlPopup"}
+local unit_order = {
+    finale.MEASUREMENTUNIT_EVPUS, finale.MEASUREMENTUNIT_INCHES, finale.MEASUREMENTUNIT_CENTIMETERS,
+    finale.MEASUREMENTUNIT_POINTS, finale.MEASUREMENTUNIT_PICAS, finale.MEASUREMENTUNIT_SPACES,
+}
+local reverse_unit_order = {}
+
+for k, v in ipairs(unit_order) do
+    reverse_unit_order[v] = k
+end
+
+-- Disabled methods
+mixin_helper.disable_methods(
+    props, "Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetItemText",
+    "InsertString", "DeleteItem", "SetItemText", "AddHandleSelectionChange", "RemoveHandleSelectionChange")
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCXCtrlMeasurementUnitPopup)
+]]
+function props:Init()
+    mixin.assert(
+        mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"),
+        "FCXCtrlMeasurementUnitPopup must have a parent window that is an instance of FCXCustomLuaWindow")
+
+    for _, v in ipairs(unit_order) do
+        mixin.FCMCtrlPopup.AddString(self, measurement.get_unit_name(v))
+    end
+
+    self:UpdateMeasurementUnit()
+
+    mixin.FCMCtrlPopup.AddHandleSelectionChange(
+        self, function(control)
+            control:GetParent():SetMeasurementUnit(unit_order[control:GetSelectedItem_() + 1])
+        end)
+end
+
+--[[
+% UpdateSelection
+
+**[Fluid]**
+Checks the parent window's measurement unit and updates the selection if necessary.
+
+@ self (FCXCtrlMeasurementUnitPopup)
+]]
+function props:UpdateMeasurementUnit()
+    local unit = self:GetParent():GetMeasurementUnit()
+
+    if unit == unit_order[self:GetSelectedItem_() + 1] then
+        return
+    end
+
+    mixin.FCMCtrlPopup.SetSelectedItem(self, reverse_unit_order[unit] - 1)
+end
+
+return props

--- a/src/mixin/FCXCtrlStatic.lua
+++ b/src/mixin/FCXCtrlStatic.lua
@@ -1,0 +1,205 @@
+--  Author: Edward Koltun
+--  Date: April 15, 2022
+--[[
+$module FCXCtrlStatic
+
+*Extends `FCMCtrlStatic`*
+
+Summary of changes:
+- Parent window must be `FCXCustomLuaWindow`
+- Added methods for setting and displaying measurements
+]] --
+local mixin = require("library.mixin")
+local measurement = require("library.measurement")
+local utils = require("library.utils")
+
+local private = setmetatable({}, {__mode = "k"})
+local props = {MixinParent = "FCMCtrlStatic"}
+
+local temp_str = finale.FCString()
+
+local function get_suffix(unit, suffix_type)
+    if suffix_type == 1 then
+        return measurement.get_unit_suffix(unit)
+    elseif suffix_type == 2 then
+        return measurement.get_unit_abbreviation(unit)
+    elseif suffix_type == 3 then
+        return " " .. string.lower(measurement.get_unit_name(unit))
+    end
+end
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCXCtrlStatic)
+]]
+function props:Init()
+    mixin.assert(
+        mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"),
+        "FCXCtrlStatic must have a parent window that is an instance of FCXCustomLuaWindow")
+
+    private[self] = private[self] or {ShowMeasurementSuffix = true, MeasurementSuffixType = 2}
+end
+
+--[[
+% SetText
+
+**[Fluid] [Override]**
+Switches the control's measurement status off.
+
+@ self (FCXCtrlStatic)
+@ str (FCString|string|number)
+]]
+function props:SetText(str)
+    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+
+    mixin.FCMControl.SetText(self, str)
+
+    private[self].Measurement = nil
+    private[self].MeasurementType = nil
+end
+
+--[[
+% SetMeasurement
+
+**[Fluid]**
+Sets a measurement in EVPUs which will be displayed in the parent window's current measurement unit. This will be automatically updated if the parent window's measurement unit changes.
+
+@ self (FCXCtrlStatic)
+@ value (number) Value in EVPUs
+]]
+function props:SetMeasurement(value)
+    mixin.assert_argument(value, "number", 2)
+
+    local unit = self:GetParent():GetMeasurementUnit()
+    temp_str:SetMeasurement(value, unit)
+    temp_str:AppendLuaString(
+        private[self].ShowMeasurementSuffix and get_suffix(unit, private[self].MeasurementSuffixType) or "")
+
+    self:SetText_(temp_str)
+
+    private[self].Measurement = value
+    private[self].MeasurementType = "Measurement"
+end
+
+--[[
+% SetMeasurementInteger
+
+**[Fluid]**
+Sets a measurement in whole EVPUs which will be displayed in the parent window's current measurement unit. This will be automatically updated if the parent window's measurement unit changes.
+
+@ self (FCXCtrlStatic)
+@ value (number) Value in whole EVPUs (fractional part will be rounded to nearest integer)
+]]
+function props:SetMeasurementInteger(value)
+    mixin.assert_argument(value, "number", 2)
+
+    value = utils.round(value)
+    local unit = self:GetParent():GetMeasurementUnit()
+    temp_str:SetMeasurement(value, unit)
+    temp_str:AppendLuaString(
+        private[self].ShowMeasurementSuffix and get_suffix(unit, private[self].MeasurementSuffixType) or "")
+
+    self:SetText_(temp_str)
+
+    private[self].Measurement = value
+    private[self].MeasurementType = "MeasurementInteger"
+end
+
+--[[
+% SetMeasurementEfix
+
+**[Fluid]**
+Sets a measurement in EFIXes which will be displayed in the parent window's current measurement unit. This will be automatically updated if the parent window's measurement unit changes.
+
+@ self (FCXCtrlStatic)
+@ value (number) Value in EFIXes
+]]
+function props:SetMeasurementEfix(value)
+    mixin.assert_argument(value, "number", 2)
+
+    local evpu = value / 64
+    local unit = self:GetParent():GetMeasurementUnit()
+    temp_str:SetMeasurement(evpu, unit)
+    temp_str:AppendLuaString(
+        private[self].ShowMeasurementSuffix and get_suffix(unit, private[self].MeasurementSuffixType) or "")
+
+    self:SetText_(temp_str)
+
+    private[self].Measurement = value
+    private[self].MeasurementType = "MeasurementEfix"
+end
+
+--[[
+% SetShowMeasurementSuffix
+
+**[Fluid]**
+Sets whether to show a suffix at the end of a measurement (eg `cm` in `2.54cm`). This is on by default.
+
+@ self (FCXCtrlStatic)
+@ on (boolean)
+]]
+function props:SetShowMeasurementSuffix(on)
+    mixin.assert_argument(on, "boolean", 2)
+
+    private[self].ShowMeasurementSuffix = on
+    self:UpdateMeasurementUnit()
+end
+
+--[[
+% SetMeasurementSuffixShort
+
+**[Fluid]**
+Sets the measurement suffix to the short style used by Finale's internals (eg `e`, `i`, `c`, etc)
+
+@ self (FCXCtrlStatic)
+]]
+function props:SetMeasurementSuffixShort()
+    private[self].MeasurementSuffixType = 1
+    self:UpdateMeasurementUnit()
+end
+
+--[[
+% SetMeasurementSuffixAbbreviated
+
+**[Fluid]**
+Sets the measurement suffix to commonly known abbrevations (eg `in`, `cm`, `pt`, etc).
+This is the default style.
+
+@ self (FCXCtrlStatic)
+]]
+function props:SetMeasurementSuffixAbbreviated()
+    private[self].MeasurementSuffixType = 2
+    self:UpdateMeasurementUnit()
+end
+
+--[[
+% SetMeasurementSuffixFull
+
+**[Fluid]**
+Sets the measurement suffix to the full unit name. (eg `inches`, `centimeters`, etc).
+
+@ self (FCXCtrlStatic)
+]]
+function props:SetMeasurementSuffixFull()
+    private[self].MeasurementSuffixType = 3
+    self:UpdateMeasurementUnit()
+end
+
+--[[
+% UpdateMeasurementUnit
+
+**[Fluid] [Internal]**
+Updates the displayed measurement unit in line with the parent window.
+
+@ self (FCXCtrlStatic)
+]]
+function props:UpdateMeasurementUnit()
+    if private[self].Measurement then
+        self["Set" .. private[self].MeasurementType](self, private[self].Measurement)
+    end
+end
+
+return props

--- a/src/mixin/FCXCtrlUpDown.lua
+++ b/src/mixin/FCXCtrlUpDown.lua
@@ -1,0 +1,457 @@
+--  Author: Edward Koltun
+--  Date: April 10, 2022
+--[[
+$module FCXCtrlUpDown
+
+*Extends `FCMCtrlUpDown`*
+An up down control that is created by `FCXCustomLuaWindow`.
+
+Summary of modifications:
+- The ability to set the step size on a per-measurement unit basis.
+- Step size for integers can also be changed.
+- Added a setting for forcing alignment to the next step when moving up or down.
+- Connected edit must be an instance of `FCXCtrlEdit`
+- Measurement edits can be connected in two additional ways which affect the underlying methods used in `GetValue` and `SetValue`
+- Measurement EFIX edits have a different set of default step sizes.
+]] --
+local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
+
+local private = setmetatable({}, {__mode = "k"})
+local props = {MixinParent = "FCMCtrlUpDown"}
+
+local temp_str = finale.FCString()
+
+-- Enumerates the edit type
+local function enum_edit_type(edit, edit_type)
+    if edit_type == "Integer" then
+        return 1
+    else
+        if edit:IsTypeMeasurement() then
+            return 2
+        elseif edit:IsTypeMeasurementInteger() then
+            return 3
+        elseif edit:IsTypeMeasurementEfix() then
+            return 4
+        end
+    end
+end
+
+local default_measurement_steps = {
+    [finale.MEASUREMENTUNIT_EVPUS] = {value = 1, is_evpus = true},
+    [finale.MEASUREMENTUNIT_INCHES] = {value = 0.03125, is_evpus = false},
+    [finale.MEASUREMENTUNIT_CENTIMETERS] = {value = 0.01, is_evpus = false},
+    [finale.MEASUREMENTUNIT_POINTS] = {value = 0.25, is_evpus = false},
+    [finale.MEASUREMENTUNIT_PICAS] = {value = 1, is_evpus = true},
+    [finale.MEASUREMENTUNIT_SPACES] = {value = 0.125, is_evpus = false},
+}
+
+local default_efix_steps = {
+    [finale.MEASUREMENTUNIT_EVPUS] = {value = 0.015625, is_evpus = true},
+    [finale.MEASUREMENTUNIT_INCHES] = {value = 0.03125, is_evpus = false},
+    [finale.MEASUREMENTUNIT_CENTIMETERS] = {value = 0.001, is_evpus = false},
+    [finale.MEASUREMENTUNIT_POINTS] = {value = 0.03125, is_evpus = false},
+    [finale.MEASUREMENTUNIT_PICAS] = {value = 0.015625, is_evpus = true},
+    [finale.MEASUREMENTUNIT_SPACES] = {value = 0.03125, is_evpus = false},
+}
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCXCtrlUpDown)
+]]
+function props:Init()
+    mixin.assert(
+        mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"),
+        "FCXCtrlUpDown must have a parent window that is an instance of FCXCustomLuaWindow")
+    private[self] = private[self] or {IntegerStepSize = 1, MeasurementSteps = {}, AlignWhenMoving = true}
+
+    self:AddHandlePress(
+        function(self, delta)
+            if not private[self].ConnectedEdit then
+                return
+            end
+
+            local edit = private[self].ConnectedEdit
+            local edit_type = enum_edit_type(edit, private[self].ConnectedEditType)
+            local unit = self:GetParent():GetMeasurementUnit()
+            local separator = mixin.UI():GetDecimalSeparator()
+            local step_def
+
+            if edit_type == 1 then
+                step_def = {value = private[self].IntegerStepSize}
+            else
+                step_def = private[self].MeasurementSteps[unit] or (edit_type == 4 and default_efix_steps[unit]) or
+                               default_measurement_steps[unit]
+            end
+
+            -- Get real value
+            local value
+            if edit_type == 1 then
+                value = edit:GetText():match("^%-*[0-9%.%,%" .. separator .. "-]+")
+                value = value and tonumber(value) or 0
+            else
+                if step_def.is_evpus then
+                    value = edit:GetMeasurement()
+                else
+                    -- Strings like '2.75i' allow the unit to be overridden, so doing this extra step guarantees that it's normalised to the current unit
+                    temp_str:SetMeasurement(edit:GetMeasurement(), unit)
+                    value = temp_str.LuaString:gsub("%" .. separator, ".")
+                    value = tonumber(value)
+                end
+            end
+
+            -- Align to closest step if needed
+            if private[self].AlignWhenMoving then
+                -- Casting back and forth works around floating point issues, such as 0.3/0.1 not being equal to 3 (even though 3 is displayed)
+                local num_steps = tonumber(tostring(value / step_def.value))
+
+                if num_steps ~= math.floor(num_steps) then
+                    if delta > 0 then
+                        value = math.ceil(num_steps) * step_def.value
+                        delta = delta - 1
+                    elseif delta < 0 then
+                        value = math.floor(num_steps) * step_def.value
+                        delta = delta + 1
+                    end
+                end
+            end
+
+            -- Calculate new value
+            local new_value = value + delta * step_def.value
+
+            -- Set new value
+            if edit_type == 1 then
+                self:SetValue(new_value)
+            else
+                if step_def.is_evpus then
+                    self:SetValue(edit_type == 4 and new_value * 64 or new_value)
+                else
+                    -- If we're not in EVPUs, we need the EVPU value to determine whether clamping is required
+                    temp_str.LuaString = tostring(new_value)
+                    local new_evpus = temp_str:GetMeasurement(unit)
+                    if new_evpus < private[self].Minimum or new_evpus > private[self].Maximum then
+                        self:SetValue(edit_type == 4 and new_evpus * 64 or new_evpus)
+                    else
+                        edit:SetText(temp_str.LuaString:gsub("%.", separator))
+                    end
+                end
+            end
+
+        end)
+end
+
+--[[
+% GetConnectedEdit
+
+**[Override]**
+Ensures that original edit control is returned.
+
+@ self (FCXCtrlUpDown)
+: (FCXCtrlEdit|nil) `nil` if there is no edit connected.
+]]
+function props:GetConnectedEdit()
+    return private[self].ConnectedEdit
+end
+
+--[[
+% ConnectIntegerEdit
+
+**[Fluid] [Override]**
+Connects an integer edit.
+The underlying methods used in `GetValue` and `SetValue` will be `GetRangeInteger` and `SetInteger` respectively.
+
+@ self (FCXCtrlUpDown)
+@ control (FCMCtrlEdit)
+@ minimum (number)
+@ maximum (maximum)
+]]
+function props:ConnectIntegerEdit(control, minimum, maximum)
+    mixin.assert_argument(control, "FCMCtrlEdit", 2)
+    mixin.assert_argument(minimum, "number", 3)
+    mixin.assert_argument(maximum, "number", 4)
+    mixin.assert(
+        not mixin.is_instance_of(control, "FCXCtrlMeasurementEdit"),
+        "A measurement edit cannot be connected as an integer edit.")
+
+    private[self].ConnectedEdit = control
+    private[self].ConnectedEditType = "Integer"
+    private[self].Minimum = minimum
+    private[self].Maximum = maximum
+end
+
+--[[
+% ConnectMeasurementEdit
+
+**[Fluid] [Override]**
+Connects a measurement edit. The control will be automatically registered as a measurement edit if it isn't already.
+The underlying methods used in `GetValue` and `SetValue` will depend on the measurement edit's type.
+
+@ self (FCXCtrlUpDown)
+@ control (FCXCtrlMeasurementEdit)
+@ minimum (number)
+@ maximum (maximum)
+]]
+function props:ConnectMeasurementEdit(control, minimum, maximum)
+    mixin.assert_argument(control, "FCXCtrlMeasurementEdit", 2)
+    mixin.assert_argument(minimum, "number", 3)
+    mixin.assert_argument(maximum, "number", 4)
+
+    private[self].ConnectedEdit = control
+    private[self].ConnectedEditType = "Measurement"
+    private[self].Minimum = minimum
+    private[self].Maximum = maximum
+end
+
+--[[
+% SetIntegerStepSize
+
+**[Fluid]**
+Sets the step size for integer edits.
+
+@ self (FCXCtrlUpDown)
+@ value (number)
+]]
+function props:SetIntegerStepSize(value)
+    mixin.assert_argument(value, "number", 2)
+
+    private[self].IntegerStepSize = value
+end
+
+--[[
+% SetEVPUsStepSize
+
+**[Fluid]**
+Sets the step size for measurement edits that are currently displaying in EVPUs.
+
+@ self (FCXCtrlUpDown)
+@ value (number)
+]]
+function props:SetEVPUsStepSize(value)
+    mixin.assert_argument(value, "number", 2)
+
+    private[self].MeasurementSteps[finale.MEASUREMENTUNIT_EVPUS] = {value = value, is_evpus = true}
+end
+
+--[[
+% SetInchesStepSize
+
+**[Fluid]**
+Sets the step size for measurement edits that are currently displaying in Inches.
+
+@ self (FCXCtrlUpDown)
+@ value (number)
+@ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Inches.
+]]
+function props:SetInchesStepSize(value, is_evpus)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+
+    private[self].MeasurementSteps[finale.MEASUREMENTUNIT_INCHES] = {
+        value = value,
+        is_evpus = is_evpus and true or false,
+    }
+end
+
+--[[
+% SetCentimetersStepSize
+
+**[Fluid]**
+Sets the step size for measurement edits that are currently displaying in Centimeters.
+
+@ self (FCXCtrlUpDown)
+@ value (number)
+@ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Centimeters.
+]]
+function props:SetCentimetersStepSize(value, is_evpus)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+
+    private[self].MeasurementSteps[finale.MEASUREMENTUNIT_CENTIMETERS] = {
+        value = value,
+        is_evpus = is_evpus and true or false,
+    }
+end
+
+--[[
+% SetPointsStepSize
+
+**[Fluid]**
+Sets the step size for measurement edits that are currently displaying in Points.
+
+@ self (FCXCtrlUpDown)
+@ value (number)
+@ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Points.
+]]
+function props:SetPointsStepSize(value, is_evpus)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+
+    private[self].MeasurementSteps[finale.MEASUREMENTUNIT_POINTS] = {
+        value = value,
+        is_evpus = is_evpus and true or false,
+    }
+end
+
+--[[
+% SetPicasStepSize
+
+**[Fluid]**
+Sets the step size for measurement edits that are currently displaying in Picas.
+
+@ self (FCXCtrlUpDown)
+@ value (number|string)
+@ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Picas.
+]]
+function props:SetPicasStepSize(value, is_evpus)
+    mixin.assert_argument(value, {"number", "string"}, 2)
+
+    if not is_evpus then
+        temp_str:SetText(tostring(value))
+        value = temp_str:GetMeasurement(finale.MEASUREMENTUNIT_PICAS)
+    end
+
+    private[self].MeasurementSteps[finale.MEASUREMENTUNIT_PICAS] = {value = value, is_evpus = true}
+end
+
+--[[
+% SetSpacesStepSize
+
+**[Fluid]**
+Sets the step size for measurement edits that are currently displaying in Spaces.
+
+@ self (FCXCtrlUpDown)
+@ value (number)
+@ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Spaces.
+]]
+function props:SetSpacesStepSize(value, is_evpus)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+
+    private[self].MeasurementSteps[finale.MEASUREMENTUNIT_SPACES] = {
+        value = value,
+        is_evpus = is_evpus and true or false,
+    }
+end
+
+--[[
+% AlignWSetAlignWhenMovinghenMoving
+
+**[Fluid]**
+Sets whether to align to the next multiple of a step when moving.
+
+@ self (FCXCtrlUpDown)
+@ on (boolean)
+]]
+function props:SetAlignWhenMoving(on)
+    mixin.assert_argument(on, "boolean", 2)
+
+    private[self].AlignWhenMoving = on
+end
+
+--[[
+% GetValue
+
+**[Override]**
+Returns the value of the connected edit, clamped according to the set minimum and maximum.
+
+Different types of connected edits will return different types and use different methods to access the value of the edit. The methods are:
+- Integer edit => `GetRangeInteger`
+- Measurement edit ("Measurement") => `GetRangeMeasurement`
+- Measurement edit ("MeasurementInteger") => `GetRangeMeasurementInteger`
+- Measurement edit ("MeasurementEfix") => `GetRangeMeasurementEfix`
+
+@ self (FCXCtrlUpDown)
+: (number) An integer for an integer edit, EVPUs for a measurement edit, whole EVPUs for a measurement integer edit, or EFIXes for a measurement EFIX edit.
+]]
+function props:GetValue()
+    if not private[self].ConnectedEdit then
+        return
+    end
+
+    local edit = private[self].ConnectedEdit
+
+    if private[self].ConnectedEditType == "Measurement" then
+        return edit["Get" .. edit:GetType()](edit, private[self].Minimum, private[self].Maximum)
+    else
+        return edit:GetRangeInteger(private[self].Minimum, private[self].Maximum)
+    end
+end
+
+--[[
+% SetValue
+
+**[Fluid] [Override]**
+Sets the value of the attached control, clamped according to the set minimum and maximum.
+
+Different types of connected edits will accept different types and use different methods to set the value of the edit. The methods are:
+- Integer edit => `SetRangeInteger`
+- Measurement edit ("Measurement") => `SetRangeMeasurement`
+- Measurement edit ("MeasurementInteger") => `SetRangeMeasurementInteger`
+- Measurement edit ("MeasurementEfix") => `SetRangeMeasurementEfix`
+
+@ self (FCXCtrlUpDown)
+@ value (number) An integer for an integer edit, EVPUs for a measurement edit, whole EVPUs for a measurement integer edit, or EFIXes for a measurement EFIX edit.
+]]
+function props:SetValue(value)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert(private[self].ConnectedEdit, "Unable to set value: no connected edit.")
+
+    -- Clamp the value
+    value = value < private[self].Minimum and private[self].Minimum or value
+    value = value > private[self].Maximum and private[self].Maximum or value
+
+    local edit = private[self].ConnectedEdit
+
+    if private[self].ConnectedEditType == "Measurement" then
+        edit["Set" .. edit:GetType()](edit, value)
+    else
+        edit:SetInteger(value)
+    end
+end
+
+--[[
+% GetMinimum
+
+**[Override]**
+
+@ self (FCMCtrlUpDown)
+: (number) An integer for integer edits or EVPUs for measurement edits.
+]]
+function props:GetMinimum()
+    return private[self].Minimum
+end
+
+--[[
+% GetMaximum
+
+**[Override]**
+
+@ self (FCMCtrlUpDown)
+: (number) An integer for integer edits or EVPUs for measurement edits.
+]]
+
+function props:GetMaximum()
+    return private[self].Maximum
+end
+
+--[[
+% SetRange
+
+**[Fluid] [Override]**
+
+@ self (FCMCtrlUpDown)
+@ minimum (number) An integer for integer edits or EVPUs for measurement edits.
+@ maximum (number) An integer for integer edits or EVPUs for measurement edits.
+]]
+function props:SetRange(minimum, maximum)
+    mixin.assert_argument(minimum, "number", 2)
+    mixin.assert_argument(maximum, "number", 3)
+
+    private[self].Minimum = minimum
+    private[self].Maximum = maximum
+end
+
+return props

--- a/src/mixin/FCXCustomLuaWindow.lua
+++ b/src/mixin/FCXCustomLuaWindow.lua
@@ -1,0 +1,259 @@
+--  Author: Edward Koltun
+--  Date: April 10, 2022
+--[[
+$module FCXCustomLuaWindow
+
+*Extends `FCMCustomLuaWindow`*
+
+Summary of modifications:
+- Measurement unit can be set on the window or changed by the user through a `FCXCtrlMeasurementUnitPopup`.
+- Windows also have the option of inheriting the parent window's measurement unit when opening.
+- Introduced a `MeasurementUnitChange` event.
+- All controls with an `UpdateMeasurementUnit` method will have that method called upon a measurement unit change to allow them to immediately update their displayed values without needing to wait for a `MeasurementUnitChange` event.
+]] --
+local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
+local measurement = require("library.measurement")
+
+local private = setmetatable({}, {__mode = "k"})
+local props = {MixinParent = "FCMCustomLuaWindow"}
+
+local trigger_measurement_unit_change
+local each_last_measurement_unit_change
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCXCustomLuaWindow)
+]]
+function props:Init()
+    private[self] = private[self] or
+                        {
+            MeasurementEdits = {},
+            MeasurementUnit = measurement.get_real_default_unit(),
+            UseParentMeasurementUnit = true,
+        }
+end
+
+--[[
+% GetMeasurementUnit
+
+Returns the window's current measurement unit.
+
+@ self (FCXCustomLuaWindow)
+: (number) The value of one of the finale MEASUREMENTUNIT constants.
+]]
+function props:GetMeasurementUnit()
+    return private[self].MeasurementUnit
+end
+
+--[[
+% SetMeasurementUnit
+
+**[Fluid]**
+Sets the window's current measurement unit. Millimeters are not supported.
+
+All controls that have an `UpdateMeasurementUnit` method will have that method called to allow them to immediately update their displayed measurement unit without needing to wait for a `MeasurementUnitChange` event.
+
+@ self (FCXCustomLuaWindow)
+@ unit (number) One of the finale MEASUREMENTUNIT constants.
+]]
+function props:SetMeasurementUnit(unit)
+    mixin.assert_argument(unit, "number", 2)
+
+    if unit == private[self].MeasurementUnit then
+        return
+    end
+
+    if unit == finale.MEASUREMENTUNIT_DEFAULT then
+        unit = measurement.get_real_default_unit()
+    end
+
+    mixin.force_assert(measurement.is_valid_unit(unit), "Measurement unit is not valid.")
+
+    private[self].MeasurementUnit = unit
+
+    -- Update all measurement controls
+    for ctrl in each(self) do
+        local func = ctrl.UpdateMeasurementUnit
+        if func then
+            func(ctrl)
+        end
+    end
+
+    trigger_measurement_unit_change(self)
+end
+
+--[[
+% GetMeasurementUnitName
+
+Returns the name of the window's current measurement unit.
+
+@ self (FCXCustomLuaWindow)
+: (string)
+]]
+function props:GetMeasurementUnitName()
+    return measurement.get_unit_name(private[self].MeasurementUnit)
+end
+
+--[[
+% UseParentMeasurementUnit
+
+**[Fluid]**
+Sets whether to use the parent window's measurement unit when opening this window. Defaults to `true`.
+
+@ self (FCXCustomLuaWindow)
+@ on (boolean)
+]]
+function props:UseParentMeasurementUnit(on)
+    mixin.assert_argument(on, "boolean", 2)
+
+    private[self].UseParentMeasurementUnit = on
+end
+
+--[[
+% CreateMeasurementEdit
+
+Creates a `FCXCtrlMeasurementEdit` control.
+
+@ self (FCXCustomLuaWindow)
+@ x (number)
+@ y (number)
+@ [control_name] (string)
+: (FCXCtrlMeasurementEdit)
+]]
+function props:CreateMeasurementEdit(x, y, control_name)
+    mixin.assert_argument(x, "number", 2)
+    mixin.assert_argument(y, "number", 3)
+    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+
+    local edit = mixin.FCMCustomWindow.CreateEdit(self, x, y, control_name)
+    return mixin.subclass(edit, "FCXCtrlMeasurementEdit")
+end
+
+--[[
+% CreateMeasurementUnitPopup
+
+Creates a popup which allows the user to change the window's measurement unit.
+
+@ self (FCXCustomLuaWindow)
+@ x (number)
+@ y (number)
+@ [control_name] (string)
+: (FCXCtrlMeasurementUnitPopup)
+]]
+function props:CreateMeasurementUnitPopup(x, y, control_name)
+    mixin.assert_argument(x, "number", 2)
+    mixin.assert_argument(y, "number", 3)
+    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+
+    local popup = mixin.FCMCustomWindow.CreatePopup(self, x, y, control_name)
+    return mixin.subclass(popup, "FCXCtrlMeasurementUnitPopup")
+end
+
+--[[
+% CreateStatic
+
+**[Override]**
+Creates an `FCXCtrlStatic` control.
+
+@ self (FCXCustomLuaWindow)
+@ x (number)
+@ y (number)
+@ [control_name] (string)
+: (FCXCtrlStatic)
+]]
+function props:CreateStatic(x, y, control_name)
+    mixin.assert_argument(x, "number", 2)
+    mixin.assert_argument(y, "number", 3)
+    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+
+    local popup = mixin.FCMCustomWindow.CreateStatic(self, x, y, control_name)
+    return mixin.subclass(popup, "FCXCtrlStatic")
+end
+
+--[[
+% CreateUpDown
+
+**[Override]**
+Creates an `FCXCtrlUpDown` control.
+
+@ self (FCXCustomLuaWindow)
+@ x (number)
+@ y (number)
+@ [control_name] (string)
+: (FCXCtrlUpDown)
+]]
+function props:CreateUpDown(x, y, control_name)
+    mixin.assert_argument(x, "number", 2)
+    mixin.assert_argument(y, "number", 3)
+    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+
+    local updown = mixin.FCMCustomWindow.CreateUpDown(self, x, y, control_name)
+    return mixin.subclass(updown, "FCXCtrlUpDown")
+end
+
+--[[
+% ExecuteModal
+
+**[Override]**
+If a parent window is passed and the `UseParentMeasurementUnit` setting is on, the measurement unit is automatically changed to match the parent.
+
+@ self (FCXCustomLuaWindow)
+@ parent (FCCustomWindow|FCMCustomWindow|nil)
+: (number)
+]]
+function props:ExecuteModal(parent)
+    if mixin.is_instance_of(parent, "FCXCustomLuaWindow") and private[self].UseParentMeasurementUnit then
+        self:SetMeasurementUnit(parent:GetMeasurementUnit())
+    end
+
+    return mixin.FCMCustomWindow.ExecuteModal(self, parent)
+end
+
+--[[
+% HandleMeasurementUnitChange
+
+**[Callback Template]**
+Template for MeasurementUnitChange handlers.
+
+@ window (FCXCustomLuaWindow) The window that triggered the event.
+@ last_unit (number) The window's previous measurement unit.
+]]
+
+--[[
+% AddHandleMeasurementUnitChange
+
+**[Fluid]**
+Adds a handler for a change in the window's measurement unit.
+The even will fire when:
+- The window is created (if the measurement unit is not `finale.MEASUREMENTUNIT_DEFAULT`)
+- The measurement unit is changed by the user via a `FCXCtrlMeasurementUnitPopup`
+- The measurement unit is changed programmatically (if the measurement unit is changed within a handler, that *same* handler will not be called again for that change.)
+
+@ self (FCXCustomLuaWindow)
+@ callback (function) See `HandleMeasurementUnitChange` for callback signature.
+]]
+
+--[[
+% RemoveHandleMeasurementUnitChange
+
+**[Fluid]**
+Removes a handler added with `AddHandleMeasurementUnitChange`.
+
+@ self (FCXCustomLuaWindow)
+@ callback (function)
+]]
+props.AddHandleMeasurementUnitChange, props.RemoveHandleMeasurementUnitChange, trigger_measurement_unit_change, each_last_measurement_unit_change =
+    mixin_helper.create_custom_window_change_event(
+        {
+            name = "last_unit",
+            get = function(win)
+                return mixin.FCXCustomLuaWindow.GetMeasurementUnit(win)
+            end,
+            initial = measurement.get_real_default_unit(),
+        })
+
+return props

--- a/src/mixin/__FCMUserWindow.lua
+++ b/src/mixin/__FCMUserWindow.lua
@@ -1,20 +1,17 @@
 --  Author: Edward Koltun
 --  Date: March 3, 2022
-
 --[[
 $module __FCMUserWindow
 
 Summary of modifications:
 - Setters that accept `FCString` now also accept Lua `string` and `number`.
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
-]]
-
+]] --
 local mixin = require("library.mixin")
 
 local props = {}
 
 local temp_str = finale.FCString()
-
 
 --[[
 % GetTitle
@@ -50,13 +47,12 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 function props:SetTitle(title)
     mixin.assert_argument(title, {"string", "number", "FCString"}, 2)
 
-    if type(str) ~= "userdata" then
+    if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)
         title = temp_str
     end
 
     self:SetTitle_(title)
 end
-
 
 return props


### PR DESCRIPTION
This PR mainly contains mixins that deal with measurements and being able to easily control the measurement unit that they are displayed in. It also contains some bug fixes and some other small additions. There are a lot of changes/additions so I'll just summarise the ones that are important or that might need discussing. I wrote all of these a few weeks ago so I hope I've remembered everything.

Library Changes:
- `library/mixin.lua`
  - In keeping with the changes in #150, personal mixins can now be added to a `personal_mixin` folder. Personal mixins are checked first, so they can override a public mixin.
  - Added `UI` function which is the mixin equivalent of `finenv.UI()`
- `library/measurement.lua`
  - Added methods that return an abbreviation for the measurement unit. I haven't come across an official abbreviation for EVPU or Pica, so let me know if you would like something different.
- `mixin_helper`
  - Mainly just a large refactor to enable code reuse between custom control and window change events.

FCM Mixin Changes:
- `FCMCtrlEdit`
  - Added some missing change event triggers
- `FCMCtrlPopup`, `FCMUI`
  - Additional convenience methods.
- `FCMCustomWindow`
  - Parent window is now stored and is accessible via `GetParent` while window is showing as modal.
- `FCMCustomLuaWindow`
  - `Command` events occasionally fire twice (eg at Init, or when a child modal is opened) for the same control, the second while the first is still running. So I added a check to avoid concurrency issues and race conditions.

FCX Mixins:
- `FCXCustomLuaWindow`
  - Includes the ability to set the measurement unit at the window level. This is then adhered to by the control mixins below.
  - Any control that has a method called `UpdateMeasurementUnit` will be instantly updated when the measurement unit is changed.
- `FCXCtrlMeasurementUnitPopup`
  - This is a popup that allows the user to set the measurement unit for the window in the same manner as Finale's in-built dialogs (eg Document Options, Page Format, etc) 
- `FCXCtrlMeasurementEdit`
  - Displays measurements in the parent window's measurement unit and updates automatically when it changes.
- `FCXCtrlStatic`
  - Added methods for setting a measurement value
  - Measurement values ares displayed in the parent window's measurement unit with the option to set a display suffix.
- `FCXCtrlUpDown`
  - `ConnectMeasurementEdit` will only accept a `FCXCtrlMeasurementEdit`
  - Added methods to set a custom step size for different measurement units. I included a set of default step sizes which are more closely in harmony with the measurement unit they relate to, rather than a blanket step size of 1 EVPU. Let me know what you think or if any of the defaults need to be changed. Play around with the test script below to see it in action. There are different defaults depending on whether the MeasurementEdit's type is EVPU or EFIX.


Here is a script for testing out measurement edits, the new up/down mixin and the measurement unit popup:
```lua
local mixin = require("library.mixin")
local dialog = mixin.FCXCustomLuaWindow()

local edit = dialog:CreateMeasurementEdit(10, 10)

-- To test default EFIX step sizes, uncomment the line below
--edit:SetTypeMeasurementEfix()

dialog:CreateUpDown(80, 10):ConnectMeasurementEdit(edit, 0, 100)

dialog:CreateMeasurementUnitPopup(10, 40)

dialog:ExecuteModal(nil)
```