### PR TITLE
Page Size Library & Mixins

### DIFF
--- a/src/library/measurement.lua
+++ b/src/library/measurement.lua
@@ -26,7 +26,7 @@ local unit_abbreviations = {
     [finale.MEASUREMENTUNIT_INCHES] = "in",
     [finale.MEASUREMENTUNIT_CENTIMETERS] = "cm",
     [finale.MEASUREMENTUNIT_POINTS] = "pt",
-    [finale.MEASUREMENTUNIT_PICAS] = "",
+    [finale.MEASUREMENTUNIT_PICAS] = "pc",
     [finale.MEASUREMENTUNIT_SPACES] = "sp",
 }
 

--- a/src/library/page_size.lua
+++ b/src/library/page_size.lua
@@ -1,0 +1,149 @@
+--  Author: Edward Koltun
+--  Date: April 13, 2021
+--[[
+$module Page Size
+
+A library for determining page sizes.
+]] --
+local page_size = {}
+local utils = require("library.utils")
+
+-- Dimensions must be in EVPUs and in portrait (ie width is always the shorter side)
+local sizes = {}
+
+-- Finale's standard sizes
+sizes.A3 = {width = 3366, height = 4761}
+sizes.A4 = {width = 2381, height = 3368}
+sizes.A5 = {width = 1678, height = 2380}
+sizes.B4 = {width = 2920, height = 4127}
+sizes.B5 = {width = 1994, height = 2834}
+sizes.Concert = {width = 2592, height = 3456}
+sizes.Executive = {width = 2160, height = 2880}
+sizes.Folio = {width = 2448, height = 3744}
+sizes.Hymn = {width = 1656, height = 2376}
+sizes.Legal = {width = 2448, height = 4032}
+sizes.Letter = {width = 2448, height = 3168}
+sizes.Octavo = {width = 1944, height = 3024}
+sizes.Quarto = {width = 2448, height = 3110}
+sizes.Statement = {width = 1584, height = 2448}
+sizes.Tabloid = {width = 3168, height = 4896}
+
+-- Other sizes
+
+--[[
+% get_dimensions
+
+Returns the dimensions of the requested page size. Dimensions are in portrait.
+
+@ size (string) The page size.
+: (table) Has keys `width` and `height` which contain the dimensions in EVPUs.
+]]
+function page_size.get_dimensions(size)
+    return utils.copy_table(sizes[size])
+end
+
+--[[
+% is_size
+
+Checks if the given size is defined.
+
+@ size (string)
+: (boolean) `true` if defined, `false` if not
+]]
+function page_size.is_size(size)
+    return sizes[size] and true or false
+end
+
+--[[
+% get_size
+
+Determines the page size based on the given dimensions.
+
+@ width (number) Page width in EVPUs.
+@ height (number) Page height in EVPUs.
+: (string|nil) Page size, or `nil` if no match.
+]]
+function page_size.get_size(width, height)
+    -- If landscape, swap to portrait
+    if height < width then
+        local temp = height
+        height = width
+        width = temp
+    end
+
+    for size, dimensions in pairs(sizes) do
+        if dimensions.width == width and dimensions.height == height then
+            return size
+        end
+    end
+
+    return nil
+end
+
+--[[
+% get_page_size
+
+Determines the page size of an `FCPage`.
+
+@ page (FCPage)
+: (string|nil) Page size, or `nil` if no match.
+]]
+function page_size.get_page_size(page)
+    return page_size.get_size(page.Width, page.Height)
+end
+
+--[[
+% set_page_size
+
+Sets the dimensions of an `FCPage` to the given size. The existing page orientation will be preserved.
+
+@ page (FCPage)
+@ size (string)
+]]
+function page_size.set_page_size(page, size)
+    if not sizes[size] then
+        return
+    end
+
+    if page:IsPortrait() then
+        page:SetWidth(sizes[size].width)
+        page:SetHeight(sizes[size].height)
+    else
+        page:SetWidth(sizes[size].height)
+        page:SetHeight(sizes[size].width)
+    end
+end
+
+--[[
+% pairs
+
+Return an alphabetical order iterator that yields the following pairs:
+`(string) size`
+`(table) dimensions` => has keys `width` and `height` which contain the dimensions in EVPUs
+
+: (function)
+]]
+local sizes_index
+function page_size.pairs()
+    if not sizes_index then
+        for size in pairs(sizes) do
+            table.insert(sizes_index, size)
+        end
+
+        table.sort(sizes_index)
+    end
+
+    local i = 0
+    local iterator = function()
+        i = i + 1
+        if sizes_index[i] == nil then
+            return nil
+        else
+            return sizes_index[i], sizes[sizes_index[i]]
+        end
+    end
+
+    return iterator
+end
+
+return page_size

--- a/src/mixin/FCMPage.lua
+++ b/src/mixin/FCMPage.lua
@@ -1,0 +1,55 @@
+--  Author: Edward Koltun
+--  Date: April 13, 2021
+--[[
+$module FCMPage
+
+Summary of modifications:
+- Added methods for getting and setting the page size by its name according to the `page_size` library.
+- Added method for checking if the page is blank.
+]] --
+local mixin = require("library.mixin")
+local page_size = require("library.page_size")
+
+local props = {}
+
+--[[
+% GetSize
+
+Returns the size of the page.
+
+@ self (FCMPage)
+: (string|nil) The page size or `nil` if there is no defined size that matches the dimensions of this page.
+]]
+function props:GetSize()
+    return page_size.get_page_size(self)
+end
+
+--[[
+% SetSize
+
+**[Fluid]**
+Sets the dimensions of this page to match the given size. Page orientation will be preserved.
+
+@ self (FCMPage)
+@ size (string) A defined page size.
+]]
+function props:SetSize(size)
+    mixin.assert_argument(size, "string", 2)
+    mixin.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
+
+    page_size.set_page_size(self, size)
+end
+
+--[[
+% IsBlank
+
+Checks if this is a blank page (ie it contains no systems).
+
+@ self (FCMPage)
+: (boolean) `true` if this is page is blank
+]]
+function props:IsBlank()
+    return self:GetFirstSystem() == -1
+end
+
+return props

--- a/src/mixin/FCXCtrlMeasurementUnitPopup.lua
+++ b/src/mixin/FCXCtrlMeasurementUnitPopup.lua
@@ -15,8 +15,12 @@ The following inherited methods have been disabled:
 - `SetStrings`
 - `GetSelectedItem`
 - `SetSelectedItem`
+- `SetSelectedLast`
+- `ItemExists`
 - `InsertString`
 - `DeleteItem`
+- `GetItemText`
+- `SetItemText`
 - `AddHandleSelectionChange`
 - `RemoveHandleSelectionChange`
 
@@ -39,8 +43,9 @@ end
 
 -- Disabled methods
 mixin_helper.disable_methods(
-    props, "Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetItemText",
-    "InsertString", "DeleteItem", "SetItemText", "AddHandleSelectionChange", "RemoveHandleSelectionChange")
+    props, "Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetSelectedLast",
+    "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange",
+    "RemoveHandleSelectionChange")
 
 --[[
 % Init
@@ -67,9 +72,9 @@ function props:Init()
 end
 
 --[[
-% UpdateSelection
+% UpdateMeasurementUnit
 
-**[Fluid]**
+**[Fluid] [Internal]**
 Checks the parent window's measurement unit and updates the selection if necessary.
 
 @ self (FCXCtrlMeasurementUnitPopup)

--- a/src/mixin/FCXCtrlPageSizePopup.lua
+++ b/src/mixin/FCXCtrlPageSizePopup.lua
@@ -1,0 +1,191 @@
+--  Author: Edward Koltun
+--  Date: April 13, 2021
+--[[
+$module FCXCtrlPageSizePopup
+
+*Extends `FCMCtrlPopup`*
+
+A popup for selecting a defined page size. The dimensions in the current unit are displayed along side each page size in the same way as the Page Format dialog.
+
+Summary of modifications:
+- `SelectionChange` has been overridden to match the specialised functionality.
+- Setting and getting is now only done base on page size.
+
+The following inherited methods have been disabled:
+- `Clear`
+- `AddString`
+- `AddStrings`
+- `SetStrings`
+- `GetSelectedItem`
+- `SetSelectedItem`
+- `SetSelectedLast`
+- `ItemExists`
+- `InsertString`
+- `DeleteItem`
+- `GetItemText`
+- `SetItemText`
+- `AddHandleSelectionChange`
+- `RemoveHandleSelectionChange`
+]] --
+local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
+local measurement = require("library.measurement")
+local page_size = require("library.page_size")
+
+local private = setmetatable({}, {__mode = "k"})
+local props = {}
+
+local trigger_page_size_change
+local each_last_page_size_change
+
+local temp_str = finale.FCString()
+
+-- Disabled methods
+mixin_helper.disable_methods(
+    props, "Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetSelectedLast",
+    "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange",
+    "RemoveHandleSelectionChange")
+
+local function repopulate(control)
+    local unit = mixin.is_instance_of(control:GetParent(), "FCXCustomLuaWindow") and
+                     control:GetParent():GetMeasurementUnit() or measurement.get_real_default_unit()
+
+    if private[control].LastUnit == unit then
+        return
+    end
+
+    local suffix = measurement.get_unit_abbreviation(unit)
+    local selection = control:GetSelectedItem_()
+
+    -- Use FCMCtrlPopup methods because `GetSelectedString` is needed in `GetSelectedPageSize`
+    mixin.FCMCtrlPopup.Clear()
+
+    for size, dimensions in page_size.pairs() do
+        local str = size .. " ("
+        temp_str:SetMeasurement(dimensions.width, unit)
+        str = str .. temp_str.LuaString .. suffix .. " x "
+        temp_str:SetMeasurement(dimensions.height, unit)
+        str = str .. temp_str.LuaString .. suffix .. ")"
+
+        mixin.FCMCtrlPopup.AddString(str)
+    end
+
+    control:SetSelectedItem_(selection)
+    private[control].LastUnit = unit
+end
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCXCtrlPageSizePopup)
+]]
+function props:Init()
+    private[self] = private[self] or {}
+
+    repopulate(self)
+end
+
+--[[
+% GetSelectedPageSize
+
+Returns the selected page size.
+
+@ self (FCXCtrlPageSizePopup)
+: (string|nil) The page size or `nil` if nothing is selected.
+]]
+function props:GetSelectedPageSize()
+    local str = mixin.FCMCtrlPopup.GetSelectedString()
+    if not str then
+        return nil
+    end
+
+    return str:match("(.+) %(")
+end
+
+--[[
+% SetSelectedPageSize
+
+**[Fluid]**
+Sets the selected page size. Must be a valid page size.
+
+@ self (FCXCtrlPageSizePopup)
+@ size (FCString|string)
+]]
+function props:SetSelectedPageSize(size)
+    mixin.assert_argument(size, {"string", "FCString"}, 2)
+    size = type(size) == "userdata" and size.LuaString or tostring(size)
+    mixin.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
+
+    local index = 0
+    for s in page_size.pairs() do
+        if size == s then
+            if index ~= self:_GetSelectedItem() then
+                mixin.FCMCtrlPopup.SetSelectedItem(index)
+                trigger_page_size_change(self)
+            end
+
+            return
+        end
+
+        index = index + 1
+    end
+end
+
+--[[
+% UpdateMeasurementUnit
+
+**[Fluid] [Internal]**
+Checks the parent window's measurement and updates the displayed page dimensions if necessary.
+
+@ self (FCXCtrlPageSizePopup)
+]]
+function props:UpdateMeasurementUnit()
+    repopulate(self)
+end
+
+--[[
+% HandlePageSizeChange
+
+**[Callback Template]**
+
+@ control (FCXCtrlPageSizePopup)
+@ last_page_size (string) The last page size that was selected. If no page size was previously selected, will be `false`.
+]]
+
+--[[
+% AddHandlePageSizeChange
+
+**[Fluid]**
+Adds a handler for PageSizeChange events.
+If the selected item is changed by a handler, that same handler will not be called again for that change.
+
+The event will fire in the following cases:
+- When the window is created (if an item is selected)
+- Change in selected item by user or programatically (inserting an item before or after will not trigger the event)
+
+@ self (FCXCtrlPageSizePopup)
+@ callback (function) See `HandlePageSizeChange` for callback signature.
+]]
+
+--[[
+% RemoveHandlePageSizeChange
+
+**[Fluid]**
+Removes a handler added with `AddHandlePageSizeChange`.
+
+@ self (FCXCtrlPageSizePopup)
+@ callback (function) Handler to remove.
+]]
+props.AddHandlePageSizeChange, props.RemoveHandlePageSizeChange, trigger_page_size_change, each_last_page_size_change =
+    mixin_helper.create_custom_control_change_event(
+        {
+            name = "last_page_size",
+            get = function(ctrl)
+                return mixin.FCXCtrlPageSizePopup.GetSelectedPageSize(ctrl)
+            end,
+            initial = false,
+        })
+
+return props

--- a/src/mixin/FCXCustomLuaWindow.lua
+++ b/src/mixin/FCXCustomLuaWindow.lua
@@ -154,6 +154,26 @@ function props:CreateMeasurementUnitPopup(x, y, control_name)
 end
 
 --[[
+% CreatePageSizePopup
+
+Creates a popup which allows the user to select a page size.
+
+@ self (FCXCustomLuaWindow)
+@ x (number)
+@ y (number)
+@ [control_name] (string)
+: (FCXCtrlPageSizePopup)
+]]
+function props:CreatePageSizePopup(x, y, control_name)
+    mixin.assert_argument(x, "number", 2)
+    mixin.assert_argument(y, "number", 3)
+    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+
+    local popup = mixin.FCMCustomWindow.CreatePopup(self, x, y, control_name)
+    return mixin.subclass(popup, "FCXCtrlPageSizePopup")
+end
+
+--[[
 % CreateStatic
 
 **[Override]**


### PR DESCRIPTION
This PR adds a `page_size` library for determining the named size of a page. It also adds methods for determining a page's size to the `FCMPage` mixin and adds a popup for selecting page sizes (like in the Page Format dialog). There are also some small pieces of housekeeping.

Page sizes are hardcoded and I've left a space in the library for adding custom sizes. 