### PR TITLE
Store window state

### DIFF
--- a/src/mixin/FCXCustomLuaWindow.lua
+++ b/src/mixin/FCXCustomLuaWindow.lua
@@ -10,6 +10,7 @@ Summary of modifications:
 - Windows also have the option of inheriting the parent window's measurement unit when opening.
 - Introduced a `MeasurementUnitChange` event.
 - All controls with an `UpdateMeasurementUnit` method will have that method called upon a measurement unit change to allow them to immediately update their displayed values without needing to wait for a `MeasurementUnitChange` event.
+- Changed the default auto restoration behaviour for window position to enabled
 ]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
@@ -35,6 +36,10 @@ function props:Init()
             MeasurementUnit = measurement.get_real_default_unit(),
             UseParentMeasurementUnit = true,
         }
+
+    if self.SetAutoRestorePosition then
+        self:SetAutoRestorePosition(true)
+    end
 end
 
 --[[
@@ -230,7 +235,7 @@ function props:ExecuteModal(parent)
         self:SetMeasurementUnit(parent:GetMeasurementUnit())
     end
 
-    return mixin.FCMCustomWindow.ExecuteModal(self, parent)
+    return mixin.FCMCustomLuaWindow.ExecuteModal(self, parent)
 end
 
 --[[


### PR DESCRIPTION
This PR adds some mixin methods that allow window state (position & size) to persist across script executions and window showings.

This is primarily controlled with two methods: `SetAutoRestorePosition` and `SetAutoRestoreSize`. The default behaviour in `FCMCustomLuaWindow` is disabled (to keep it backwards compatible) and the default behaviour in `FCXCustomLuaWindow` is enabled for position only.

While testing I noticed that restoring position for a window that can't be user-resized can have strange results:
```lua
local mixin = require("library.mixin")

local function create_window()
    local window = mixin.FCXCustomLuaWindow()
    window:SetAutoRestoreSize(true)
    window:CreateEdit(10, 10):SetText("")

    finenv.RegisterModelessDialog(window)
    return window
end

if not dialog then
    dialog = create_window()
    finenv.RetainLuaState = true
end

dialog:ShowModeless()
```

On second running, the window balloons out to a much larger size.