### PR TITLE
FCCustomLuaWindow Mixin Fixes

### DIFF
--- a/src/mixin/FCMCustomLuaWindow.lua
+++ b/src/mixin/FCMCustomLuaWindow.lua
@@ -30,8 +30,7 @@ local function flush_custom_queue(self)
 end
 
 local function restore_position(window)
-    if private[window].HasBeenShown and private[window].AutoRestorePosition and
-        (finenv.MajorVersion > 0 or finenv.MinorVersion >= 60) then
+    if private[window].HasBeenShown and private[window].AutoRestorePosition and window.StorePosition then
         window:StorePosition(false)
         window:SetRestorePositionOnlyData_(private[window].StoredX, private[window].StoredY)
         window:RestorePosition()
@@ -125,9 +124,12 @@ function props:Init()
                 self["Register" .. f .. "_"](
                     self, function()
                         cb()
-                        self:StorePosition(false)
-                        private[self].StoredX = self.StoredX
-                        private[self].StoredY = self.StoredY
+
+                        if self.StorePosition then
+                            self:StorePosition(false)
+                            private[self].StoredX = self.StoredX
+                            private[self].StoredY = self.StoredY
+                        end
                     end)
             else
                 self["Register" .. f .. "_"](self, cb)


### PR DESCRIPTION
Just a couple of quick improvements:
- Window position is only stored if `StorePosition` method exists (fixes JW Lua compatability)
- `ShowModeless` now registers the window with `finenv.RegisterModelessWindow` automatically in `FCXCustomLuaWindow`
- Implemented suggestion from @rpatters1 to assist debugging (if ALT or SHIFT key is pressed when window is closed and debug mode is enabled, `finenv.RetainLuaState` will be set to false)