### PR TITLE
Add library to get client details and capabilities

### DIFF
--- a/src/library/clef.lua
+++ b/src/library/clef.lua
@@ -5,6 +5,8 @@ A library of general clef utility functions.
 ]] --
 local clef = {}
 
+local client = require("library.client")
+
 --[[
 % get_cell_clef
 
@@ -53,18 +55,6 @@ function clef.get_default_clef(first_measure, last_measure, staff_number)
 end
 
 --[[
-% can_change_clef
-
-Determine if the current version of the plugin can change clefs.
-
-: (boolean) Whether or not the plugin can change clefs
-]]
-function clef.can_change_clef()
-    -- RGPLua 0.60 or later needed for clef changing
-    return finenv.IsRGPLua or finenv.StringVersion >= "0.60"
-end
-
---[[
 % restore_default_clef
 
 Restores the default clef for any staff for a specific region.
@@ -74,7 +64,7 @@ Restores the default clef for any staff for a specific region.
 @ staff_number (number) The staff number for the cell
 ]]
 function clef.restore_default_clef(first_measure, last_measure, staff_number)
-    if not clef.can_change_clef() then
+    if not client.supports_clef_changes() then
         return
     end
 

--- a/src/library/client.lua
+++ b/src/library/client.lua
@@ -1,0 +1,113 @@
+--[[
+$module Client
+
+Get information about the current client. For the purposes of Finale Lua, the client is
+the Finale application that's running on someones machine. Therefore, the client has
+details about the user's setup, such as their Finale version, plugin version, and
+operating system.
+
+One of the main uses of using client details is to check its capabilities. As such,
+the bulk of this library is helper functions to determine what the client supports.
+All functions to check a client's capabilities should start with `client.supports_`.
+These functions don't accept any arguments, and should always return a boolean.
+]] --
+local client = {}
+
+--[[
+% get_raw_finale_version
+Returns a raw Finale version from major, minor, and (optional) build parameters. For 32-bit Finale
+this is the internal major Finale version, not the year.
+
+@ major (number) Major Finale version
+@ minor (number) Minor Finale version
+@ [build] (number) zero if omitted
+
+: (number)
+]]
+function client.get_raw_finale_version(major, minor, build)
+    local retval = bit32.bor(bit32.lshift(math.floor(major), 24), bit32.lshift(math.floor(minor), 20))
+    if build then
+        retval = bit32.bor(retval, math.floor(build))
+    end
+    return retval
+end
+
+--[[
+% supports_smufl_fonts()
+
+Returns true if the current client supports SMuFL fonts.
+
+: (boolean)
+]]
+function client.supports_smufl_fonts()
+    return finenv.RawFinaleVersion >= client.get_raw_finale_version(27, 1)
+end
+
+--[[
+% supports_category_save_with_new_type()
+
+Returns true if the current client supports FCCategory::SaveWithNewType().
+
+: (boolean)
+]]
+function client.supports_category_save_with_new_type()
+    return finenv.StringVersion >= "0.58"
+end
+
+--[[
+% supports_finenv_query_invoked_modifier_keys()
+
+Returns true if the current client supports finenv.QueryInvokedModifierKeys().
+
+: (boolean)
+]]
+function client.supports_finenv_query_invoked_modifier_keys()
+    return finenv.IsRGPLua and finenv.QueryInvokedModifierKeys
+end
+
+--[[
+% supports_retained_state()
+
+Returns true if the current client supports retaining state between runs.
+
+: (boolean)
+]]
+function client.supports_retained_state()
+    return finenv.IsRGPLua and finenv.RetainLuaState ~= nil
+end
+
+--[[
+% supports_modeless_dialog()
+
+Returns true if the current client supports modeless dialogs.
+
+: (boolean)
+]]
+function client.supports_modeless_dialog()
+    return finenv.IsRGPLua
+end
+
+--[[
+% supports_clef_changes()
+
+Returns true if the current client supports changing clefs.
+
+: (boolean)
+]]
+function client.supports_clef_changes()
+    return finenv.IsRGPLua or finenv.StringVersion >= "0.60"
+end
+
+--[[
+% supports_custom_key_signatures()
+
+Returns true if the current client supports changing clefs.
+
+: (boolean)
+]]
+function client.supports_custom_key_signatures()
+    local key = finale.FCKeySignature()
+    return finenv.IsRGPLua and key.CalcTotalChromaticSteps
+end
+
+return client

--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -3,24 +3,7 @@ $module Library
 ]] --
 local library = {}
 
---[[
-% finale_version
-
-Returns a raw Finale version from major, minor, and (optional) build parameters. For 32-bit Finale
-this is the internal major Finale version, not the year.
-
-@ major (number) Major Finale version
-@ minor (number) Minor Finale version
-@ [build] (number) zero if omitted
-: (number)
-]]
-function library.finale_version(major, minor, build)
-    local retval = bit32.bor(bit32.lshift(math.floor(major), 24), bit32.lshift(math.floor(minor), 20))
-    if build then
-        retval = bit32.bor(retval, math.floor(build))
-    end
-    return retval
-end
+local client = require("library.client")
 
 --[[
 % group_overlaps_region
@@ -211,8 +194,7 @@ Returns true if measure number for the input cell is visible and left-aligned.
 @ is_for_multimeasure_rest (boolean) true if the current cell starts a multimeasure rest
 : (boolean)
 ]]
-function library.is_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part,
-                                                            is_for_multimeasure_rest)
+function library.is_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest)
     if meas_num_region.UseScoreInfoForParts then
         current_is_part = false
     end
@@ -289,7 +271,7 @@ end
 
 local calc_smufl_directory = function(for_user)
     local is_on_windows = finenv.UI():IsOnWindows()
-    local do_getenv = function (win_var, mac_var)
+    local do_getenv = function(win_var, mac_var)
         if finenv.UI():IsOnWindows() then
             return win_var and os.getenv(win_var) or ""
         else
@@ -323,9 +305,9 @@ function library.get_smufl_font_list()
         local smufl_directory = calc_smufl_directory(for_user)
         local get_dirs = function()
             if finenv.UI():IsOnWindows() then
-                return io.popen('dir "'..smufl_directory..'" /b /ad')
+                return io.popen("dir \"" .. smufl_directory .. "\" /b /ad")
             else
-                return io.popen('ls "'..smufl_directory..'"')
+                return io.popen("ls \"" .. smufl_directory .. "\"")
             end
         end
         local is_font_available = function(dir)
@@ -387,7 +369,7 @@ function library.is_font_smufl_font(font_info)
         font_info:LoadFontPrefs(finale.FONTPREF_MUSIC)
     end
 
-    if finenv.RawFinaleVersion >= library.finale_version(27, 1) then
+    if client.supports_smufl_fonts() then
         if nil ~= font_info.IsSMuFLFont then -- if this version of the lua interpreter has the IsSMuFLFont property (i.e., RGP Lua 0.59+)
             return font_info.IsSMuFLFont
         end
@@ -495,7 +477,6 @@ function library.system_indent_set_to_prefs(system, page_format_prefs)
     return system:Save()
 end
 
-
 --[[
 % calc_script_name
 
@@ -525,6 +506,5 @@ function library.calc_script_name(include_extension)
     end
     return retval
 end
-
 
 return library


### PR DESCRIPTION
For the purposes of Finale Lua, the client is the Finale application that's running on someones machine. Therefore, the client has details about the user's setup, such as their Finale version, plugin version, and operating system.

One of the main uses of using client details is to check its capabilities. As such, the bulk of this library is helper functions to determine what the client supports.

There are a few reasons to add a library to figure out what a client supports rather than doing individual checks:

1. Improved readability. It's a lot easier to understand the purpose of `if client.supports_retained_state() then` than `if finenv.IsRGPLua then`
2. Improved stability. As we add more capabilities, it makes it easier for us to check if a client supports something. Therefore, it's easier for us to write scripts that continue to work on older plugin/Finale versions, or fail gracefully.
3. If a new version of RGP Lua or Finale comes out that actually removes a capability (unlikely, but possible), we can just update the single helper function and all scripts will continue to work. The alternative that we'd need to update every individual script (and since there typically isn't a good find-and-replace mechanism for these if checks, it would be a very manual process).

In this PR, I've also gone through and replaced the obvious existing capability checks with the functions I added to this library.

CC @ThistleSifter, @cv-on-hub, and @jwink75 since if merged, this could impact how you'd want to write your scripts.