### PR TITLE
secondary beam breaks handle Ind Time Sig and correct number of beams

### DIFF
--- a/src/secondary_beam_breaks.lua
+++ b/src/secondary_beam_breaks.lua
@@ -41,7 +41,7 @@ function break_secondary_beams()
         end
 
         -- is this entry at a division point in a beamed group?
-        if not (entry.BeamBeat or entry:IsRest() or entry:Previous():IsRest())
+        if not (entry.BeamBeat or entry:IsRest() or (entry:Previous() and entry:Previous():IsRest()))
             and (entry.MeasurePos % beamed_length == 0) then
 
             local sbbm = finale.FCSecondaryBeamBreakMod()


### PR DESCRIPTION
This is a couple of refinements on the new secondary beam break script

- Only break the correct number of beams
- Handle Independent Time Signatures

@cv-on-hub 