### PR TITLE
Restore control state

### DIFF
--- a/src/mixin/FCMControl.lua
+++ b/src/mixin/FCMControl.lua
@@ -8,15 +8,28 @@ Summary of modifications:
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
 - Ported `GetParent` from PDK to allow the parent window to be accessed from a control.
 - Handlers for the `Command` event can now be set on a control.
+- Added methods for storing and restoring control state, which allows controls to correctly maintain their values across multiple script executions
 ]] --
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
 -- So as not to prevent the window (and by extension the controls) from being garbage collected in the normal way, use weak keys and values for storing the parent window
 local parent = setmetatable({}, {__mode = "kv"})
+local private = setmetatable({}, {__mode = "k"})
 local props = {}
 
 local temp_str = finale.FCString()
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCMControl)
+]]
+function props:Init()
+    private[self] = private[self] or {}
+end
 
 --[[
 % GetParent
@@ -53,10 +66,164 @@ function props:RegisterParent(window)
 end
 
 --[[
+% GetEnable
+
+**[Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+: (boolean)
+]]
+
+--[[
+% SetEnable
+
+**[Fluid] [Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+@ enable (boolean)
+]]
+
+--[[
+% GetVisible
+
+**[Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+: (boolean)
+]]
+
+--[[
+% SetVisible
+
+**[Fluid] [Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+@ visible (boolean)
+]]
+
+--[[
+% GetLeft
+
+**[Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+: (number)
+]]
+
+--[[
+% SetLeft
+
+**[Fluid] [Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+@ left (number)
+]]
+
+--[[
+% GetTop
+
+**[Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+: (number)
+]]
+
+--[[
+% SetTop
+
+**[Fluid] [Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+@ top (number)
+]]
+
+--[[
+% GetHeight
+
+**[Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+: (number)
+]]
+
+--[[
+% SetHeight
+
+**[Fluid] [Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+@ height (number)
+]]
+
+--[[
+% GetWidth
+
+**[Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+: (number)
+]]
+
+--[[
+% SetWidth
+
+**[Fluid] [Override]**
+Hooks into control state restoration.
+
+@ self (FCMControl)
+@ width (number)
+]]
+for method, valid_types in pairs({
+    Enable = {"boolean", "nil"},
+    Visible = {"boolean", "nil"},
+    Left = "number",
+    Top = "number",
+    Height = "number",
+    Width = "number",
+}) do
+    props["Get" .. method] = function(self)
+        if mixin.FCMControl.UseStoredState(self) then
+            return private[self][method]
+        end
+
+        return self["Get" .. method .. "_"](self)
+    end
+
+    props["Set" .. method] = function(self, value)
+        mixin.assert_argument(value, valid_types, 2)
+
+        if mixin.FCMControl.UseStoredState(self) then
+            private[self][method] = value
+        else
+            -- Fix bug with text box content being cleared on Mac when Enabled or Visible state is changed
+            if (method == "Enable" or method == "Visible") and finenv.UI():IsOnMac() and finenv.MajorVersion == 0 and finenv.MinorVersion < 63 then
+                self:GetText_(temp_str)
+                self:SetText_(temp_str)
+            end
+
+            self["Set" .. method .. "_"](self, value)
+        end
+    end
+end
+
+
+--[[
 % GetText
 
 **[Override]**
 Returns a Lua `string` and makes passing an `FCString` optional.
+Also hooks into control state restoration.
 
 @ self (FCMControl)
 @ [str] (FCString)
@@ -69,7 +236,11 @@ function props:GetText(str)
         str = temp_str
     end
 
-    self:GetText_(str)
+    if mixin.FCMControl.UseStoredState(self) then
+        str.LuaString = private[self].Text
+    else
+        self:GetText_(str)
+    end
 
     return str.LuaString
 end
@@ -79,6 +250,7 @@ end
 
 **[Fluid] [Override]**
 Accepts Lua `string` and `number` in addition to `FCString`.
+Also hooks into control state restoration.
 
 @ self (FCMControl)
 @ str (FCString|string|number)
@@ -91,7 +263,68 @@ function props:SetText(str)
         str = temp_str
     end
 
-    self:SetText_(str)
+    if mixin.FCMControl.UseStoredState(self) then
+        private[self].Text = str.LuaString
+    else
+        self:SetText_(str)
+    end
+end
+
+--[[
+% UseStoredState
+
+**[Internal]**
+Checks if this control should use its stored state instead of the live state from the control.
+Do not override or disable this method.
+
+@ self (FCMControl)
+: (boolean)
+]]
+function props:UseStoredState()
+    local parent = self:GetParent()
+    return mixin.is_instance_of(parent, "FCMCustomLuaWindow") and parent:GetRestoreControlState() and not parent:WindowExists() and parent:HasBeenShown()
+end
+
+--[[
+% StoreState
+
+**[Fluid] [Internal]**
+Stores the control's current state.
+Do not disable this method. Override as needed but call the parent first.
+
+@ self (FCMControl)
+]]
+function props:StoreState()
+    self:GetText_(temp_str)
+    private[self].Text = temp_str.LuaString
+    private[self].Enable = self:GetEnable_()
+    private[self].Visible = self:GetVisible_()
+    private[self].Left = self:GetLeft_()
+    private[self].Top = self:GetTop_()
+    private[self].Height = self:GetHeight_()
+    private[self].Width = self:GetWidth_()
+end
+
+--[[
+% RestoreState
+
+**[Fluid] [Internal]**
+Restores the control's stored state.
+Do not disable this method. Override as needed but call the parent first.
+
+@ self (FCMControl)
+]]
+function props:RestoreState()
+    self:SetEnable_(private[self].Enable)
+    self:SetVisible_(private[self].Visible)
+    self:SetLeft_(private[self].Left)
+    self:SetTop_(private[self].Top)
+    self:SetHeight_(private[self].Height)
+    self:SetWidth_(private[self].Width)
+
+    -- Call SetText last to work around the Mac text box issue described above
+    temp_str.LuaString = private[self].Text
+    self:SetText_(temp_str)
 end
 
 --[[

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -21,7 +21,10 @@ local props = {}
 @ self (FCMCustomWindow)
 ]]
 function props:Init()
-    private[self] = private[self] or {Controls = {}, NamedControls = {}}
+    private[self] = private[self] or {
+        Controls = {},
+        NamedControls = {},
+    }
 end
 
 --[[

--- a/src/mixin/FCXCustomLuaWindow.lua
+++ b/src/mixin/FCXCustomLuaWindow.lua
@@ -36,16 +36,17 @@ local each_last_measurement_unit_change
 ]]
 function props:Init()
     private[self] = private[self] or {
-            MeasurementUnit = measurement.get_real_default_unit(),
-            UseParentMeasurementUnit = true,
-            HandleTimer = {},
-            RunModelessDefaultAction = nil,
-        }
+        MeasurementUnit = measurement.get_real_default_unit(),
+        UseParentMeasurementUnit = true,
+        HandleTimer = {},
+        RunModelessDefaultAction = nil,
+    }
 
     if self.SetAutoRestorePosition then
         self:SetAutoRestorePosition(true)
     end
 
+    self:SetRestoreControlState(true)
     self:SetEnableDebugClose(true)
 
     -- Register proxy for HandlerTimer if it's available in this RGPLua version.
@@ -413,7 +414,7 @@ Automatically registers the dialog with `finenv.RegisterModelessDialog`.
 @ self (FCXCustomLuaWindow)
 : (boolean)
 ]]
-props:ShowModeless()
+function props:ShowModeless()
     finenv.RegisterModelessDialog(self)
     return mixin.FCMCustomLuaWindow.ShowModeless(self)
 end


### PR DESCRIPTION
This PR allows control state to persist across executions without the script author needing to perform any additional handling.

At the moment I've just done the base control properties from `FCControl`, but before I continue with the control-specific properties, I was wondering if someone could test it on Mac, since I only have a Windows machine (I'm assuming it should be fine but this proved to be more of a headache than I initially anticipated, so I would like to make sure).

Here is a test script (also uncomment the line near the bottom for additional testing):
```lua
local mixin = require("library.mixin")

function create()
    local window = mixin.FCXCustomLuaWindow()
    window:CreateEdit(0, 0, "edit")

    window:CreateButton(0, 40):SetWidth(75):SetText("Toggle Enable"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetEnable(not edit:GetEnable())
    end)
    
    window:CreateButton(80, 40):SetWidth(75):SetText("Toggle Visible"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetVisible(not edit:GetVisible())
    end)

    window:CreateButton(0, 70):SetText("Move Left"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetLeft(edit:GetLeft() - 10)
    end)

    window:CreateButton(80, 70):SetText("Move Right"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetLeft(edit:GetLeft() + 10)
    end)

    window:CreateButton(0, 100):SetText("Narrower"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetWidth(edit:GetWidth() - 10)
    end)

    window:CreateButton(80, 100):SetText("Wider"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetWidth(edit:GetWidth() + 10)
    end)

    window:CreateButton(0, 130):SetText("Shorter"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetHeight(edit:GetHeight() - 10)
    end)

    window:CreateButton(80, 130):SetText("Taller"):AddHandleCommand(function(self)
        local edit = self:GetParent():GetControl("edit")
        edit:SetHeight(edit:GetHeight() + 10)
    end)

    return window
end

dialog = dialog or create()

-- This should make the edit control one notch shorter on each opening (and invisible on the very first opening, since GetHeight returns 0)
-- (tests the ability to edit control values outside of window execution and still preserve correct state)
--dialog:GetControl("edit"):SetHeight(dialog:GetControl("edit"):GetHeight() - 10)

finenv.RetainLuaState = true

dialog:ShowModeless()
```