### PR TITLE
Rgp/misc fixes

### DIFF
--- a/src/library/tie.lua
+++ b/src/library/tie.lua
@@ -34,7 +34,7 @@ For this function to work correctly across barlines, the input note
 must be from an instance of FCNoteEntryLayer that contains both the
 input note and the tied-to note.
 
-@ note (FCNote) the note for which to return the tied-from note
+@ note (FCNote) the note for which to return the tied-to note
 @ [tie_must_exist] if true, only returns a note if the tie already exists.
 : (FCNote) Returns the tied-to note or nil if none
 ]]
@@ -102,7 +102,7 @@ Calculates the (potential) start and end notes for a tie, given an input note. T
 input note can be from anywhere, including from the `eachentry()` iterator functions.
 The function returns 3 values:
 
-    - A FCNoteLayerEntry containing both the start and and notes (if they exist),
+    - A FCNoteLayerEntry containing both the start and and notes (if they exist).
     You must maintain the lifetime of this variable as long as you are referencing either
     of the other two values.
     - The potential or actual start note of the tie (taken from the FCNoteLayerEntry above).

--- a/src/meter_change.lua
+++ b/src/meter_change.lua
@@ -11,7 +11,10 @@ function plugindef()
         Changes the meter. If a single measure is selected,
         the meter will be set for remaining measures in the score.
         If multiple measures are selected, the meter will be set
-        only for the selected measures.
+        only for the selected measures. However, you can override this
+        by holding down Shift or Option keys when invoking the script.
+        Then the meter is changed only in the range you selected, including
+        a single measure.
     ]]
     finaleplugin.AdditionalMenuOptions = [[
         Meter - 1/2
@@ -84,15 +87,16 @@ denominators[2] = 2048
 denominators[4] = 1024
 denominators[8] = 1536 -- for compound meters
 
+local do_single_bar = finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT) or finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_SHIFT)
+
 function set_time(beat_num, beat_duration)
     local measures = finale.FCMeasures()
     measures:LoadRegion(finenv.Region())
-    if measures.Count > 1 then
+    if measures.Count > 1 or do_single_bar then
         for m in each(measures) do
             local time_sig = m:GetTimeSignature()
-            time_sig:SetBeats(beat_num)
-            time_sig:SetBeatDuration(beat_duration)
-            time_sig:Save()
+            time_sig:RemoveCompositeTop(beat_num)
+            time_sig:RemoveCompositeBottom(beat_duration)
             m:Save()
         end
     else
@@ -102,9 +106,8 @@ function set_time(beat_num, beat_duration)
             local selectedMeasure = measures:GetItemAt(0)
             if (m.ItemNo >= selectedMeasure.ItemNo) then
                 local time_sig = m:GetTimeSignature()
-                time_sig:SetBeats(beat_num)
-                time_sig:SetBeatDuration(beat_duration)
-                time_sig:Save()
+                time_sig:RemoveCompositeTop(beat_num)
+                time_sig:RemoveCompositeBottom(beat_duration)
                 m:Save()
             end
         end


### PR DESCRIPTION
This pull request:

- Fixes some typos in the `tie.lua` documentation
- Changes `meter_change.lua` to cleanly erase pre-existing composite time signature.
- Enhances `meter_change.lua` to optionally create a single-measure time change by invoking the script with a shift key.
 