### PR TITLE
add user_settings to configuration library

### DIFF
--- a/src/library/configuration.lua
+++ b/src/library/configuration.lua
@@ -3,7 +3,7 @@
 --[[
 $module Configuration
 
-This library implements a UTF-8 text file scheme for configuration as follows:
+This library implements a UTF-8 text file scheme for configuration and user settings as follows:
 
 - Comments start with `--`
 - Leading, trailing, and extra whitespace is ignored
@@ -33,7 +33,9 @@ right_dynamic_cushion		= -6		--evpus
 
 Configuration files must be placed in a subfolder called `script_settings` within
 the folder of the calling script. Each script that has a configuration file
-defines its own configuration file name.
+defines its own configuration file name. Scripts may not create or modify configuration
+files. For that, use get_user_settings and save_user_settings. These are saved in
+the user's preferences folder (on Mac) or AppData folder (on Windows).
 ]] --
 local configuration = {}
 
@@ -54,8 +56,6 @@ end
 local strip_leading_trailing_whitespace = function(str)
     return str:match("^%s*(.-)%s*$") -- lua pattern magic taken from the Internet
 end
-
-local parse_parameter -- forward function declaration
 
 local parse_table = function(val_string)
     local ret_table = {}
@@ -81,14 +81,11 @@ parse_parameter = function(val_string)
     return tonumber(val_string)
 end
 
-local get_parameters_from_file = function(file_name)
+local get_parameters_from_file = function(file_path)
     local parameters = {}
 
-    local path = finale.FCString()
-    path:SetRunningLuaFolderPath()
-    local file_path = path.LuaString .. path_delimiter .. file_name
     if not file_exists(file_path) then
-        return parameters
+        return parameters, false
     end
 
     for line in io.lines(file_path) do
@@ -104,19 +101,30 @@ local get_parameters_from_file = function(file_name)
         end
     end
 
-    return parameters
+    return parameters, true
 end
 
 --[[
 % get_parameters
 
-Searches for a file with the input filename in the `script_settings` directory and replaces the default values in `parameter_list` with any that are found in the config file.
+Searches for a file with the input filename in the `script_settings` directory and replaces the default values in `parameter_list`
+with any that are found in the config file.
 
 @ file_name (string) the file name of the config file (which will be prepended with the `script_settings` directory)
 @ parameter_list (table) a table with the parameter name as key and the default value as value
+: [boolean] true if the file exists
 ]]
 function configuration.get_parameters(file_name, parameter_list)
-    local file_parameters = get_parameters_from_file(script_settings_dir .. path_delimiter .. file_name)
+    local path = ""
+    if finenv.IsRGPLua then
+        path = finenv.RunningLuaFolderPath()
+    else
+        local str = finale.FCString()
+        str:SetRunningLuaFolderPath()
+        path = str.LuaString
+    end
+    local file_path = path .. script_settings_dir .. path_delimiter .. file_name
+    local file_parameters, exists = get_parameters_from_file(file_path)
     if nil ~= file_parameters then
         for param_name, def_val in pairs(parameter_list) do
             local param_val = file_parameters[param_name]
@@ -125,37 +133,89 @@ function configuration.get_parameters(file_name, parameter_list)
             end
         end
     end
+    return exists
+end
+
+-- Calculates a filepath in the user's preferences folder using recommended naming conventions
+--
+local calc_preferences_filepath = function(script_name)
+    local str = finale.FCString()
+    str:SetUserOptionsPath()
+    local folder_name = str.LuaString
+    if not finenv.IsRGPLua and finenv.UI():IsOnMac() then
+        -- works around bug in SetUserOptionsPath() in JW Lua
+        folder_name = os.getenv("HOME") .. folder_name:sub(2) -- strip '~' and replace with actual folder
+    end
+    if finenv.UI():IsOnWindows() then
+        folder_name = folder_name .. path_delimiter .. "FinaleLua"
+    end
+    local file_path = folder_name .. path_delimiter
+    if finenv.UI():IsOnMac() then
+        file_path = file_path .. "com.finalelua."
+    end
+    file_path = file_path .. script_name .. ".settings.txt"
+    return file_path, folder_name
 end
 
 --[[
-% save_parameters
+% save_user_settings
 
-Saves a config file with the input filename in the `script_settings` directory using values provided in `parameter_list`.
+Saves the user's preferences for a script from the values provided in `parameter_list`.
 
-@ file_name (string) the file name of the config file (which will be prepended with the `script_settings` directory)
+@ script_name (string) the name of the script (without an extension)
 @ parameter_list (table) a table with the parameter name as key and the default value as value
+: boolean true on success
 ]]
-function configuration.save_parameters(file_name, parameter_list)
-    local folder_path = finenv:RunningLuaFolderPath() .. script_settings_dir
-    local file_path = folder_path ..  path_delimiter .. file_name
+function configuration.save_user_settings(script_name, parameter_list)
+    local file_path, folder_path = calc_preferences_filepath(script_name)
     local file = io.open(file_path, "w")
-    if file == nil then -- file not found
-        os.execute('mkdir "' .. folder_path ..'"') -- so try to make a folder
+    if not file and finenv.UI():IsOnWindows() then -- file not found
+        os.execute('mkdir "' .. folder_path ..'"') -- so try to make a folder (windows only, since the folder is guaranteed to exist on mac)
         file = io.open(file_path, "w") -- try the file again
-        if file == nil then -- still couldn't find file
-            return false -- so give up
-        end
     end
-    for i,v in pairs(parameter_list) do -- only integer or string values
+    if not file then -- still couldn't find file
+        return false -- so give up
+    end
+    file:write("-- User settings for " .. script_name .. ".lua\n\n")
+    for k,v in pairs(parameter_list) do -- only number, boolean, or string values
         if type(v) == "string" then
             v = "\"" .. v .."\""
         else
             v = tostring(v)
         end
-        file:write(i, " = ", v, "\n")
+        file:write(k, " = ", v, "\n")
     end
     file:close()
     return true -- success
+end
+
+--[[
+% get_user_settings
+
+Find the user's settings for a script in the preferences directory and replaces the default values in `parameter_list`
+with any that are found in the preferences file. The actual name and path of the preferences file is OS dependent, so
+the input string should just be the script name (without an extension).
+
+@ script_name (string) the name of the script (without an extension)
+@ parameter_list (table) a table with the parameter name as key and the default value as value
+@ (boolean) (create_automatically) if true, create the file automatically (default is `true`)
+: [boolean] `true` if the file already existed, `false` if it did not or if it was created automatically
+]]
+function configuration.get_user_settings(script_name, parameter_list, create_automatically)
+    if create_automatically == nil then create_automatically = true end
+    local file_parameters, exists = get_parameters_from_file(calc_preferences_filepath(script_name))
+    if nil ~= file_parameters then
+        for param_name, def_val in pairs(parameter_list) do
+            local param_val = file_parameters[param_name]
+            if nil ~= param_val then
+                parameter_list[param_name] = param_val
+            end
+        end
+    end
+    if not exists and create_automatically then
+        configuration.save_user_settings(script_name, parameter_list)
+    end
+    return exists
 end
 
 return configuration


### PR DESCRIPTION
This function modifies `configuration.lua` to add the concept of _user settings_. User settings are written by the scripts themselves and reside in the user's preferences folder in an appropriately-named location. (The naming convention is a detail that the configuration library handles for the caller.) If the user settings are to be changed from their defaults, the script itself should provide a means to change them.

User settings are in contrast to _configuration_ settings, which only the user may modify and then only if they wish to.

The changes are as follows:

- added `configuration.get_user_settings` function
- added `configuration.save_user_settings` function
- removed `configuration.save_parameters` function

@cv-on-hub @jwink75 