### PR TITLE
Enable bundling of personal scripts while preventing committing them

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -4529,8 +4529,8 @@ const bundleFileBase = (name, importedFiles, mixins, fetcher) => {
         const nextImport = (_a = importStack.pop()) !== null && _a !== void 0 ? _a : '';
         if (importedFileNames.has(nextImport))
             continue;
-        try {
-            (0, exports.importFileBase)(nextImport, importedFiles, fetcher);
+        const fileFound = (0, exports.importFileBase)(nextImport, importedFiles, fetcher);
+        if (fileFound) {
             const file = importedFiles[nextImport];
             importedFileNames.add(nextImport);
             if (file) {
@@ -4540,7 +4540,7 @@ const bundleFileBase = (name, importedFiles, mixins, fetcher) => {
             if ((0, lua_require_1.resolveRequiredFile)(nextImport) === 'library/mixin.lua')
                 importStack.push(...mixins);
         }
-        catch (_b) {
+        else {
             console.error(`Unresolvable import in file "${name}": ${nextImport}`);
             process.exitCode = 1;
         }
@@ -4627,8 +4627,6 @@ if (fs_extra_1.default.pathExistsSync(path_1.default.join(sourcePath, 'personal_
     */
 const sourceFiles = fs_extra_1.default.readdirSync(sourcePath).filter(fileName => fileName.endsWith('.lua'));
 sourceFiles.forEach(file => {
-    if (file.startsWith('personal'))
-        return;
     const bundledFile = (0, bundle_1.bundleFile)(file, sourcePath, mixins);
     fs_extra_1.default.writeFileSync(path_1.default.join(outputPath, file), bundledFile);
 });

--- a/.github/actions/bundle/src/index.ts
+++ b/.github/actions/bundle/src/index.ts
@@ -41,7 +41,6 @@ if (fs.pathExistsSync(path.join(sourcePath, 'personal_mixin'))) {
 const sourceFiles = fs.readdirSync(sourcePath).filter(fileName => fileName.endsWith('.lua'))
 
 sourceFiles.forEach(file => {
-    if (file.startsWith('personal')) return
     const bundledFile = bundleFile(file, sourcePath, mixins)
     fs.writeFileSync(path.join(outputPath, file), bundledFile)
 })

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ node_modules
 coverage
 mobdebug.lua
 
-src/personal*
+src/**/personal*
+dist/**/personal*
 
 .vscode/settings.json
 */**/.vscode


### PR DESCRIPTION
Previously, the bundler would ignore any scripts marked as personal (i.e., `personal_*`). However, this means it's nearly impossible to share scripts.

Now, you can run the bundler locally ([described here](https://github.com/finale-lua/lua-scripts/blob/master/.github/actions/bundle/README.md)) and it will bundle those scripts as well. Git will now also still ensure those scripts won't be committed into the repository.

As a side effect, this PR also allows one to create personal libraries. Any file in the library can be prefixed with `personal_` and it will not be committed into the repo.