### PR TITLE
Create 'region_replicate_music.lua'

### DIFF
--- a/src/region_replicate_music.lua
+++ b/src/region_replicate_music.lua
@@ -3,14 +3,16 @@ function plugindef()
     finaleplugin.Version = 1.0
     finaleplugin.Copyright = "2022/01/03"
     finaleplugin.HandlesUndo = true
+    finaleplugin.Notes = [[
+    Inspired by the 'r' key in Sibelius, this script copies the selected music, and pastes it directly to the right.
+Works with a single or multiple measures.
+When activated with a shortcut or hotkey, ultra fast replication is possible.
+]]
 return "Replicate Music", "Replicate Music", "Inspired by the 'r' key in Sibelius, this script copies the selected music, and pastes it directly to the right"
 end
 
---[[
-Inspired by the 'r' key in Sibelius, this script copies the selected music, and pastes it directly to the right.
-Works with a single or multiple measures.
-When activated with a shortcut or hotkey, ultra fast replication is possible.
---]]
+
+
 
 
 local function replicate_music()

--- a/src/region_replicate_music.lua
+++ b/src/region_replicate_music.lua
@@ -1,0 +1,32 @@
+function plugindef()
+    finaleplugin.Author = "Michael McClennan"
+    finaleplugin.Version = 1.0
+    finaleplugin.Copyright = "2022/01/03"
+    finaleplugin.HandlesUndo = true
+return "Replicate Music", "Replicate Music", "Inspired by the 'r' key in Sibelius, this script copies the selected music, and pastes it directly to the right"
+end
+
+--[[
+Inspired by the 'r' key in Sibelius, this script copies the selected music, and pastes it directly to the right.
+Works with a single or multiple measures.
+When activated with a shortcut or hotkey, ultra fast replication is possible.
+--]]
+
+
+local function replicate_music()
+    local region = finenv.Region()
+    local start_measure = finenv.Region().StartMeasure
+    local end_measure = finenv.Region().EndMeasure
+    local sum_measures = end_measure - start_measure
+    local start_paste_region = end_measure + 1
+    
+    region:CopyMusic()
+    finenv.Region():SetStartMeasure(start_paste_region) 
+    finenv.Region():SetEndMeasure(start_paste_region + sum_measures) 
+    region:PasteMusic()
+    region:ReleaseMusic()
+end
+
+
+
+replicate_music()


### PR DESCRIPTION
Submitting on behalf of Michael McLennan.

Jake notes: This is a simple but elegant little script! I wish it actually worked like the Sibelius/Dorico version, where the repetition is at any level, and not just at the measure level. Maybe it wouldn't be hard to adapt to that... But for now, this is pretty slick! I renamed it region_replicate_music rather than just replicate_music, to try to make it fit the repo style better.