### PR TITLE
Generate mixin documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,11 @@ jobs:
               with:
                   input: './lua/src/library'
                   output: './lua/docs/library'
+            - name: Generate the docs
+              uses: finale-lua/lua-docs-generator@1.2.1
+              with:
+                  input: './lua/src/mixin'
+                  output: './lua/docs/mixin'
             - run: 'rm -rf website/docs'
             - run: 'cp -R lua/docs website/docs'
             - name: Commit & Push docs to website


### PR DESCRIPTION
The mixin files themselves have very good documentation comments. For instance, take a look at FCMCtrlEdit.lua.

https://github.com/finale-lua/lua-scripts/blob/master/src/mixin/FCMCtrlEdit.lua

However, these are currently not being parsed or displayed on the website. This PR should hopefully change that.

Since there's no good way for me to test this locally, I'm going to go ahead and merge it immediately. Then I can check if there are any bugs when deploying the website and rollback if needed.

@rpatters1 FYI