### PR TITLE
Update generated docs to link back to source code

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,14 +34,16 @@ jobs:
                   source: ./lua/src
                   output: ./website/src/lib/lib/script-data.json
             - name: Generate the docs
-              uses: finale-lua/lua-docs-generator@1.2.1
+              uses: finale-lua/lua-docs-generator@1.3.0
               with:
                   input: './lua/src/library'
+                  repositoryUrl: 'https://github.com/finale-lua/lua-scripts/tree/master/src/library'
                   output: './lua/docs/library'
             - name: Generate the docs
-              uses: finale-lua/lua-docs-generator@1.2.1
+              uses: finale-lua/lua-docs-generator@1.3.0
               with:
                   input: './lua/src/mixin'
+                  repositoryUrl: 'https://github.com/finale-lua/lua-scripts/tree/master/src/mixin'
                   output: './lua/docs/mixin'
             - run: 'rm -rf website/docs'
             - run: 'cp -R lua/docs website/docs'


### PR DESCRIPTION
I just pushed an update to the docs generator to automatically generate links that will take you back to the source code.

You can view the full writeup in the changelog:

https://github.com/finale-lua/lua-docs-generator/releases/tag/1.3.0