### PR TITLE
Update staff_explode.lua

### DIFF
--- a/src/staff_explode.lua
+++ b/src/staff_explode.lua
@@ -11,16 +11,19 @@ function plugindef()
         It warns if pre-existing music in the destination will be erased. 
         It duplicates all markings from the original and resets the current clef on each destination staff.
 
-        This script doesn't respace the selected music after it completes. 
-        If you want automatic respacing you must create a `configuration` file. 
+        By default this script doesn't respace the selected music after it completes. 
+        If you want automatic respacing, hold down the `shift` or `alt` (option) key when selecting the script's menu item. 
+
+        Alternatively, if you want the default behaviour to include spacing then create a `configuration` file:  
         If it does not exist, create a subfolder called `script_settings` in the folder containing this script. 
-        In that folder create a plain text file  called `staff_explode.config.txt` containing the line:  
+        In that folder create a plain text file  called `staff_explode.config.txt` containing the line: 
 
         ```
         fix_note_spacing = true -- respace music when the script finishes
         ```
+        If you subsequently hold down the `shift` or `alt` (option) key, spacing will not be included.
     ]]
-    return "Staff Explode", "Staff Explode", "Staff Explode onto consecutive single staves"
+    return "Staff Explode", "Staff Explode", "Explode chords from one staff into single notes on consecutive staves"
 end
 
 local configuration = require("library.configuration")
@@ -72,6 +75,12 @@ function ensure_score_has_enough_staves(slot, note_count)
 end
 
 function staff_explode()
+    if finenv.QueryInvokedModifierKeys and
+    (finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT) or finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_SHIFT))
+        then
+        config.fix_note_spacing = not config.fix_note_spacing
+    end
+
     local source_staff_region = finale.FCMusicRegion()
     source_staff_region:SetCurrentSelection()
     if source_staff_region:CalcStaffSpan() > 1 then


### PR DESCRIPTION
3 parallel "Explosion" scripts - all being changed to default to NO NOTE SPACING with User Config File and Option Key override. This is the first one.