### PR TITLE
Rgp/bug fixes

### DIFF
--- a/src/document_save_as_text.lua
+++ b/src/document_save_as_text.lua
@@ -35,6 +35,8 @@ function plugindef()
     return "Save Document As Text File...", "", "Write current document to text file."
 end
 
+local library = require("library.general_library")
+
 local text_extension = ".txt"
 
 local note_entry = require('library.note_entry')
@@ -359,6 +361,13 @@ function document_save_as_text()
         finenv.UI():AlertError("Unable to open " .. file_to_write .. ". Please check folder permissions.", "")
         return
     end
+    local score_part = nil
+    if not library.get_current_part():IsScore() then
+        score_part = library.get_score()
+        score_part:SwitchTo()
+    end
+    -- no more return statements allowed in this function until
+    -- scort_part checked below
     local document_path = finale.FCString()
     document:GetPath(document_path)
     file:write("Script document_save_as_text.lua version ", finaleplugin.Version, "\n")
@@ -370,6 +379,9 @@ function document_save_as_text()
         write_measure(file, measure, measure_number_regions)
     end
     file:close()
+    if score_part then
+        score_part:SwitchBack()
+    end
 end
 
 document_save_as_text()

--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -268,6 +268,19 @@ function library.get_current_part()
 end
 
 --[[
+% get_score
+
+Returns an `FCPart` instance that represents the score.
+
+: (FCPart)
+]]
+function library.get_score()
+    local part = finale.FCPart(finale.PARTID_SCORE)
+    part:Load(part.ID)
+    return part
+end
+
+--[[
 % get_page_format_prefs
 
 Returns the default page format prefs for score or parts based on which is currently selected.

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -99,7 +99,7 @@ function vertical_dynamic_adjustment(region, direction)
     ssmm:LoadAllForRegion(region, true)
     for mark in each(ssmm) do
         local smart_shape = mark:CreateSmartShape()
-        if smart_shape:IsHairpin() then
+        if smart_shape and smart_shape:IsHairpin() then
             has_hairpins = true
             local success, staff_offset = smartshape_calc_relative_vertical_position(smart_shape)
             if success then
@@ -165,7 +165,7 @@ function vertical_dynamic_adjustment(region, direction)
         ssmm:LoadAllForRegion(region, true)
         for mark in each(ssmm) do
             local smart_shape = mark:CreateSmartShape()
-            if smart_shape:IsHairpin() then
+            if smart_shape and smart_shape:IsHairpin() then
                 local success, staff_offset = smartshape_calc_relative_vertical_position(smart_shape)
                 if success then
                     local left_seg = smart_shape:GetTerminateSegmentLeft()
@@ -290,7 +290,7 @@ function hairpin_adjustments(range_settings)
     ssmm:LoadAllForRegion(music_reg, true)
     for mark in each(ssmm) do
         local smartshape = mark:CreateSmartShape()
-        if smartshape:IsHairpin() then
+        if smartshape and smartshape:IsHairpin() then
             table.insert(hairpin_list, smartshape)
         end
     end


### PR DESCRIPTION
More bugs found due to real-world utilization of scripts for actual work.

- Prevent standalone hairpin script from crashing if smart shapes fail to load
- Always use score when generating a text file tracking document
- 