### PR TITLE
Rgp/support bar crossing for hairpins

### DIFF
--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -47,9 +47,6 @@ end
 local staff_systems = finale.FCStaffSystems()
 staff_systems:LoadAll()
 
-local distance_prefs = finale.FCDistancePrefs()
-distance_prefs:Load(1)
-
 function calc_cell_relative_vertical_position(fccell, page_offset)
     local relative_position = page_offset
     local cell_metrics = fccell:CreateCellMetrics()

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -22,7 +22,8 @@ local config = {
     limit_to_hairpins_on_notes = true,          -- if true, only hairpins attached to notes are considered
     vertical_adjustment_type = "far",           -- possible values: "near", "far", "none"
     horizontal_adjustment_type = "both",        -- possible values: "both", "left", "right", "none"
-    vertical_displacement_for_hairpins = 12     -- alignment displacement for hairpins relative to dynamics handle (evpu)
+    vertical_displacement_for_hairpins = 12,    -- alignment displacement for hairpins relative to dynamics handle (evpu)
+    extend_to_expression_in_next_bar = false    -- if true, extends to an expression at the beginning of the next bar    
 }
 
 configuration.get_parameters("standalone_hairpin_adjustment.config.txt", config)
@@ -40,6 +41,14 @@ if finenv.IsRGPLua and finenv.QueryInvokedModifierKeys then
 end
 
 -- end of parameters
+
+-- globally needed document information
+
+local staff_systems = finale.FCStaffSystems()
+staff_systems:LoadAll()
+
+local distance_prefs = finale.FCDistancePrefs()
+distance_prefs:Load(1)
 
 function calc_cell_relative_vertical_position(fccell, page_offset)
     local relative_position = page_offset
@@ -226,6 +235,19 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
         the_seg:SetMeasurePos(region_settings[3])
     end
 
+    if config.extend_to_expression_in_next_bar then
+        if left_or_right == "right" and finenv.Region():IsMeasureIncluded(the_seg.Measure + 1) then
+            local cell = finale.FCCell(the_seg.Measure, the_seg.Staff)
+            if the_seg.MeasurePos >= cell:CalcDuration() then
+                local this_system = staff_systems:FindMeasureNumber(the_seg.Measure)
+                if this_system and this_system:ContainsMeasure(the_seg.Measure + 1) then
+                    region:SetEndMeasure(the_seg.Measure + 1)
+                    region:SetEndMeasurePos(0)
+                end
+            end
+        end
+    end
+
     local expressions = finale.FCExpressions()
     expressions:LoadAllForRegion(region)
     local expression_list = {}
@@ -252,8 +274,17 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
             local total_x = dyn_width + config.left_dynamic_cushion + total_offset
             the_seg:SetEndpointOffsetX(total_x)
         elseif left_or_right == "right" then
+            local edu_gap_spacing = 0
+            if the_seg.Measure < dyn_exp.Measure and dyn_exp.MeasurePos == 0 then
+                require('mobdebug').start()
+                local seg_point = finale.FCPoint(0, 0)
+                hairpin:CalcRightCellMetricPos(seg_point)
+                local next_cell_metrics = finale.FCCellMetrics()
+                next_cell_metrics:LoadAtCell(finale.FCCell(dyn_exp.Measure, dyn_exp.Staff))
+                edu_gap_spacing = next_cell_metrics.MusicStartPos + distance_prefs.SpaceBefore - seg_point.X
+            end
             cushion_bool = false
-            local total_x = (0 - dyn_width) + config.right_dynamic_cushion + total_offset
+            local total_x = (0 - dyn_width) + config.right_dynamic_cushion + edu_gap_spacing + total_offset
             the_seg:SetEndpointOffsetX(total_x)
         end
     end

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -276,27 +276,11 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
         elseif left_or_right == "right" then
             local next_measure_gap = 0
             if the_seg.Measure < dyn_exp.Measure and dyn_exp.MeasurePos == 0 then
-                finale.FCCellMetrics.MarkMetricsForRebuild() -- have to rebuild because the cushion_bool could have changed things
+                finale.FCCellMetrics.MarkMetricsForRebuild() -- have to rebuild because the cushion_bool could have changed things on the "left" pass
                 local seg_point = finale.FCPoint(0, 0)
                 hairpin:CalcRightCellMetricPos(seg_point)
                 local exp_point = finale.FCPoint(0, 0)
                 dyn_exp:CalcMetricPos(exp_point)
-                local cell_metrics = finale.FCCellMetrics()
-                cell_metrics:LoadAtCell(finale.FCCell(the_seg.Measure, the_seg.Staff))
-                local next_cell_metrics = finale.FCCellMetrics()
-                next_cell_metrics:LoadAtCell(finale.FCCell(dyn_exp.Measure, dyn_exp.Staff))
-                local remove_horz_stretch = function(metrics, value)
-                    local horz_stretch = metrics.HorizontalStretch / 10000
-                    return math.floor(value/horz_stretch + 0.5)
-                end
-                local a_segx = seg_point.X
-                local a_expx = exp_point.X
-                local a_horzpos = dyn_exp.HorizontalPos
-                local a_segpos = the_seg.EndpointOffsetX
---require('mobdebug').start()
-                --next_measure_gap = remove_horz_stretch(next_cell_metrics, exp_point.X) - dyn_exp.HorizontalPos - remove_horz_stretch(cell_metrics, seg_point.X) + the_seg.EndpointOffsetX
-                --next_measure_gap = exp_point.X - dyn_exp.HorizontalPos - seg_point.X
-                --next_measure_gap = remove_horz_stretch(cell_metrics, exp_point.X) - dyn_exp.HorizontalPos - (seg_point.X - the_seg.EndpointOffsetX))
                 next_measure_gap = (exp_point.X - handle_offset_from_edupos) - (seg_point.X - the_seg.EndpointOffsetX)
             end
             cushion_bool = false

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "CJ Garcia"
     finaleplugin.Copyright = "© 2021 CJ Garcia Music"
-    finaleplugin.Version = "1.2"
-    finaleplugin.Date = "2/29/2021"
+    finaleplugin.Version = "1.3"
+    finaleplugin.Date = "8/4/2022"
     return "Hairpin and Dynamic Adjustments", "Hairpin and Dynamic Adjustments", "Adjusts hairpins to remove collisions with dynamics and aligns hairpins with dynamics."
 end
 

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -269,22 +269,38 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
         elseif finale.EXPRJUSTIFY_RIGHT == dyn_def.HorizontalJustification then
             dyn_width = 0
         end
-        local total_offset = expression.calc_handle_offset_for_smart_shape(dyn_exp)
+        local handle_offset_from_edupos = expression.calc_handle_offset_for_smart_shape(dyn_exp)
         if left_or_right == "left" then
-            local total_x = dyn_width + config.left_dynamic_cushion + total_offset
+            local total_x = dyn_width + config.left_dynamic_cushion + handle_offset_from_edupos
             the_seg:SetEndpointOffsetX(total_x)
         elseif left_or_right == "right" then
-            local edu_gap_spacing = 0
+            local next_measure_gap = 0
             if the_seg.Measure < dyn_exp.Measure and dyn_exp.MeasurePos == 0 then
-                require('mobdebug').start()
+                finale.FCCellMetrics.MarkMetricsForRebuild() -- have to rebuild because the cushion_bool could have changed things
                 local seg_point = finale.FCPoint(0, 0)
                 hairpin:CalcRightCellMetricPos(seg_point)
+                local exp_point = finale.FCPoint(0, 0)
+                dyn_exp:CalcMetricPos(exp_point)
+                local cell_metrics = finale.FCCellMetrics()
+                cell_metrics:LoadAtCell(finale.FCCell(the_seg.Measure, the_seg.Staff))
                 local next_cell_metrics = finale.FCCellMetrics()
                 next_cell_metrics:LoadAtCell(finale.FCCell(dyn_exp.Measure, dyn_exp.Staff))
-                edu_gap_spacing = next_cell_metrics.MusicStartPos + distance_prefs.SpaceBefore - seg_point.X
+                local remove_horz_stretch = function(metrics, value)
+                    local horz_stretch = metrics.HorizontalStretch / 10000
+                    return math.floor(value/horz_stretch + 0.5)
+                end
+                local a_segx = seg_point.X
+                local a_expx = exp_point.X
+                local a_horzpos = dyn_exp.HorizontalPos
+                local a_segpos = the_seg.EndpointOffsetX
+--require('mobdebug').start()
+                --next_measure_gap = remove_horz_stretch(next_cell_metrics, exp_point.X) - dyn_exp.HorizontalPos - remove_horz_stretch(cell_metrics, seg_point.X) + the_seg.EndpointOffsetX
+                --next_measure_gap = exp_point.X - dyn_exp.HorizontalPos - seg_point.X
+                --next_measure_gap = remove_horz_stretch(cell_metrics, exp_point.X) - dyn_exp.HorizontalPos - (seg_point.X - the_seg.EndpointOffsetX))
+                next_measure_gap = (exp_point.X - handle_offset_from_edupos) - (seg_point.X - the_seg.EndpointOffsetX)
             end
             cushion_bool = false
-            local total_x = (0 - dyn_width) + config.right_dynamic_cushion + edu_gap_spacing + total_offset
+            local total_x = (0 - dyn_width) + config.right_dynamic_cushion + next_measure_gap + handle_offset_from_edupos
             the_seg:SetEndpointOffsetX(total_x)
         end
     end


### PR DESCRIPTION
This is an enhancement to `standalone_hairpin_adjustment.lua`. The motivation for the change is that I frequently (for example) have a cresc. hairpin from pp to ff where the ff occurs on the downbeat of the following bar. If I extend the hairpin to that downbeat, then if that next bar occurs on a new system, I end up with an ugly and stubby hairpin continuation. I prefer not to have these, so I usually set my hairpins to the end of the preceding bar in these situations.

This enhancement extends hairpins that end at the end of a bar to a dynamic at the beginning of the next bar if they are on the same systems and otherwise behaves as now if they are on different systems. It is triggered by an option that I have added to `config`. Both bars have to be selected before it does this.

Besides the usual code review, I would like to ask whether this new behavior should be the default. Right now I have it set not to engage, so it has to be activated with a config file.
