### PR TITLE
Remove comments when bundling

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -4501,6 +4501,7 @@ const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 const helpers_1 = __nccwpck_require__(8092);
 const lua_require_1 = __nccwpck_require__(9083);
+const remove_comments_1 = __nccwpck_require__(6236);
 const wrap_import_1 = __nccwpck_require__(3494);
 exports.files = {};
 const importFileBase = (name, importedFiles, fetcher) => {
@@ -4551,7 +4552,7 @@ const bundleFileBase = (name, importedFiles, mixins, fetcher) => {
 };
 exports.bundleFileBase = bundleFileBase;
 const bundleFile = (name, sourcePath, mixins) => {
-    return (0, exports.bundleFileBase)(name, exports.files, mixins, (fileName) => fs_1.default.readFileSync(path_1.default.join(sourcePath, fileName)).toString());
+    return (0, remove_comments_1.removeComments)((0, exports.bundleFileBase)(name, exports.files, mixins, (fileName) => fs_1.default.readFileSync(path_1.default.join(sourcePath, fileName)).toString()));
 };
 exports.bundleFile = bundleFile;
 
@@ -4674,6 +4675,25 @@ const resolveRequiredFile = (name) => {
     return path_1.default.join(...splitName) + '.lua';
 };
 exports.resolveRequiredFile = resolveRequiredFile;
+
+
+/***/ }),
+
+/***/ 6236:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.removeComments = void 0;
+const removeComments = (contents) => {
+    return contents
+        .replace(/--\[\[[^\]]*\]\]/giu, '')
+        .replace(/--.*$/gimu, '')
+        .replace(/\n\n+/gimu, '\n')
+        .replace(/ *$/gimu, '');
+};
+exports.removeComments = removeComments;
 
 
 /***/ }),

--- a/.github/actions/bundle/src/bundle.ts
+++ b/.github/actions/bundle/src/bundle.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { getAllImports } from './helpers'
 import { generateLuaRequire, resolveRequiredFile } from './lua-require'
+import { removeComments } from './remove-comments'
 import { wrapImport } from './wrap-import'
 
 export type ImportedFile = {
@@ -62,7 +63,9 @@ export const bundleFileBase = (
 }
 
 export const bundleFile = (name: string, sourcePath: string, mixins: string[]): string => {
-    return bundleFileBase(name, files, mixins, (fileName: string) =>
-        fs.readFileSync(path.join(sourcePath, fileName)).toString()
+    return removeComments(
+        bundleFileBase(name, files, mixins, (fileName: string) =>
+            fs.readFileSync(path.join(sourcePath, fileName)).toString()
+        )
     )
 }

--- a/.github/actions/bundle/src/remove-comments.test.ts
+++ b/.github/actions/bundle/src/remove-comments.test.ts
@@ -1,0 +1,56 @@
+import { removeComments } from './remove-comments'
+
+const tests: [string, string][] = [
+    [`--[[]]`, ``],
+    [`--[[hello world]]`, ``],
+    [`--[[[[]]]]`, `]]`],
+    [`--[[--[[]]]]`, `]]`],
+    [`--[[]]--`, ``],
+    [`--[[]]--\nhello world`, `\nhello world`],
+    [`\n\n`, `\n`],
+    [`\n\n\n`, `\n`],
+    [`\n\n\n\n`, `\n`],
+    [`\n\n\n\n\n`, `\n`],
+    [`--[[\nhello\nworld\n]]`, ``],
+    [`--[[\n--hello\nworld\n]]`, ``],
+    [`hello world --[[\n--hello\nworld\n]]`, `hello world`],
+    [`hello world -- this is a comment`, `hello world`],
+    [` -- this is a comment\nhello world`, `\nhello world`],
+    [
+        `finaleplugin.AdditionalMenuOptions = [[  CrossStaff Offset No Dialog  ]] `,
+        `finaleplugin.AdditionalMenuOptions = [[  CrossStaff Offset No Dialog  ]]`,
+    ],
+    [
+        `finaleplugin.AdditionalMenuOptions = [[\n    CrossStaff Offset No Dialog\n]]`,
+        `finaleplugin.AdditionalMenuOptions = [[\n    CrossStaff Offset No Dialog\n]]`,
+    ],
+    [
+        `
+    __imports["library.client"] = function()
+        --[[
+        $module Client
+        Get information about the current client. For the purposes of Finale Lua, the client is
+        the Finale application that's running on someones machine. Therefore, the client has
+        details about the user's setup, such as their Finale version, plugin version, and
+        operating system.
+        One of the main uses of using client details is to check its capabilities. As such,
+        the bulk of this library is helper functions to determine what the client supports.
+        ]] --
+        local client = {}
+
+        local function to_human_string(feature)
+            return string.gsub(feature, "_", " ")
+        end`,
+        `
+    __imports["library.client"] = function()
+
+        local client = {}
+        local function to_human_string(feature)
+            return string.gsub(feature, "_", " ")
+        end`,
+    ],
+]
+
+it.each(tests)(`removeComments(%p)`, (input, expected) => {
+    expect(removeComments(input)).toBe(expected)
+})

--- a/.github/actions/bundle/src/remove-comments.ts
+++ b/.github/actions/bundle/src/remove-comments.ts
@@ -1,0 +1,7 @@
+export const removeComments = (contents: string): string => {
+    return contents
+        .replace(/--\[\[[^\]]*\]\]/giu, '')
+        .replace(/--.*$/gimu, '')
+        .replace(/\n\n+/gimu, '\n')
+        .replace(/ *$/gimu, '')
+}


### PR DESCRIPTION
This PR removes all comments from bundling as discussed in https://github.com/finale-lua/lua-scripts/issues/332#issuecomment-1214578160. This includes both multiline documentation comments and single-line comments.

Additionally, some extra whitespace is removed, along with successive empty lines.

It's possible this will break the bundled scripts (again), but at least this change has fairly good test coverage and it's possible to add any new errors as test cases to the bundler.

Going to merge this one without review since several of us are in agreement on the idea, and I'm really the only person who understands the bundler at this point so I'm unsure how useful code review will be.

cc @ThistleSifter @cv-on-hub @rpatters1 