### PR TITLE
Fix remove-comments

### DIFF
--- a/.github/actions/bundle/src/bundle.ts
+++ b/.github/actions/bundle/src/bundle.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { getAllImports } from './helpers'
 import { generateLuaRequire, resolveRequiredFile } from './lua-require'
+import { removeComments } from './remove-comments'
 import { wrapImport } from './wrap-import'
 
 export type ImportedFile = {
@@ -62,7 +63,9 @@ export const bundleFileBase = (
 }
 
 export const bundleFile = (name: string, sourcePath: string, mixins: string[]): string => {
-    return bundleFileBase(name, files, mixins, (fileName: string) =>
-        fs.readFileSync(path.join(sourcePath, fileName)).toString()
+    return removeComments(
+        bundleFileBase(name, files, mixins, (fileName: string) =>
+            fs.readFileSync(path.join(sourcePath, fileName)).toString()
+        )
     )
 }

--- a/.github/actions/bundle/src/remove-comments.test.ts
+++ b/.github/actions/bundle/src/remove-comments.test.ts
@@ -131,6 +131,16 @@ function note_entry.get_evpu_notehead_height(entry)
     return evpu_height
 end`,
     ],
+    [
+        `--[[
+% is_note_side
+Uses \`FCArticulation.CalcMetricPos\` to determine if the input articulation is on the note-side.
+@ artic (FCArticulation)
+@ [curr_pos] (FCPoint) current position of articulation that will be calculated if not supplied
+: (boolean) true if on note-side, otherwise false
+]]`,
+        ''
+    ],
 ]
 
 it.each(tests)(`removeComments(%p)`, (input, expected) => {

--- a/.github/actions/bundle/src/remove-comments.ts
+++ b/.github/actions/bundle/src/remove-comments.ts
@@ -1,6 +1,6 @@
 export const removeComments = (contents: string): string => {
     return contents
-        .replace(/--\[\[[^\]]*\]\]/giu, '')
+        .replace(/--\[\[[\s\S]*?\]\]/giu, '')
         .replace(/--.*$/gimu, '')
         .replace(/\n\n+/gimu, '\n')
         .replace(/ *$/gimu, '')


### PR DESCRIPTION
I had a few spare minutes this morning so I thought I'd have a go at a couple of bundler issues.

First is the issue with multiline comments that contain a `]`.

I also added a test. I'm not sure if that's the kind of test you're after or if you want more. Let me know.