### PR TITLE
Bundler require fix

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -4564,12 +4564,20 @@ exports.bundleFile = bundleFile;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getAllImports = exports.getImport = void 0;
+exports.getAllImports = exports.getImport = exports.requireRegex = void 0;
+exports.requireRegex = new RegExp([
+    /(?:^|[\W])/,
+    /(?:__original_)?require/,
+    /[\s]*/,
+    // Module. Match one single- or double-quoted string, optionally enclosed in parentheses, capturing only its contents
+    /(?:"([\w.]+?)"|'([\w.]+?)'|\("([\w.]+?)"\)|\('([\w.]+?)'\))/,
+].map(r => r.source).join(''), 'iu'); // Flags
 const getImport = (line) => {
-    const matches = line.match(/require\(["']([A-Z_a-z.]+)["']\)/iu);
-    if (!matches)
-        return { importedFile: '', isImport: false };
-    return { importedFile: matches[1], isImport: true };
+    const matches = line.match(exports.requireRegex);
+    return {
+        importedFile: matches ? matches[1] || matches[2] || matches[3] || matches[4] : '',
+        isImport: !!matches,
+    };
 };
 exports.getImport = getImport;
 const getAllImports = (file) => {

--- a/.github/actions/bundle/src/helpers.test.ts
+++ b/.github/actions/bundle/src/helpers.test.ts
@@ -15,6 +15,12 @@ describe('detects valid imports', () => {
         ['local library = import("library.file_name")', ''],
         ['local library = require("library.")', 'library.'],
         ['local library = require("file_name")', 'file_name'],
+        ['local library = require"library.articulation"', 'library.articulation'],
+        ['local library = require\'library.articulation\'', 'library.articulation'],
+        ['local library = require "library.articulation"', 'library.articulation'],
+        ['local library = require \'library.articulation\'', 'library.articulation'],
+        ['local library = __original_require("library.file_name")', 'library.file_name'],
+        ['local library = my_require("library.file_name")', ''],
     ]
 
     it.each(lines)('line "%s" imports "%s"', (line, importFile) => {

--- a/.github/actions/bundle/src/helpers.ts
+++ b/.github/actions/bundle/src/helpers.ts
@@ -1,7 +1,18 @@
+export const requireRegex = new RegExp([
+    /(?:^|[\W])/, // Begin at either the start of a line or the start of an identifier
+    /(?:__original_)?require/, // Match require or __original_require (introduced in RGPLua 0.64)
+    /[\s]*/, // Any number of whitespace characters are allowed between a function name and its arguments
+    // Module. Match one single- or double-quoted string, optionally enclosed in parentheses, capturing only its contents
+    /(?:"([\w.]+?)"|'([\w.]+?)'|\("([\w.]+?)"\)|\('([\w.]+?)'\))/,
+    ].map(r => r.source).join(''),
+    'iu'); // Flags
+
 export const getImport = (line: string): { importedFile: string; isImport: boolean } => {
-    const matches = line.match(/require\(["']([A-Z_a-z.]+)["']\)/iu)
-    if (!matches) return { importedFile: '', isImport: false }
-    return { importedFile: matches[1], isImport: true }
+    const matches = line.match(requireRegex);
+    return {
+        importedFile: matches ? matches[1] || matches[2] || matches[3] || matches[4] : '',
+        isImport: !!matches,
+    };
 }
 
 export const getAllImports = (file: string): string[] => {


### PR DESCRIPTION
This allows the bundler to handle require statements with no parentheses. It should handle calls with parentheses, a space and no space.