### PR TITLE
Restore state for edit controls

### DIFF
--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -132,5 +132,18 @@ function utils.calc_alphabet(num)
     return string.char(64 + letter) .. (n > 0 and n or "")
 end
 
-return utils
+--[[
+% clamp
 
+Clamps a number between two values.
+
+@ num (number) The number to clamp.
+@ minimum (number) The minimum value.
+@ maximum (number) The maximum value.
+: (number)
+]]
+function utils.clamp(num, minimum, maximum)
+    return math.min(math.max(num, minimum), maximum)
+end
+
+return utils

--- a/src/mixin/FCMString.lua
+++ b/src/mixin/FCMString.lua
@@ -1,0 +1,46 @@
+--  Author: Edward Koltun
+--  Date: August 8, 2022
+--[[
+$module FCMString
+
+Summary of modifications:
+- Added `GetMeasurementInteger` and `SetMeasurementInteger` methods for parity with `FCCtrlEdit`
+]] --
+local mixin = require("library.mixin")
+local utils = require("library.utils")
+
+local props = {}
+
+--[[
+% GetMeasurementInteger
+
+Returns the measurement in whole EVPUs.
+
+@ self (FCMString)
+@ measurementunit (number) Any of the `finale.MEASUREMENTUNIT*_` constants.
+: (number)
+]]
+function props:GetMeasurementInteger(measurementunit)
+    mixin.assert_argument(measurementunit, "number", 2)
+
+    return utils.round(self:GetMeasurement_(measurementunit))
+end
+
+--[[
+% SetMeasurementInteger
+
+**[Fluid]**
+Sets a measurement in whole EVPUs.
+
+@ self (FCMString)
+@ value (number) The value in whole EVPUs.
+@ measurementunit (number) Any of the `finale.MEASUREMENTUNIT*_` constants.
+]]
+function props:SetMeasurementInteger(value, measurementunit)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(measurementunit, "number", 3)
+
+    self:SetMeasurement_(utils.round(value), measurementunit)
+end
+
+return props


### PR DESCRIPTION
This PR adds full support for control state restoration in all mixin controls that are based on `FCCtrlEdit`.

I had to jump through a few hoops to make this all happen smoothly but the results should all be consistent with the native methods.