### PR TITLE
Fix module state in bundled scripts

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -4647,8 +4647,8 @@ exports.resolveRequiredFile = exports.generateLuaRequire = void 0;
 const path_1 = __importDefault(__nccwpck_require__(1017));
 const generateLuaRequire = () => {
     return [
-        'local __imports = {}',
-        'local __import_results = {}',
+        '__imports = __imports or {}',
+        '__import_results = __import_results or {}',
         '',
         'function require(item)',
         '    if not __imports[item] then',
@@ -4686,7 +4686,7 @@ exports.resolveRequiredFile = resolveRequiredFile;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.wrapImport = void 0;
 const wrapImport = (name, contents) => {
-    const output = [`__imports["${name}"] = function()`];
+    const output = [`__imports["${name}"] = __imports["${name}"] or function()`];
     for (const line of contents.split('\n')) {
         if (line === '')
             output.push(line);

--- a/.github/actions/bundle/src/lua-require.test.ts
+++ b/.github/actions/bundle/src/lua-require.test.ts
@@ -4,8 +4,8 @@ describe('generateLuaRequire', () => {
     it('lua-require', () => {
         expect(generateLuaRequire()).toBe(
             [
-                'local __imports = {}',
-                'local __import_results = {}',
+                '__imports = __imports or {}',
+                '__import_results = __import_results or {}',
                 '',
                 'function require(item)',
                 '    if not __imports[item] then',

--- a/.github/actions/bundle/src/lua-require.ts
+++ b/.github/actions/bundle/src/lua-require.ts
@@ -2,8 +2,8 @@ import path from 'path'
 
 export const generateLuaRequire = () => {
     return [
-        'local __imports = {}',
-        'local __import_results = {}',
+        '__imports = __imports or {}',
+        '__import_results = __import_results or {}',
         '',
         'function require(item)',
         '    if not __imports[item] then',

--- a/.github/actions/bundle/src/wrap-import.test.ts
+++ b/.github/actions/bundle/src/wrap-import.test.ts
@@ -23,7 +23,7 @@ describe('wrapImport', () => {
     it('stuff', () => {
         expect(wrapImport('stuff', stuff)).toBe(
             [
-                '__imports["stuff"] = function()',
+                '__imports["stuff"] = __imports["stuff"] or function()',
                 '    local stuff = {}',
                 '',
                 '    function stuff.hello()',
@@ -39,7 +39,7 @@ describe('wrapImport', () => {
     it('stuff2', () => {
         expect(wrapImport('stuff2', stuff2)).toBe(
             [
-                '__imports["stuff2"] = function()',
+                '__imports["stuff2"] = __imports["stuff2"] or function()',
                 '    local stuff = {}',
                 '',
                 '    function stuff.hello()',
@@ -55,7 +55,7 @@ describe('wrapImport', () => {
     it('works with a dot in the name', () => {
         expect(wrapImport('my.stuff', stuff)).toBe(
             [
-                '__imports["my.stuff"] = function()',
+                '__imports["my.stuff"] = __imports["my.stuff"] or function()',
                 '    local stuff = {}',
                 '',
                 '    function stuff.hello()',

--- a/.github/actions/bundle/src/wrap-import.ts
+++ b/.github/actions/bundle/src/wrap-import.ts
@@ -1,5 +1,5 @@
 export const wrapImport = (name: string, contents: string) => {
-    const output = [`__imports["${name}"] = function()`]
+    const output = [`__imports["${name}"] = __imports["${name}"] or function()`]
     for (const line of contents.split('\n')) {
         if (line === '') output.push(line)
         else output.push('    ' + line)


### PR DESCRIPTION
Fixes #360 
This should fix the issue with modules not retaining their state in bundled scripts by changing `__imports` and `__import_results` to globals.

I have one question: since they're now global, do the two variable names need to be more unique or is it okay to leave them as they are?

Marking this as draft until I can work out why `pnpm` just keeps giving me errors.