### PR TITLE
Remove comments fix

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -4697,7 +4697,7 @@ exports.removeComments = void 0;
 const removeComments = (contents) => {
     return contents
         .replace(/--\[\[[\s\S]*?\]\]/giu, '')
-        .replace(/--.*$/gimu, '')
+        .replace(/(?<!")--.*$/gimu, '')
         .replace(/\n\n+/gimu, '\n')
         .replace(/ *$/gimu, '');
 };

--- a/.github/actions/bundle/src/remove-comments.test.ts
+++ b/.github/actions/bundle/src/remove-comments.test.ts
@@ -141,6 +141,7 @@ Uses \`FCArticulation.CalcMetricPos\` to determine if the input articulation is 
 ]]`,
         ''
     ],
+    [`local comment_marker = "--"`, `local comment_marker = "--"`],
 ]
 
 it.each(tests)(`removeComments(%p)`, (input, expected) => {

--- a/.github/actions/bundle/src/remove-comments.ts
+++ b/.github/actions/bundle/src/remove-comments.ts
@@ -1,7 +1,7 @@
 export const removeComments = (contents: string): string => {
     return contents
         .replace(/--\[\[[\s\S]*?\]\]/giu, '')
-        .replace(/--.*$/gimu, '')
+        .replace(/(?<!")--.*$/gimu, '')
         .replace(/\n\n+/gimu, '\n')
         .replace(/ *$/gimu, '')
 }


### PR DESCRIPTION
This should fix #383

Skips removing comments that are preceded by a double quote. This could potentially result in some comments being left in but better that than the alternative.