### PR TITLE
Update notehead.lua

### DIFF
--- a/src/library/notehead.lua
+++ b/src/library/notehead.lua
@@ -115,7 +115,7 @@ if library.is_font_smufl_font() then
     config = {
         diamond = {
             quarter = { glyph = 0xe0e1, size = 110 },
-            half  = { glyph = 0xe0e1, size = 110 },
+            half  = { glyph = 0xe0da, size = 110 }, -- or "0xe0e1" to match quarter notehead
             whole = { glyph = 0xe0d8, size = 110 },
             breve = { glyph = 0xe0d7, size = 110 },
         },


### PR DESCRIPTION
Suggesting change half-note diamond head to a larger size SMuFL character. Not sure how others feel about this.

Gould states all harmonic diamond heads should be the same size regardless of duration (indicate duration above the staff). But there's a really nice larger diamond in SMuFL to differentiate from the quarter. I'd already given whole and breve notes noticeably different characters. 