### PR TITLE
Rgp/bug fixes

### DIFF
--- a/src/library/configuration.lua
+++ b/src/library/configuration.lua
@@ -20,6 +20,12 @@ Parameter values may be:
 - Booleans (`true` or `false`)
 - Numbers
 
+Parameter names may specify nested tables using dot-syntax:
+
+```lua
+diamond.quarter.glyph = 226
+```
+
 Currently the following are not supported:
 
 - Tables embedded within tables
@@ -30,8 +36,8 @@ A sample configuration file might be:
 ```lua
 -- Configuration File for "Hairpin and Dynamic Adjustments" script
 --
-left_dynamic_cushion 		= 12		--evpus
-right_dynamic_cushion		= -6		--evpus
+left_dynamic_cushion         = 12        --evpus
+right_dynamic_cushion        = -6        --evpus
 ```
 
 ## Configuration Files
@@ -149,7 +155,6 @@ end
 
 local get_parameters_from_file = function(file_path, parameter_list)
     local file_parameters = {}
-
     if not file_exists(file_path) then
         return false
     end
@@ -167,12 +172,20 @@ local get_parameters_from_file = function(file_path, parameter_list)
         end
     end
 
-    for param_name, _ in pairs(parameter_list) do
-        local param_val = file_parameters[param_name]
-        if nil ~= param_val then
-            parameter_list[param_name] = param_val
+    local function process_table(param_table, param_prefix)
+        param_prefix = param_prefix and param_prefix.."." or ""
+        for param_name, param_val in pairs(param_table) do
+            local file_param_name = param_prefix .. param_name
+            local file_param_val = file_parameters[file_param_name]
+            if nil ~= file_param_val then
+                param_table[param_name] = file_param_val
+            elseif type(param_val) == "table" then
+                    process_table(param_val, param_prefix..param_name)
+            end
         end
     end
+
+    process_table(parameter_list)
 
     return true
 end

--- a/src/pitch_transform_harmonics_fourth.lua
+++ b/src/pitch_transform_harmonics_fourth.lua
@@ -12,6 +12,7 @@ end
 
 local articulation = require("library.articulation")
 local transposition = require("library.transposition")
+require('mobdebug').start()
 local notehead = require("library.notehead")
 local note_entry = require("library.note_entry")
 

--- a/src/pitch_transform_harmonics_fourth.lua
+++ b/src/pitch_transform_harmonics_fourth.lua
@@ -12,7 +12,6 @@ end
 
 local articulation = require("library.articulation")
 local transposition = require("library.transposition")
-require('mobdebug').start()
 local notehead = require("library.notehead")
 local note_entry = require("library.note_entry")
 

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -285,6 +285,10 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
         elseif finale.EXPRJUSTIFY_RIGHT == dyn_def.HorizontalJustification then
             dyn_width = 0
         end
+        local cell_metrics = finale.FCCellMetrics()
+        cell_metrics:LoadAtCell(finale.FCCell(dyn_exp.Measure, dyn_exp.Staff))
+        local staff_percent = cell_metrics.StaffScaling / cell_metrics.SystemScaling
+        dyn_width = dyn_width * staff_percent
         local handle_offset_from_edupos = expression.calc_handle_offset_for_smart_shape(dyn_exp)
         if left_or_right == "left" then
             local total_x = dyn_width + config.left_dynamic_cushion + handle_offset_from_edupos
@@ -296,7 +300,8 @@ function horizontal_hairpin_adjustment(left_or_right, hairpin, region_settings, 
                 local seg_point = finale.FCPoint(0, 0)
                 local exp_point = finale.FCPoint(0, 0)
                 if hairpin:CalcRightCellMetricPos(seg_point) and dyn_exp:CalcMetricPos(exp_point) then
-                    next_measure_gap = (exp_point.X - handle_offset_from_edupos) - (seg_point.X - the_seg.EndpointOffsetX)
+                    local end_x = math.floor((exp_point.X * staff_percent) + 0.5)
+                    next_measure_gap = (end_x - handle_offset_from_edupos) - (seg_point.X - the_seg.EndpointOffsetX)
                 end
             end
             cushion_bool = false


### PR DESCRIPTION
Addresses the following issues:

- standalone hairpins script now supports reduced staff sizes
- configuration files now support parameter names with dot-syntax for nested tables
- configuration files now support any Lua syntax for table-valued parameter values, including nested tables.

Potentially we could support any Lua syntax for any parameter value, but as of now this PR is restricted to table-valued parameters. This is limit error risk.