### PR TITLE
Split Layers

### DIFF
--- a/src/library/layer.lua
+++ b/src/library/layer.lua
@@ -11,8 +11,9 @@ Duplicates the notes from the source layer to the destination. The source layer 
 @ region (FCMusicRegion) the region to be copied
 @ source_layer (number) the number (1-4) of the layer to duplicate
 @ destination_layer (number) the number (1-4) of the layer to be copied to
+@ [clone_articulations] (boolean) if true, clone articulations (default is false)
 ]]
-function layer.copy(region, source_layer, destination_layer)
+function layer.copy(region, source_layer, destination_layer, clone_articulations)
     local start = region.StartMeasure
     local stop = region.EndMeasure
     local sysstaves = finale.FCSystemStaves()
@@ -28,6 +29,18 @@ function layer.copy(region, source_layer, destination_layer)
             destination_layer, staffNum, start)
         noteentry_destination_layer:Save()
         noteentry_destination_layer:CloneTuplets(noteentry_source_layer)
+        -- ToDo: (possible) clone note-level items such as custom notehead alterations
+        if clone_articulations and noteentry_source_layer.Count == noteentry_destination_layer.Count then
+            for index = 0, noteentry_destination_layer.Count - 1 do
+                local source_entry = noteentry_source_layer:GetItemAt(index)
+                local destination_entry = noteentry_destination_layer:GetItemAt(index)
+                local source_artics = source_entry:CreateArticulations()
+                for articulation in each (source_artics) do
+                    articulation:SetNoteEntry(destination_entry)
+                    articulation:SaveNew()
+                end
+            end
+        end
         noteentry_destination_layer:Save()
     end
 end -- function layer_copy

--- a/src/library/note_entry.lua
+++ b/src/library/note_entry.lua
@@ -327,6 +327,30 @@ function note_entry.delete_note(note)
 end
 
 --[[
+% make_rest
+
+Deletes all notes and turns the note_entry into a floating rest. This function also
+deletes any attached entry details such as articulations and special tools edits.
+
+@ entry (FCNoteEntry)
+: (boolean) success
+]]
+
+function note_entry.make_rest(entry)
+    local articulations = entry:CreateArticulations()
+    for articulation in each(articulations) do
+        articulation:DeleteData()
+    end
+    if entry:IsNote() then
+        while entry.Count > 0 do
+            note_entry.delete_note(entry:GetItemAt(0)) -- cleans up note details
+        end
+    end
+    entry:MakeRest()
+    return true -- for now, always success. we can get fancier if we need to.
+end
+
+--[[
 % calc_pitch_string
 
 Calculates the pitch string of a note for display purposes.

--- a/src/staff_split_layers.lua
+++ b/src/staff_split_layers.lua
@@ -15,7 +15,7 @@ function plugindef()
         
         - From Layer (1-4): the source layer to split from (defaults to 1)
         - To Layer (1-4): the target layer to split to (defaults to 2)
-        - Split After (From Top): the number of chord tones to preserve in the source layer, counting from the top of each chord. All other notes are split to the target layer.
+        - Split At [ ] Notes From Top: the number of chord tones to preserve in the source layer, counting from the top of each chord. All other notes are split to the target layer.
         - Copy Articulations: if checked, copies articulations from the source to the target.
         
     ]]
@@ -81,7 +81,7 @@ function do_staff_split_layers()
         return
     end
     if split_from_top <= 0 then
-        finenv.UI():AlertError("Split After must be greater than zero.", "Split After")
+        finenv.UI():AlertError("Split At must be greater than zero.", "Split At")
         return
     end
     local region = finale.FCMusicRegion()
@@ -109,7 +109,7 @@ end
 function create_dialog_box()
     local dialog = mixin.FCXCustomLuaWindow():SetTitle("Split Layers")
     local current_y = 0
-    local x_increment = 130
+    local x_increment = 110
     local y_increment = 22
     local edit_width = 30
     -- from layer
@@ -132,16 +132,19 @@ function create_dialog_box()
     current_y = current_y + y_increment
     -- notes to keep
     dialog:CreateStatic(0, current_y + 2)
-        :SetWidth(x_increment - 5)
-        :SetText("Split After (From Top):")
+        :SetWidth(100)
+        :SetText("Split At:")
     local edit_x = x_increment + (finenv.UI():IsOnMac() and 4 or 0)
     dialog:CreateEdit(edit_x, current_y, "split_after")
         :SetWidth(edit_width)
         :SetInteger(1)
+    dialog:CreateStatic(edit_x + edit_width + 5, current_y + 2)
+        :SetWidth(100)
+        :SetText("Notes From Top")
     current_y = current_y + y_increment
     -- clone articulations
     dialog:CreateCheckbox(0, current_y + 2, "clone_artics"):SetText("Copy Articulations")
-        :SetWidth(x_increment)
+        :SetWidth(x_increment + edit_width)
         :SetCheck(1)
     -- ok/cancel
     dialog:CreateOkButton()

--- a/src/staff_split_layers.lua
+++ b/src/staff_split_layers.lua
@@ -1,5 +1,6 @@
 function plugindef()
-    finaleplugin.RequireSelection = true
+    finaleplugin.RequireSelection = false
+    finaleplugin.HandlesUndo = true -- not recognized by JW Lua or RGP Lua v0.55
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.AuthorURL = "https://www.robertgpatterson.com"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
@@ -10,16 +11,12 @@ function plugindef()
         Multiple measures and staves can be selected at once. 
         Articulations on the original are optionally copied to the other layer.
     ]]
-    return "Staff Split Layers", "Staff Split Layers", "Split chords from one layer 1 into two independent layers, based on a split point."
+    return "Staff Split Layers...", "Staff Split Layers", "Split chords from one layer 1 into two independent layers, based on a split point."
 end
 
 local note_entry = require("library.note_entry")
 local layer = require("library.layer")
-
-local split_from_top = 2
-local source_layer = 1
-local destination_layer = 2
-local clone_artics = true
+local mixin = require("library.mixin")
 
 function explode_one_slot(slot)
     local region = finale.FCMusicRegion()
@@ -28,6 +25,11 @@ function explode_one_slot(slot)
     region.EndSlot = slot
     region:SetStartMeasurePosLeft()
     region:SetEndMeasurePosRight()
+
+    local split_from_top = global_dialog:GetControl("split_after"):GetInteger()
+    local source_layer = global_dialog:GetControl("from_layer"):GetInteger()
+    local destination_layer = global_dialog:GetControl("to_layer"):GetInteger()
+    local clone_artics = 0 ~= global_dialog:GetControl("clone_artics"):GetCheck()
 
     local start_measure = region.StartMeasure
     local end_measure = region.EndMeasure
@@ -57,14 +59,77 @@ function explode_one_slot(slot)
     end
 end
 
-function staff_split_layers()
+function do_staff_split_layers()
     local region = finale.FCMusicRegion()
     if not region:SetCurrentSelection() then
-        return -- no selection, which should be impossible due to plugindef() setting
+        return -- no selection
     end
+    local undostr = "Split Layers " .. tostring(finenv.Region().StartMeasure)
+    if finenv.Region().StartMeasure ~= finenv.Region().EndMeasure then
+        undostr = undostr .. " - " .. tostring(finenv.Region().EndMeasure)
+    end
+    finenv.StartNewUndoBlock(undostr, false) -- this works on both JW Lua and RGP Lua
     for slot = region.StartSlot, region.EndSlot do
         explode_one_slot(slot)
     end
+    if finenv.EndUndoBlock then -- EndUndoBlock only exists on RGP Lua 0.56 and higher
+        finenv.EndUndoBlock(true)
+        finenv.Region():Redraw()
+    else
+        finenv.StartNewUndoBlock(undostr, true) -- JW Lua automatically terminates the final undo block we start here
+    end
+end
+
+function create_dialog_box()
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle("Split Layers")
+    local current_y = 0
+    local x_increment = 130
+    local y_increment = 22
+    local edit_width = 30
+    -- from layer
+    dialog:CreateStatic(0, current_y + 2)
+        :SetWidth(x_increment - 5)
+        :SetText("From Layer (1-4):")
+    local edit_x = x_increment + (finenv.UI():IsOnMac() and 4 or 0)
+    dialog:CreateEdit(edit_x, current_y, "from_layer")
+        :SetWidth(edit_width)
+        :SetInteger(1)
+    current_y = current_y + y_increment
+    -- to layer
+    dialog:CreateStatic(0, current_y + 2)
+        :SetWidth(x_increment - 5)
+        :SetText("To Layer (1-4):")
+    local edit_x = x_increment + (finenv.UI():IsOnMac() and 4 or 0)
+    dialog:CreateEdit(edit_x, current_y, "to_layer")
+        :SetWidth(edit_width)
+        :SetInteger(2)
+    current_y = current_y + y_increment
+    -- notes to keep
+    dialog:CreateStatic(0, current_y + 2)
+        :SetWidth(x_increment - 5)
+        :SetText("Split After (From Top):")
+    local edit_x = x_increment + (finenv.UI():IsOnMac() and 4 or 0)
+    dialog:CreateEdit(edit_x, current_y, "split_after")
+        :SetWidth(edit_width)
+        :SetInteger(1)
+    current_y = current_y + y_increment
+    -- clone articulations
+    dialog:CreateCheckbox(0, current_y + 2, "clone_artics"):SetText("Copy Articulations")
+        :SetWidth(x_increment)
+        :SetCheck(1)
+    -- ok/cancel
+    dialog:CreateOkButton()
+    dialog:CreateCancelButton()
+    dialog:RegisterHandleOkButtonPressed(function(self)
+            do_staff_split_layers()
+        end
+    )
+    return dialog
+end
+
+function staff_split_layers()
+    global_dialog = global_dialog or create_dialog_box()
+    global_dialog:RunModeless()
 end
 
 staff_split_layers()

--- a/src/staff_split_layers.lua
+++ b/src/staff_split_layers.lua
@@ -1,10 +1,10 @@
 function plugindef()
     finaleplugin.RequireSelection = true
-    finaleplugin.Author = "Carl Vine"
-    finaleplugin.AuthorURL = "http://carlvine.com/lua/"
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.AuthorURL = "https://www.robertgpatterson.com"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "v1.48"
-    finaleplugin.Date = "2022/11/14"
+    finaleplugin.Version = "v1.0"
+    finaleplugin.Date = "2023/1/11"
     finaleplugin.Notes = [[
         Chords from the source layers in the selected region are split into another layer on the same staff based on a split point. 
         Multiple measures and staves can be selected at once. 
@@ -13,61 +13,44 @@ function plugindef()
     return "Staff Split Layers", "Staff Split Layers", "Split chords from one layer 1 into two independent layers, based on a split point."
 end
 
+local note_entry = require("library.note_entry")
 local layer = require("library.layer")
 
-function get_note_count(region)
-    local note_count = 0
-    for entry in eachentry(region) do
-        if entry.Count > note_count then
-            note_count = entry.Count
-        end
-    end
-    return note_count
-end
+local split_from_top = 2
+local source_layer = 1
+local destination_layer = 2
+local clone_artics = true
 
 function explode_one_slot(slot)
-    local region = finenv.Region()
+    local region = finale.FCMusicRegion()
+    region:SetCurrentSelection()
     region.StartSlot = slot
     region.EndSlot = slot
-    local max_note_count = get_note_count(region)
-    if max_note_count == 0 then return end -- no notes in this slot
+    region:SetStartMeasurePosLeft()
+    region:SetEndMeasurePosRight()
 
     local start_measure = region.StartMeasure
     local end_measure = region.EndMeasure
     local staff = region:CalcStaffNumber(slot)
 
-    -- assume that user wants to double single layer 1 notes to layer 2
-    local unison_doubling = (max_note_count == 1) and 1 or 0
-
-    -- copy top staff to max_note_count layers
-    local layers = {}
-    layers[1] = finale.FCNoteEntryLayer(0, staff, start_measure, end_measure)
-    layers[1]:Load()
-
-    for i = 2, (max_note_count + unison_doubling) do  -- copy to the other layers
-        if i > layer.max_layers() then break end -- observe maximum layers
-        layer.copy(region, 1, i, true)
-    end
-
-    if unison_doubling == 1 then  -- special unison doubling, so don't delete layer 2
-        return
-    end
+    layer.copy(region, source_layer, destination_layer, clone_artics)
 
     -- run through all entries and split by layer
     for entry in eachentrysaved(region) do
         if entry:IsNote() then
             local this_layer = entry.LayerNumber
-            local from_top = this_layer - 1   -- delete how many notes from top?
-            local from_bottom = entry.Count - this_layer -- how many from bottom?
-
-            if from_top > 0 then -- delete TOP notes
-                for i = 1, from_top do
-                    entry:DeleteNote(entry:CalcHighestNote(nil))
+            if this_layer == source_layer and entry.Count > split_from_top then
+                for index = 0, entry.Count - split_from_top - 1 do
+                    note_entry.delete_note(entry:GetItemAt(0))
                 end
             end
-            if from_bottom > 0 and this_layer < layer.max_layers() then -- delete BOTTOM notes
-                for i = 1, from_bottom do
-                    entry:DeleteNote(entry:CalcLowestNote(nil))
+            if this_layer == destination_layer then
+                if entry.Count > split_from_top then
+                    for index = 0, split_from_top - 1 do
+                        note_entry.delete_note(entry:GetItemAt(entry.Count-1))
+                    end
+                else
+                    note_entry.make_rest(entry)
                 end
             end
         end
@@ -75,11 +58,9 @@ function explode_one_slot(slot)
 end
 
 function staff_split_layers()
-    local region = finenv.Region()
-    local note_count = get_note_count(region)
-    if note_count == 0 then -- nothing here ... go home
-        finenv.UI():AlertNeutral("", "Please select a region\nwith some notes in it!")
-        return
+    local region = finale.FCMusicRegion()
+    if not region:SetCurrentSelection() then
+        return -- no selection, which should be impossible due to plugindef() setting
     end
     for slot = region.StartSlot, region.EndSlot do
         explode_one_slot(slot)

--- a/src/staff_split_layers.lua
+++ b/src/staff_split_layers.lua
@@ -1,0 +1,89 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Carl Vine"
+    finaleplugin.AuthorURL = "http://carlvine.com/lua/"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "v1.48"
+    finaleplugin.Date = "2022/11/14"
+    finaleplugin.Notes = [[
+        Chords from the source layers in the selected region are split into another layer on the same staff based on a split point. 
+        Multiple measures and staves can be selected at once. 
+        Articulations on the original are optionally copied to the other layer.
+    ]]
+    return "Staff Split Layers", "Staff Split Layers", "Split chords from one layer 1 into two independent layers, based on a split point."
+end
+
+local layer = require("library.layer")
+
+function get_note_count(region)
+    local note_count = 0
+    for entry in eachentry(region) do
+        if entry.Count > note_count then
+            note_count = entry.Count
+        end
+    end
+    return note_count
+end
+
+function explode_one_slot(slot)
+    local region = finenv.Region()
+    region.StartSlot = slot
+    region.EndSlot = slot
+    local max_note_count = get_note_count(region)
+    if max_note_count == 0 then return end -- no notes in this slot
+
+    local start_measure = region.StartMeasure
+    local end_measure = region.EndMeasure
+    local staff = region:CalcStaffNumber(slot)
+
+    -- assume that user wants to double single layer 1 notes to layer 2
+    local unison_doubling = (max_note_count == 1) and 1 or 0
+
+    -- copy top staff to max_note_count layers
+    local layers = {}
+    layers[1] = finale.FCNoteEntryLayer(0, staff, start_measure, end_measure)
+    layers[1]:Load()
+
+    for i = 2, (max_note_count + unison_doubling) do  -- copy to the other layers
+        if i > layer.max_layers() then break end -- observe maximum layers
+        layer.copy(region, 1, i, true)
+    end
+
+    if unison_doubling == 1 then  -- special unison doubling, so don't delete layer 2
+        return
+    end
+
+    -- run through all entries and split by layer
+    for entry in eachentrysaved(region) do
+        if entry:IsNote() then
+            local this_layer = entry.LayerNumber
+            local from_top = this_layer - 1   -- delete how many notes from top?
+            local from_bottom = entry.Count - this_layer -- how many from bottom?
+
+            if from_top > 0 then -- delete TOP notes
+                for i = 1, from_top do
+                    entry:DeleteNote(entry:CalcHighestNote(nil))
+                end
+            end
+            if from_bottom > 0 and this_layer < layer.max_layers() then -- delete BOTTOM notes
+                for i = 1, from_bottom do
+                    entry:DeleteNote(entry:CalcLowestNote(nil))
+                end
+            end
+        end
+    end
+end
+
+function staff_split_layers()
+    local region = finenv.Region()
+    local note_count = get_note_count(region)
+    if note_count == 0 then -- nothing here ... go home
+        finenv.UI():AlertNeutral("", "Please select a region\nwith some notes in it!")
+        return
+    end
+    for slot = region.StartSlot, region.EndSlot do
+        explode_one_slot(slot)
+    end
+end
+
+staff_split_layers()

--- a/src/staff_split_layers.lua
+++ b/src/staff_split_layers.lua
@@ -10,6 +10,14 @@ function plugindef()
         Chords from the source layers in the selected region are split into another layer on the same staff based on a split point. 
         Multiple measures and staves can be selected at once. 
         Articulations on the original are optionally copied to the other layer.
+        
+        The dialog box has the following options:
+        
+        - From Layer (1-4): the source layer to split from (defaults to 1)
+        - To Layer (1-4): the target layer to split to (defaults to 2)
+        - Split After (From Top): the number of chord tones to preserve in the source layer, counting from the top of each chord. All other notes are split to the target layer.
+        - Copy Articulations: if checked, copies articulations from the source to the target.
+        
     ]]
     return "Staff Split Layers...", "Staff Split Layers", "Split chords from one layer 1 into two independent layers, based on a split point."
 end
@@ -18,18 +26,13 @@ local note_entry = require("library.note_entry")
 local layer = require("library.layer")
 local mixin = require("library.mixin")
 
-function explode_one_slot(slot)
+function explode_one_slot(slot, split_from_top, source_layer, destination_layer, clone_artics)
     local region = finale.FCMusicRegion()
     region:SetCurrentSelection()
     region.StartSlot = slot
     region.EndSlot = slot
     region:SetStartMeasurePosLeft()
     region:SetEndMeasurePosRight()
-
-    local split_from_top = global_dialog:GetControl("split_after"):GetInteger()
-    local source_layer = global_dialog:GetControl("from_layer"):GetInteger()
-    local destination_layer = global_dialog:GetControl("to_layer"):GetInteger()
-    local clone_artics = 0 ~= global_dialog:GetControl("clone_artics"):GetCheck()
 
     local start_measure = region.StartMeasure
     local end_measure = region.EndMeasure
@@ -59,18 +62,41 @@ function explode_one_slot(slot)
     end
 end
 
-function do_staff_split_layers()
+function do_staff_split_layers()    
+    local split_from_top = global_dialog:GetControl("split_after"):GetInteger()
+    local source_layer = global_dialog:GetControl("from_layer"):GetInteger()
+    local destination_layer = global_dialog:GetControl("to_layer"):GetInteger()
+    local clone_artics = 0 ~= global_dialog:GetControl("clone_artics"):GetCheck()
+    
+    if source_layer < 1 or source_layer > layer.max_layers() then
+        finenv.UI():AlertError("Invalid From Layer.", "Layer Number")
+        return
+    end
+    if destination_layer < 1 or destination_layer > layer.max_layers() then
+        finenv.UI():AlertError("Invalid To Layer.", "Layer Number")
+        return
+    end
+    if source_layer == destination_layer then
+        finenv.UI():AlertError("From and To layers must be different.", "Layer Number")
+        return
+    end
+    if split_from_top <= 0 then
+        finenv.UI():AlertError("Split After must be greater than zero.", "Split After")
+        return
+    end
     local region = finale.FCMusicRegion()
     if not region:SetCurrentSelection() then
+        finenv.UI():AlertError("Please select music before executing this script.", "No Selection")
         return -- no selection
     end
+
     local undostr = "Split Layers " .. tostring(finenv.Region().StartMeasure)
     if finenv.Region().StartMeasure ~= finenv.Region().EndMeasure then
         undostr = undostr .. " - " .. tostring(finenv.Region().EndMeasure)
     end
     finenv.StartNewUndoBlock(undostr, false) -- this works on both JW Lua and RGP Lua
     for slot = region.StartSlot, region.EndSlot do
-        explode_one_slot(slot)
+        explode_one_slot(slot, split_from_top, source_layer, destination_layer, clone_artics)
     end
     if finenv.EndUndoBlock then -- EndUndoBlock only exists on RGP Lua 0.56 and higher
         finenv.EndUndoBlock(true)


### PR DESCRIPTION
This script is similar to Carl Vine's Explode to Layers script, but instead of exploding it splits chords into 2 layers based on a split point in the chord. In the process I made some modifications to libary functions as well:

- `layer.copy()` now optionally clones articulations to the target layer
- `note_entry.make_rest()` is a new function that calls `FCNoteEntry::MakeRest` but does all the necessary cleanup first. I have not changed any existing code to use it because as far as I can tell it isn't needed in the context in which the existing code is calling `FCNoteEntry::MakeRest`.