### PR TITLE
Fix rounding issues in FCCtrlEdit and FCString measurement methods

### DIFF
--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -63,13 +63,16 @@ end
 --[[
 % round
 
-Rounds a number to the nearest whole integer.
+Rounds a number to the nearest integer or the specified number of decimal places.
 
 @ num (number)
+@ [places] (number) If specified, the number of decimal places to round to. If omitted or 0, will round to the nearest integer.
 : (number)
 ]]
-function utils.round(num)
-    return math.floor(num + 0.5)
+function utils.round(value, places)
+    places = places or 0
+    local multiplier = 10^places
+    return math.floor(value * multiplier + 0.5) / multiplier
 end
 
 --[[ 
@@ -144,6 +147,18 @@ Clamps a number between two values.
 ]]
 function utils.clamp(num, minimum, maximum)
     return math.min(math.max(num, minimum), maximum)
+end
+
+--[[
+% ltrim
+
+Removes whitespace from the start of a string.
+
+@ str (string)
+: (string)
+]]
+function utils.ltrim(str)
+    return string.match(str, "^%s*(.*)")
 end
 
 return utils

--- a/src/mixin/FCMString.lua
+++ b/src/mixin/FCMString.lua
@@ -5,11 +5,131 @@ $module FCMString
 
 Summary of modifications:
 - Added `GetMeasurementInteger` and `SetMeasurementInteger` methods for parity with `FCCtrlEdit`
+- Fixed rounding bugs in `GetMeasurement` and adjusted override handling behaviour to match `FCCtrlEdit.GetMeasurement` on Windows
+- Added `*Measurement10000th` methods for setting and retrieving values in 10,000ths of an EVPU (eg for piano brace settings, slur tip width, etc)
 ]] --
 local mixin = require("library.mixin")
 local utils = require("library.utils")
+local measurement = require("library.measurement")
 
 local props = {}
+
+-- Potential optimisation: reduce checked overrides to necessary minimum
+local unit_overrides = {
+    {unit = finale.MEASUREMENTUNIT_EVPUS, overrides = {"EVPUS", "evpus", "e"}},
+    {unit = finale.MEASUREMENTUNIT_INCHES, overrides = {"inches", "in", "i", "”"}},
+    {unit = finale.MEASUREMENTUNIT_CENTIMETERS, overrides = {"centimeters", "cm", "c"}},
+    -- Points MUST come before Picas in checking order to prevent "p" from "pt" being incorrectly matched
+    {unit = finale.MEASUREMENTUNIT_POINTS, overrides = {"points", "pts", "pt"}},
+    {unit = finale.MEASUREMENTUNIT_PICAS, overrides = {"picas", "p"}},
+    {unit = finale.MEASUREMENTUNIT_SPACES, overrides = {"spaces", "sp", "s"}},
+    {unit = finale.MEASUREMENTUNIT_MILLIMETERS, overrides = {"millimeters", "mm", "m"}},
+}
+
+function split_string_start(str, pattern)
+    return string.match(str, "^(" .. pattern .. ")(.*)")
+end
+
+local function split_number(str, allow_negative)
+    return split_string_start(str, (allow_negative and "%-?" or "") .. "%d+%.?%d*")
+end
+
+local function calculate_picas(whole, fractional)
+    fractional = fractional or 0
+    return tonumber(whole) * 48 + tonumber(fractional) * 4
+end
+
+--[[
+% GetMeasurement
+
+**[Override]**
+Fixes issue with incorrect rounding of returned value.
+Also changes handling of overrides to match the behaviour of `FCCtrlEdit` on Windows
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT_*` constants.
+: (number) EVPUs with decimal part.
+]]
+function props:GetMeasurement(measurementunit)
+    mixin.assert_argument(measurementunit, "number", 2)
+
+    -- Normalise decimal separator
+    local value = string.gsub(self.LuaString, "%" .. mixin.UI():GetDecimalSeparator(), '.')
+    local start_number, remainder = split_number(value, true)
+
+    if not start_number then
+        return 0
+    end
+
+    if remainder then
+        -- Spaces are allowed between the number and the override, so strip them
+        remainder = utils.ltrim(remainder)
+
+        if remainder == "" then
+            goto continue
+        end
+
+        for _, unit in ipairs(unit_overrides) do
+            for _, override in ipairs(unit.overrides) do
+                local a, b = split_string_start(remainder, override)
+                if a then
+                    measurementunit = unit.unit
+                    if measurementunit == finale.MEASUREMENTUNIT_PICAS then
+                        return calculate_picas(start_number, split_number(utils.ltrim(b)))
+                    end
+                    goto continue
+                end
+            end
+        end
+
+        :: continue ::
+    end
+
+    if measurementunit == finale.MEASUREMENTUNIT_DEFAULT then
+        measurementunit = measurement.get_real_default_unit()
+    end
+
+    start_number = tonumber(start_number)
+
+    if measurementunit == finale.MEASUREMENTUNIT_EVPUS then
+        return start_number
+    elseif measurementunit == finale.MEASUREMENTUNIT_INCHES then
+        return start_number * 288
+    elseif measurementunit == finale.MEASUREMENTUNIT_CENTIMETERS then
+        return start_number * 288 / 2.54
+    elseif measurementunit == finale.MEASUREMENTUNIT_POINTS then
+        return start_number * 4
+    elseif measurementunit == finale.MEASUREMENTUNIT_PICAS then
+        return start_number * 48
+    elseif measurementunit == finale.MEASUREMENTUNIT_SPACES then
+        return start_number * 24
+    elseif measurementunit == finale.MEASUREMENTUNIT_MILLIMETERS then
+        return start_number * 288 / 25.4
+    end
+
+    -- Original method returns 0 for invalid measurement units
+    return 0
+end
+
+--[[
+% GetRangeMeasurement
+
+**[Override]**
+See `FCMString.GetMeasurement`.
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurement(measurementunit, minimum, maximum)
+    mixin.assert_argument(measurementunit, "number", 2)
+    mixin.assert_argument(minimum, "number", 3)
+    mixin.assert_argument(maximum, "number", 4)
+
+    return utils.clamp(mixin.FCMString.GetMeasurement(measurementunit), minimum, maximum)
+end
 
 --[[
 % GetMeasurementInteger
@@ -17,13 +137,33 @@ local props = {}
 Returns the measurement in whole EVPUs.
 
 @ self (FCMString)
-@ measurementunit (number) Any of the `finale.MEASUREMENTUNIT*_` constants.
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 : (number)
 ]]
 function props:GetMeasurementInteger(measurementunit)
     mixin.assert_argument(measurementunit, "number", 2)
 
-    return utils.round(self:GetMeasurement_(measurementunit))
+    return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit))
+end
+
+--[[
+% GetRangeMeasurementInteger
+
+Returns the measurement in whole EVPUs, clamped between two values.
+Also ensures that any decimal places in `minimum` are correctly taken into account instead of being discarded.
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurementInteger(measurementunit, minimum, maximum)
+    mixin.assert_argument(measurementunit, "number", 2)
+    mixin.assert_argument(minimum, "number", 3)
+    mixin.assert_argument(maximum, "number", 4)
+
+    return utils.clamp(mixin.FCMString.GetMeasurementInteger(measurementunit), math.ceil(minimum), math.floor(maximum))
 end
 
 --[[
@@ -34,13 +174,116 @@ Sets a measurement in whole EVPUs.
 
 @ self (FCMString)
 @ value (number) The value in whole EVPUs.
-@ measurementunit (number) Any of the `finale.MEASUREMENTUNIT*_` constants.
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
 function props:SetMeasurementInteger(value, measurementunit)
     mixin.assert_argument(value, "number", 2)
     mixin.assert_argument(measurementunit, "number", 3)
 
     self:SetMeasurement_(utils.round(value), measurementunit)
+end
+
+--[[
+% GetMeasurementEfix
+
+Returns the measurement in whole EFIXes (1/64th of an EVPU)
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+: (number)
+]]
+function props:GetMeasurementEfix(measurementunit)
+    mixin.assert_argument(measurementunit, "number", 2)
+
+    return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit) * 64)
+end
+
+--[[
+% GetRangeMeasurementEfix
+
+Returns the measurement in whole EFIXes (1/64th of an EVPU), clamped between two values.
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurementEfix(measurementunit, minimum, maximum)
+    mixin.assert_argument(measurementunit, "number", 2)
+    mixin.assert_argument(minimum, "number", 3)
+    mixin.assert_argument(maximum, "number", 4)
+
+    return utils.clamp(mixin.FCMString.GetMeasurementEfix(measurementunit), math.ceil(minimum), math.floor(maximum))
+end
+
+--[[
+% SetMeasurementEfix
+
+**[Fluid]**
+Sets a measurement in whole EFIXes.
+
+@ self (FCMString)
+@ value (number) The value in EFIXes (1/64th of an EVPU)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+]]
+function props:SetMeasurementEfix(value, measurementunit)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(measurementunit, "number", 3)
+
+    self:SetMeasurement_(utils.round(value) / 64, measurementunit)
+end
+
+--[[
+% GetMeasurement10000th
+
+Returns the measurement in 10,000ths of an EVPU.
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+: (number)
+]]
+function props:GetMeasurement10000th(measurementunit)
+    mixin.assert_argument(measurementunit, "number", 2)
+
+    return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit) * 10000)
+end
+
+--[[
+% GetRangeMeasurement10000th
+
+Returns the measurement in 10,000ths of an EVPU, clamped between two values.
+Also ensures that any decimal places in `minimum` are handled correctly instead of being discarded.
+
+@ self (FCMString)
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+@ minimum (number)
+@ maximum (number)
+: (number)
+]]
+function props:GetRangeMeasurement10000th(measurementunit)
+    mixin.assert_argument(measurementunit, "number", 2)
+    mixin.assert_argument(minimum, "number", 3)
+    mixin.assert_argument(maximum, "number", 4)
+
+    return utils.clamp(mixin.FCMString.GetMeasurement10000th(self, measurementunit), math.ceil(minimum), math.floor(maximum))
+end
+
+--[[
+% SetMeasurement10000th
+
+**[Fluid]**
+Sets a measurement in 10,000ths of an EVPU.
+
+@ self (FCMString)
+@ value (number) The value in 10,000ths of an EVPU.
+@ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
+]]
+function props:SetMeasurement10000th(value, measurementunit)
+    mixin.assert_argument(value, "number", 2)
+    mixin.assert_argument(measurementunit, "number", 3)
+
+    self:SetMeasurement_(utils.round(value) / 10000, measurementunit)
 end
 
 return props


### PR DESCRIPTION
This PR fixes the measurement rounding issues that are partly causing the problems described in #389.

Here are the changes made:
- Rewrote `GetMeasurement` method from scratch in `FCMString` to solve the rounding problem. I also emulated the handling of overrides from `FCCtrlEdit` on Windows, which is more comprehensive than what `FCString` does (eg handling Picas overrides correctly).
- Changed the rounding of `minimum` in `GetMeasurementInteger` so that if decimal values are passed, they are handled correctly instead of being discarded (if I want an integer between `12.5` and `20` and I give it `11`, I should get `13` in return, not `12`).
- `GetMeasurementEfix` now returns whole EFIXes instead of decimals, rounded correctly (which is really what it should've done in the first place, just like `GetMeasurementInteger` does with EVPUs). My reason for doing this is that if a value like `63.75` is returned and then used on an EFIX field the decimals will be discarded, meaning that the actual value saved will be `63` instead of `64`. By returning an already rounded value, the script author doesn't need to think about handling this.
- Added `*Measurement10000th` methods for getting and setting values in 10,000ths of an EVPU, again mainly so that correct rounding can be handled automatically. This means that there are now methods for returning correct values in all 3 measurement types used in Finale (integer EVPU, integer EFIX and 10,000th EVPU)
- Modified `FCMCtrlEdit` so that it uses the new `FCMString` methods

I haven't touched the `Set*` methods. I might be able look into it next week, but at the moment finding time at the computer for testing is a bit tight and there's only so much I can write on my phone without being able to test.

Anyway, here is a test script. Since `FCMCtrlEdit` just calls the `FCMString` methods internally, the values should be the same but I put it in there just to make sure:
```lua
local mixin = require("library.mixin")
local dialog = mixin.FCXCustomLuaWindow()
dialog:CreateStatic(0, 3):SetText("Enter a measurement:"):SetWidth(120)
dialog:CreateEdit(110, 0, "edit")
dialog:CreateMeasurementUnitPopup(190, 0)

local function create_handler(method)
    return function(self)
        local unit = self:GetParent():GetMeasurementUnit()
        local edit = self:GetParent():GetControl("edit")
        local str = mixin.FCMString()
        edit:GetText(str)

        local msg = ""
        if edit[method .. "_"] then
            msg = msg .."FCCtrlEdit: " .. edit[method .. "_"](edit, unit) .. "\n"
        end
        if str[method .. "_"] then
            msg = msg .. "FCString: " .. str[method .. "_"](str, unit) .. "\n"
        end
        if str[method] then
            msg = msg .. "FCMString: " .. str[method](str, unit) .. "\n"
        end
        if edit[method] then
            msg = msg .."FCMCtrlEdit: " .. edit[method](edit, unit) .. "\n"
        end

        finenv.UI():AlertInfo(msg, method .. " Results")
    end
end

dialog:CreateButton(0, 30):SetText("GetMeasurement"):SetWidth(90):AddHandleCommand(create_handler("GetMeasurement"))
dialog:CreateButton(95, 30):SetText("GetMeasurementInteger"):SetWidth(120):AddHandleCommand(create_handler("GetMeasurementInteger"))
dialog:CreateButton(220, 30):SetText("GetMeasurementEfix"):SetWidth(110):AddHandleCommand(create_handler("GetMeasurementEfix"))
dialog:CreateButton(335, 30):SetText("GetMeasurement10000th"):SetWidth(130):AddHandleCommand(create_handler("GetMeasurement10000th"))

dialog:ExecuteModal()
```
I intentionally made it regular text box, not a MeasurementEdit, so changing the unit doesn't change the display value, it just changes what unit the text box value is treated as when you click the buttons. Play around with it, including with overrides. For a list of overrides, check the code or look here: https://usermanuals.finalemusic.com/Finale2012Win/Content/Finale/OptionsOMeasurement_Units.htm There are hours of fun to be had!

@rpatters1 @cv-on-hub 