### PR TITLE
reverse most of json code, in case that is what's breaking the build

### DIFF
--- a/docs/rgp-lua/development-environment.md
+++ b/docs/rgp-lua/development-environment.md
@@ -94,50 +94,17 @@ One effective way to do this is to detect modifier keys. If your script has a di
     debuggee.start(json, { redirectPrint = true })
     ```
    
-6. Type <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> or click on the "Run and Debug" icon in the side bar, then click on the "create a launch.json file" link. From the "Select debugger" dropdown that appears, select `Lua Debugger`. This will create a default `launch.json` file that should look like this:
+6. Type <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> or click on the "Run and Debug" icon in the side bar, then click on the "create a launch.json file" link. From the "Select debugger" dropdown that appears, select `Lua Debugger`. This will create a default `launch.json` file with a `wait` section that should look like this:
 
-    ```json
-    {
-        "version": "0.2.0",
-        "configurations": [
-            {
-                "name": "launch-lua",
-                "type": "lua",
-                "request": "launch",
-                "workingDirectory": "${workspaceRoot}",
-                "sourceBasePath": "${workspaceRoot}",
-                "executable": "${workspaceRoot}/lua.exe",
-                "arguments": "main.lua",
-                "listenPublicly": false,
-                "listenPort": 56789,
-                "encoding": "UTF-8",
-                "env": {}
-            },
-            {
-                "name": "launch-gideros",
-                "type": "lua",
-                "request": "launch",
-                "workingDirectory": "${workspaceRoot}",
-                "giderosPath": "C:/Program Files (x86)/Gideros",
-                "gprojPath": "${workspaceRoot}/GPROJ.gproj",
-                "jumpToGiderosErrorPosition": false,
-                "stopGiderosWhenDebuggerStops": true,
-                "listenPublicly": false,
-                "listenPort": 56789,
-                "encoding": "UTF-8"
-            },
-            {
-                "name": "wait",
-                "type": "lua",
-                "request": "attach",
-                "workingDirectory": "${workspaceRoot}",
-                "sourceBasePath": "${workspaceRoot}",
-                "listenPublicly": false,
-                "listenPort": 56789,
-                "encoding": "UTF-8"
-            }
-        ]
-    }
+	```
+    "name": "wait",
+    "type": "lua",
+    "request": "attach",
+    "workingDirectory": "${workspaceRoot}",
+    "sourceBasePath": "${workspaceRoot}",
+    "listenPublicly": false,
+    "listenPort": 56789,
+    "encoding": "UTF-8"
     ```
 
 8. Launch the `wait` configuration by selecting it from the dropdown at the top of the "Run and Debug" panel and clicking the arrow next to it (or hitting <kbd>F5</kbd>). This tells VS Code to listen for messages from remote execution of your script.


### PR DESCRIPTION
This is an emergency documentation fix. If it doesn't solve the issue, there will be a subsequent PR that reverses #405.