### PR TITLE
Restore control state - FCMCtrlPopup and FCMCtrlListBox

### DIFF
--- a/src/library/page_size.lua
+++ b/src/library/page_size.lua
@@ -126,6 +126,7 @@ Return an alphabetical order iterator that yields the following pairs:
 local sizes_index
 function page_size.pairs()
     if not sizes_index then
+        sizes_index = {}
         for size in pairs(sizes) do
             table.insert(sizes_index, size)
         end

--- a/src/mixin/FCXCtrlMeasurementUnitPopup.lua
+++ b/src/mixin/FCXCtrlMeasurementUnitPopup.lua
@@ -35,10 +35,10 @@ local unit_order = {
     finale.MEASUREMENTUNIT_EVPUS, finale.MEASUREMENTUNIT_INCHES, finale.MEASUREMENTUNIT_CENTIMETERS,
     finale.MEASUREMENTUNIT_POINTS, finale.MEASUREMENTUNIT_PICAS, finale.MEASUREMENTUNIT_SPACES,
 }
-local reverse_unit_order = {}
+local flipped_unit_order = {}
 
 for k, v in ipairs(unit_order) do
-    reverse_unit_order[v] = k
+    flipped_unit_order[v] = k
 end
 
 -- Disabled methods
@@ -55,9 +55,7 @@ mixin_helper.disable_methods(
 @ self (FCXCtrlMeasurementUnitPopup)
 ]]
 function props:Init()
-    mixin.assert(
-        mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"),
-        "FCXCtrlMeasurementUnitPopup must have a parent window that is an instance of FCXCustomLuaWindow")
+    mixin.assert(mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"), "FCXCtrlMeasurementUnitPopup must have a parent window that is an instance of FCXCustomLuaWindow")
 
     for _, v in ipairs(unit_order) do
         mixin.FCMCtrlPopup.AddString(self, measurement.get_unit_name(v))
@@ -65,10 +63,9 @@ function props:Init()
 
     self:UpdateMeasurementUnit()
 
-    mixin.FCMCtrlPopup.AddHandleSelectionChange(
-        self, function(control)
-            control:GetParent():SetMeasurementUnit(unit_order[control:GetSelectedItem_() + 1])
-        end)
+    mixin.FCMCtrlPopup.AddHandleSelectionChange(self, function(control)
+        control:GetParent():SetMeasurementUnit(unit_order[mixin.FCMCtrlPopup.GetSelectedItem(control) + 1])
+    end)
 end
 
 --[[
@@ -82,11 +79,11 @@ Checks the parent window's measurement unit and updates the selection if necessa
 function props:UpdateMeasurementUnit()
     local unit = self:GetParent():GetMeasurementUnit()
 
-    if unit == unit_order[self:GetSelectedItem_() + 1] then
+    if unit == unit_order[mixin.FCMCtrlPopup.GetSelectedItem(self) + 1] then
         return
     end
 
-    mixin.FCMCtrlPopup.SetSelectedItem(self, reverse_unit_order[unit] - 1)
+    mixin.FCMCtrlPopup.SetSelectedItem(self, flipped_unit_order[unit] - 1)
 end
 
 return props


### PR DESCRIPTION
This PR adds full preservation of state across multiple executions for Popup and ListBox controls. There are also some indentation changes and some small bug fixes.

Here is a test script. It doesn't include every single method, but it's pretty easy to modify if you want to try something out:
```lua
local mixin = require("library.mixin")

local function create_dialog()
    local dialog = mixin.FCXCustomLuaWindow()

    --dialog:CreatePageSizePopup(10, 10)

    dialog:CreateEdit(0, 0, "edit"):SetWidth(40)

    dialog:CreateButton(50, 0):SetText("Add Item"):AddHandleCommand(function(self)
        self:GetParent():GetControl("popup"):AddString(self:GetParent():GetControl("edit"):GetText())
        self:GetParent():GetControl("edit"):SetText("")
    end)

    dialog:CreateButton(120, 0):SetText("Set 2nd Item Text"):SetWidth(100):AddHandleCommand(function(self)
        self:GetParent():GetControl("popup"):SetItemText(1, self:GetParent():GetControl("edit"):GetText())
        self:GetParent():GetControl("edit"):SetText("")
    end)

    dialog:CreateButton(230, 0):SetText("Insert 2nd Item"):SetWidth(80):AddHandleCommand(function(self)
        self:GetParent():GetControl("popup"):InsertItem(1, self:GetParent():GetControl("edit"):GetText())
        self:GetParent():GetControl("edit"):SetText("")
    end)

    dialog:CreateButton(0, 30):SetText("Delete 2nd Item"):SetWidth(90):AddHandleCommand(function(self)
        self:GetParent():GetControl("popup"):DeleteItem(1)
    end)

    -- Change this to "CreatePopup" to test popup control
    dialog:CreateListBox(0, 60, "popup"):AddStrings("a", "b", "c", "d")

    return dialog
end

window = window or create_dialog()
-- Uncomment the line below for additional testing (will clear popup/listbox before each window showing)
--window:GetControl("popup"):Clear()
finenv.RetainLuaState = true
window:ExecuteModal(nil)
```