### PR TITLE
Update notehead.lua - default size correction

### DIFF
--- a/src/library/notehead.lua
+++ b/src/library/notehead.lua
@@ -16,7 +16,7 @@ And for offset (horizontal - left/right):
 
 Note that many of the shapes assumed in this file don't exist in Maestro but only in proper SMuFL fonts.
 
-version cv0.55 2023/01/18
+version cv0.56 2023/02/09
 ]] --
 
 local notehead = {}
@@ -226,6 +226,8 @@ function notehead.change_shape(note, shape)
 
     if shape == "default" then
         notehead_mod:ClearChar()
+        notehead_mod.Resize = 100
+        notehead_mod.HorizontalPos = 0
     else
         local entry = note:GetEntry()
         if not entry then return end -- invalid note supplied


### PR DESCRIPTION
setting `default` character now resets any previously applied size and position changes. (I thought these would have been cleared by the preceding `notehead_mod:EraseAt()` but they aren't.