### PR TITLE
Remove beat charts that are no longer compatible

### DIFF
--- a/src/meter_change.lua
+++ b/src/meter_change.lua
@@ -198,6 +198,20 @@ function set_time(beat_num, beat_duration)
             apply_new_time(selected_item, beat_num, beat_duration)
         end
     end
+    for measure_number, _ in pairs(measures_processed) do
+        local measure = finale.FCMeasure()
+        measure:Load(measure_number)
+        local beat_chart = measure:CreateBeatChartElements()
+        if beat_chart.Count > 0 then
+            if beat_chart:GetItemAt(0).MeasurePos ~= measure:GetDuration() then -- FCBeatChartElement.MeasurePos for element 0 is the total duration of the beat chart 
+                beat_chart:DeleteDataForItem(measure_number)
+                if measure.PositioningNotesMode == finale.POSITIONING_BEATCHART then
+                    measure.PositioningNotesMode = finale.POSITIONING_TIMESIG
+                    measure:Save()
+                end
+            end
+        end
+    end
 end
 
 set_time(numerator, denominators[denominator])


### PR DESCRIPTION
Remove beat charts that are no longer compatible with the new time signatures. This implementation differs slightly from what Finale does:

- Finale replaces the beat chart whereas this code removes them and changes the measure to "Align to Time Signature". However, the visual result is the same because the beat chart Finale substitutes is exactly aligned to the time signature.
- Finale always replaces the beat chart whereas this code only deletes the beat chart if its EDU length differs from the new EDU length of the measure. This means you can switch, e.g., from 2/2 time to 4/4 time without losing your note spacing.

