### PR TITLE
choose first part where the selected staff is visible

### DIFF
--- a/src/UI_switch_to_selected_part.lua
+++ b/src/UI_switch_to_selected_part.lua
@@ -27,7 +27,20 @@ function ui_switch_to_selected_part()
         for part in each(parts) do
             if (not part:IsScore()) and part:IsStaffIncluded(top_cell.Staff) then
                 part_ID = part:GetID()
-                break
+                -- stop searching if the top selected staff is visible on the system of the first selected measure
+                local found_staff = false
+                local part = finale.FCPart(part_ID)
+                part:SwitchTo()
+                local systems = finale.FCStaffSystems()
+                systems:LoadAll()
+                local system = systems:FindMeasureNumber(top_cell.Measure)
+                if system then
+                    local staves = finale.FCSystemStaves()
+                    staves:LoadAllForItem(system.ItemNo)
+                    found_staff = staves:FindStaff(top_cell.Staff) ~= nil
+                end
+                part:SwitchBack()
+                if found_staff then break end
             end
         end
         if part_ID ~= nil then

--- a/src/UI_switch_to_selected_part.lua
+++ b/src/UI_switch_to_selected_part.lua
@@ -1,9 +1,9 @@
 function plugindef()
     finaleplugin.NoStore = true
     finaleplugin.Author = "CJ Garcia"
-    finaleplugin.Copyright = "© 2020 CJ Garcia Music"
-    finaleplugin.Version = "1.2"
-    finaleplugin.Date = "June 12, 2020"
+    finaleplugin.Copyright = "© 2022 CJ Garcia Music"
+    finaleplugin.Version = "1.3"
+    finaleplugin.Date = "February 14, 2022"
     finaleplugin.CategoryTags = "UI"
     return "Switch To Selected Part", "Switch To Selected Part",
            "Switches to the first part of the top staff in a selected region in a score. Switches back to the score if viewing a part."


### PR DESCRIPTION
This PR refines `UI_switch_to_selected_part.lua` as follows:

Previously it selected the first part where the staff in the part. This PR changes it to select the first part where the staff is visible in the part on the selected system.

What this addresses:

Many times a linked part will include one or more staves from other parts that are cue staves. It is often that case that the cue staves are mostly force-hidden and only appear in a very restricted passage. This change allows the script to ignore cue staves as long as they are hidden.
