### PR TITLE
Mixin Update

### DIFF
--- a/src/mixin/FCMControl.lua
+++ b/src/mixin/FCMControl.lua
@@ -56,7 +56,7 @@ Do not disable this method.
 @ window (FCMCustomWindow)
 ]]
 function props:RegisterParent(window)
-    mixin.assert_argument(window, {"FCMCustomWindow", "FCMCustomLuaWindow"}, 2)
+    mixin_helper.assert_argument_type(2, window, "FCMCustomWindow", "FCMCustomLuaWindow")
 
     if parent[self] then
         error("This method is for internal use only.", 2)
@@ -187,10 +187,10 @@ Hooks into control state restoration.
 for method, valid_types in pairs({
     Enable = {"boolean", "nil"},
     Visible = {"boolean", "nil"},
-    Left = "number",
-    Top = "number",
-    Height = "number",
-    Width = "number",
+    Left = {"number"},
+    Top = {"number"},
+    Height = {"number"},
+    Width = {"number"},
 }) do
     props["Get" .. method] = function(self)
         if mixin.FCMControl.UseStoredState(self) then
@@ -201,7 +201,7 @@ for method, valid_types in pairs({
     end
 
     props["Set" .. method] = function(self, value)
-        mixin.assert_argument(value, valid_types, 2)
+        mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         if mixin.FCMControl.UseStoredState(self) then
             private[self][method] = value
@@ -230,7 +230,7 @@ Also hooks into control state restoration.
 : (string)
 ]]
 function props:GetText(str)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     if not str then
         str = temp_str
@@ -256,7 +256,7 @@ Also hooks into control state restoration.
 @ str (FCString|string|number)
 ]]
 function props:SetText(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)
@@ -282,7 +282,7 @@ Do not override or disable this method.
 ]]
 function props:UseStoredState()
     local parent = self:GetParent()
-    return mixin.is_instance_of(parent, "FCMCustomLuaWindow") and parent:GetRestoreControlState() and not parent:WindowExists() and parent:HasBeenShown()
+    return mixin_helper.is_instance_of(parent, "FCMCustomLuaWindow") and parent:GetRestoreControlState() and not parent:WindowExists() and parent:HasBeenShown()
 end
 
 --[[

--- a/src/mixin/FCMCtrlCheckbox.lua
+++ b/src/mixin/FCMCtrlCheckbox.lua
@@ -24,7 +24,7 @@ Ensures that `CheckChange` event is triggered.
 @ checked (number)
 ]]
 function props:SetCheck(checked)
-    mixin.assert_argument(checked, "number", 2)
+    mixin_helper.assert_argument_type(2, checked, "number")
 
     self:SetCheck_(checked)
 

--- a/src/mixin/FCMCtrlDataList.lua
+++ b/src/mixin/FCMCtrlDataList.lua
@@ -25,8 +25,8 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 @ columnwidth (number)
 ]]
 function props:AddColumn(title, columnwidth)
-    mixin.assert_argument(title, {"string", "number", "FCString"}, 2)
-    mixin.assert_argument(columnwidth, "number", 3)
+    mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
+    mixin_helper.assert_argument_type(3, columnwidth, "number")
 
     if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)
@@ -47,8 +47,8 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 @ title (FCString|string|number)
 ]]
 function props:SetColumnTitle(columnindex, title)
-    mixin.assert_argument(columnindex, "number", 2)
-    mixin.assert_argument(title, {"string", "number", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, columnindex, "number")
+    mixin_helper.assert_argument_type(3, title, "string", "number", "FCString")
 
     if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)

--- a/src/mixin/FCMCtrlEdit.lua
+++ b/src/mixin/FCMCtrlEdit.lua
@@ -28,7 +28,7 @@ Ensures that `Change` event is triggered.
 @ str (FCString|string|number)
 ]]
 function props:SetText(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     mixin.FCMControl.SetText(self, str)
     trigger_change(self)
@@ -76,8 +76,8 @@ Also hooks into control state restoration.
 @ value (number)
 ]]
 for method, valid_types in pairs({
-    Integer = "number",
-    Float = "number",
+    Integer = {"number"},
+    Float = {"number"},
 }) do
     props["Get" .. method] = function(self)
         -- This is the long way around, but it ensures that the correct control value is used
@@ -86,7 +86,7 @@ for method, valid_types in pairs({
     end
 
     props["Set" .. method] = function(self, value)
-        mixin.assert_argument(value, valid_types, 2)
+        mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         temp_str["Set" .. method](temp_str, value)
         mixin.FCMControl.SetText(self, temp_str)
@@ -236,30 +236,30 @@ Sets a measurement in 10000ths of an EVPU.
 @ measurementunit (number)
 ]]
 for method, valid_types in pairs({
-    Measurement = "number",
-    MeasurementEfix = "number",
-    MeasurementInteger = "number",
-    Measurement10000th = "number",
+    Measurement = {"number"},
+    MeasurementEfix = {"number"},
+    MeasurementInteger = {"number"},
+    Measurement10000th = {"number"},
 }) do
     props["Get" .. method] = function(self, measurementunit)
-        mixin.assert_argument(measurementunit, "number", 2)
+        mixin_helper.assert_argument_type(2, measurementunit, "number")
 
         mixin.FCMControl.GetText(self, temp_str)
         return temp_str["Get" .. method](temp_str, measurementunit)
     end
 
     props["GetRange" .. method] = function(self, measurementunit, minimum, maximum)
-        mixin.assert_argument(measurementunit, "number", 2)
-        mixin.assert_argument(minimum, "number", 3)
-        mixin.assert_argument(maximum, "number", 4)
+        mixin_helper.assert_argument_type(2, measurementunit, "number")
+        mixin_helper.assert_argument_type(3, minimum, "number")
+        mixin_helper.assert_argument_type(4, maximum, "number")
 
         mixin.FCMControl.GetText(self, temp_str)
         return temp_str["GetRange" .. method](temp_str, measurementunit, minimum, maximum)
     end
 
     props["Set" .. method] = function(self, value, measurementunit)
-        mixin.assert_argument(value, valid_types, 2)
-        mixin.assert_argument(measurementunit, "number", 3)
+        mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
+        mixin_helper.assert_argument_type(3, measurementunit, "number")
 
         temp_str["Set" .. method](temp_str, value, measurementunit)
         mixin.FCMControl.SetText(self, temp_str)
@@ -280,8 +280,8 @@ Fixes issue with decimal places in `minimum` being discarded instead of being co
 : (number)
 ]]
 function props:GetRangeInteger(minimum, maximum)
-    mixin.assert_argument(minimum, "number", 2)
-    mixin.assert_argument(maximum, "number", 3)
+    mixin_helper.assert_argument_type(2, minimum, "number")
+    mixin_helper.assert_argument_type(3, maximum, "number")
 
     return utils.clamp(mixin.FCMCtrlEdit.GetInteger(self), math.ceil(minimum), math.floor(maximum))
 end

--- a/src/mixin/FCMCtrlListBox.lua
+++ b/src/mixin/FCMCtrlListBox.lua
@@ -139,7 +139,7 @@ Also hooks into control state restoration.
 @ index (number)
 ]]
 function props:SetSelectedItem(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     if mixin.FCMControl.UseStoredState(self) then
         private[self].SelectedItem = index
@@ -196,7 +196,7 @@ Checks if there is an item at the specified index.
 : (boolean) `true` if the item exists, `false` if it does not exist.
 ]]
 function props:ItemExists(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     return private[self].Items[index + 1] and true or false
 end
@@ -212,7 +212,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 @ str (FCString|string|number)
 ]]
 function props:AddString(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)
@@ -239,7 +239,7 @@ Adds multiple strings to the list box.
 function props:AddStrings(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
-        mixin.assert_argument(v, {"string", "number", "FCString", "FCStrings"}, i + 1)
+        mixin_helper.assert_argument_type(i + 1, v, "string", "number", "FCString", "FCStrings")
 
         if type(v) == "userdata" and v:ClassName() == "FCStrings" then
             for str in each(v) do
@@ -261,7 +261,7 @@ Returns a copy of all strings in the list box.
 : (table) A table of strings (1-indexed - beware if accessing keys!).
 ]]
 function props:GetStrings(strs)
-    mixin.assert_argument(strs, {"nil", "FCStrings"}, 2)
+    mixin_helper.assert_argument_type(2, strs, "nil", "FCStrings")
 
     if strs then
         strs:ClearAll()
@@ -321,8 +321,8 @@ This method works in all JW/RGP Lua versions and irrespective of whether `InitWi
 : (string)
 ]]
 function props:GetItemText(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"nil", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "nil", "FCString")
 
     if not mixin.FCMCtrlListBox.ItemExists(self, index) then
         error("No item at index " .. tostring(index), 2)
@@ -346,8 +346,8 @@ Sets the text for an item.
 @ str (FCString|string|number)
 ]]
 function props:SetItemText(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
     if not private[self].Items[index + 1] then
         error("No item at index " .. tostring(index), 2)
@@ -393,7 +393,7 @@ Returns the text for the item that is currently selected.
 : (string|nil) `nil` if no item is currently selected.
 ]]
 function props:GetSelectedString(str)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local index = mixin.FCMCtrlListBox.GetSelectedItem(self)
 
@@ -423,7 +423,7 @@ If no match is found, the current selected item will remain selected. Matches ar
 @ str (FCString|string|number)
 ]]
 function props:SetSelectedString(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = type(str) == "userdata" and str.LuaString or tostring(str)
 
@@ -448,8 +448,8 @@ If index is >= Count, will insert at the end.
 @ str (FCString|string|number) The value to insert.
 ]]
 function props:InsertItem(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
     if index < 0 then
         index = 0
@@ -493,7 +493,7 @@ If the currently selected item is deleted, items will be deselected (ie set to -
 @ index (number) 0-based index of item to delete.
 ]]
 function props:DeleteItem(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     if index < 0 or index >= mixin.FCMCtrlListBox.GetCount(self) then
         return

--- a/src/mixin/FCMCtrlPopup.lua
+++ b/src/mixin/FCMCtrlPopup.lua
@@ -142,7 +142,7 @@ Also hooks into control state restoration.
 @ index (number)
 ]]
 function props:SetSelectedItem(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     if mixin.FCMControl.UseStoredState(self) then
         private[self].SelectedItem = index
@@ -187,7 +187,7 @@ Checks if there is an item at the specified index.
 : (boolean) `true` if the item exists, `false` if it does not exist.
 ]]
 function props:ItemExists(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     return private[self].Items[index + 1] and true or false
 end
@@ -204,7 +204,7 @@ Also hooks into control state restoration.
 @ str (FCString|string|number)
 ]]
 function props:AddString(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)
@@ -231,7 +231,7 @@ Adds multiple strings to the popup.
 function props:AddStrings(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
-        mixin.assert_argument(v, {"string", "number", "FCString", "FCStrings"}, i + 1)
+        mixin_helper.assert_argument_type(i + 1, v, "string", "number", "FCString", "FCStrings")
 
         if type(v) == "userdata" and v:ClassName() == "FCStrings" then
             for str in each(v) do
@@ -253,7 +253,7 @@ Returns a copy of all strings in the popup.
 : (table) A table of strings (1-indexed - beware when accessing by key!).
 ]]
 function props:GetStrings(strs)
-    mixin.assert_argument(strs, {"nil", "FCStrings"}, 2)
+    mixin_helper.assert_argument_type(2, strs, "nil", "FCStrings")
 
     if strs then
         strs:ClearAll()
@@ -312,8 +312,8 @@ Returns the text for an item in the popup.
 : (string|nil) `nil` if the item doesn't exist
 ]]
 function props:GetItemText(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"nil", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "nil", "FCString")
 
     if not mixin.FCMCtrlPopup.ItemExists(self, index) then
         error("No item at index " .. tostring(index), 2)
@@ -337,8 +337,8 @@ Sets the text for an item.
 @ str (FCString|string|number)
 ]]
 function props:SetItemText(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
     if not mixin.FCMCtrlPopup.ItemExists(self, index) then
         error("No item at index " .. tostring(index), 2)
@@ -376,7 +376,7 @@ Returns the text for the item that is currently selected.
 : (string|nil) `nil` if no item is currently selected.
 ]]
 function props:GetSelectedString(str)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local index = mixin.FCMCtrlPopup.GetSelectedItem(self)
 
@@ -407,7 +407,7 @@ If no match is found, the current selected item will remain selected. Matching i
 @ str (FCString|string|number)
 ]]
 function props:SetSelectedString(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = type(str) == "userdata" and str.LuaString or tostring(str)
 
@@ -432,8 +432,8 @@ If index is >= Count, will insert at the end.
 @ str (FCString|string|number) The value to insert.
 ]]
 function props:InsertString(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
     if index < 0 then
         index = 0
@@ -477,7 +477,7 @@ If the currently selected item is deleted, items will be deselected (ie set to -
 @ index (number) 0-based index of item to delete.
 ]]
 function props:DeleteItem(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     if index < 0 or index >= mixin.FCMCtrlPopup.GetCount(self) then
         return

--- a/src/mixin/FCMCtrlSlider.lua
+++ b/src/mixin/FCMCtrlSlider.lua
@@ -77,7 +77,7 @@ Ensures that `ThumbPositionChange` event is triggered.
 @ position (number)
 ]]
 function props:SetThumbPosition(position)
-    mixin.assert_argument(position, "number", 2)
+    mixin_helper.assert_argument_type(2, position, "number")
 
     self:SetThumbPosition_(position)
 
@@ -94,7 +94,7 @@ Ensures that `ThumbPositionChange` is triggered.
 @ minvalue (number)
 ]]
 function props:SetMinValue(minvalue)
-    mixin.assert_argument(minvalue, "number", 2)
+    mixin_helper.assert_argument_type(2, minvalue, "number")
 
     self:SetMinValue_(minvalue)
 
@@ -111,7 +111,7 @@ Ensures that `ThumbPositionChange` is triggered.
 @ maxvalue (number)
 ]]
 function props:SetMaxValue(maxvalue)
-    mixin.assert_argument(maxvalue, "number", 2)
+    mixin_helper.assert_argument_type(2, maxvalue, "number")
 
     self:SetMaxValue_(maxvalue)
 

--- a/src/mixin/FCMCtrlStatic.lua
+++ b/src/mixin/FCMCtrlStatic.lua
@@ -8,6 +8,7 @@ Summary of modifications:
 - SetTextColor updates visible color immediately if window is showing
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 
 local private = setmetatable({}, {__mode = "k"})
@@ -38,9 +39,9 @@ Also hooks into control state restoration.
 @ blue (number)
 ]]
 function props:SetTextColor(red, green, blue)
-    mixin.assert_argument(red, "number", 2)
-    mixin.assert_argument(green, "number", 3)
-    mixin.assert_argument(blue, "number", 4)
+    mixin_helper.assert_argument_type(2, red, "number")
+    mixin_helper.assert_argument_type(3, green, "number")
+    mixin_helper.assert_argument_type(4, blue, "number")
 
     private[self].TextColor = {red, green, blue}
 

--- a/src/mixin/FCMCtrlSwitcher.lua
+++ b/src/mixin/FCMCtrlSwitcher.lua
@@ -40,7 +40,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 @ title (FCString|string|number)
 ]]
 function props:AddPage(title)
-    mixin.assert_argument(title, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
 
     if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)
@@ -63,7 +63,7 @@ Adds multiple pages, one page for each argument.
 function props:AddPages(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
-        mixin.assert_argument(v, {"string", "number", "FCString"}, i + 1)
+        mixin_helper.assert_argument_type(i + 1, v, "string", "number", "FCString")
         mixin.FCMCtrlSwitcher.AddPage(self, v)
     end
 end
@@ -79,8 +79,8 @@ Attaches a control to a page.
 : (boolean)
 ]]
 function props:AttachControlByTitle(control, title)
-    -- Given the number of possibilities, control argument is not asserted for now
-    mixin.assert_argument(title, {"string", "number", "FCString"}, 3)
+    mixin_helper.assert_argument_type(2, control, "FCControl", "FCMControl")
+    mixin_helper.assert_argument_type(3, title, "string", "number", "FCString")
 
     title = type(title) == "userdata" and title.LuaString or tostring(title)
 
@@ -91,7 +91,7 @@ function props:AttachControlByTitle(control, title)
         end
     end
 
-    mixin.force_assert(index ~= -1, "No page titled '" .. title .. "'")
+    mixin_helper.force_assert(index ~= -1, "No page titled '" .. title .. "'")
 
     return self:AttachControl_(control, index)
 end
@@ -105,7 +105,7 @@ end
 @ index (number)
 ]]
 function props:SetSelectedPage(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     self:SetSelectedPage_(index)
 
@@ -122,7 +122,7 @@ Set the selected page by its title. If the page is not found, an error will be t
 @ title (FCString|string|number) Title of page to select. Must be an exact match.
 ]]
 function props:SetSelectedPageByTitle(title)
-    mixin.assert_argument(title, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
 
     title = type(title) == "userdata" and title.LuaString or tostring(title)
 
@@ -146,7 +146,7 @@ Returns the title of the currently selected page.
 : (string|nil) Nil if no page is selected
 ]]
 function props:GetSelectedPageTitle(title)
-    mixin.assert_argument(title, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, title, "nil", "FCString")
 
     local index = self:GetSelectedPage_()
     if index == -1 then
@@ -177,8 +177,8 @@ Returns the title of a page.
 : (string)
 ]]
 function props:GetPageTitle(index, str)
-    mixin.assert_argument(index, "number", 2)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, index, "number")
+    mixin_helper.assert_argument_type(3, str, "nil", "FCString")
 
     local text = private[self].Index[index + 1]
     mixin.force_assert(text, "No page at index " .. tostring(index))

--- a/src/mixin/FCMCtrlTree.lua
+++ b/src/mixin/FCMCtrlTree.lua
@@ -7,6 +7,7 @@ Summary of modifications:
 - Methods that accept `FCString` now also accept Lua `string` and `number`.
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
@@ -25,9 +26,9 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 : (FCMTreeNode)
 ]]
 function props:AddNode(parentnode, iscontainer, text)
-    mixin.assert_argument(parentnode, {"nil", "FCTreeNode"}, 2)
-    mixin.assert_argument(iscontainer, "boolean", 3)
-    mixin.assert_argument(text, {"string", "number", "FCString"}, 4)
+    mixin_helper.assert_argument_type(2, parentnode, "nil", "FCTreeNode")
+    mixin_helper.assert_argument_type(3, iscontainer, "boolean")
+    mixin_helper.assert_argument_type(4, text, "string", "number", "FCString")
 
     if not text.ClassName then
         temp_str.LuaString = tostring(text)

--- a/src/mixin/FCMCtrlUpDown.lua
+++ b/src/mixin/FCMCtrlUpDown.lua
@@ -49,9 +49,9 @@ end
 : (boolean) `true` on success
 ]]
 function props:ConnectIntegerEdit(control, minvalue, maxvalue)
-    mixin.assert_argument(control, "FCMCtrlEdit", 2)
-    mixin.assert_argument(minvalue, "number", 3)
-    mixin.assert_argument(maxvalue, "number", 4)
+    mixin_helper.assert_argument_type(2, control, "FCMCtrlEdit")
+    mixin_helper.assert_argument_type(3, minvalue, "number")
+    mixin_helper.assert_argument_type(4, maxvalue, "number")
 
     local ret = self:ConnectIntegerEdit_(control, minvalue, maxvalue)
 
@@ -74,9 +74,9 @@ end
 : (boolean) `true` on success
 ]]
 function props:ConnectMeasurementEdit(control, minvalue, maxvalue)
-    mixin.assert_argument(control, "FCMCtrlEdit", 2)
-    mixin.assert_argument(minvalue, "number", 3)
-    mixin.assert_argument(maxvalue, "number", 4)
+    mixin_helper.assert_argument_type(2, control, "FCMCtrlEdit")
+    mixin_helper.assert_argument_type(3, minvalue, "number")
+    mixin_helper.assert_argument_type(4, maxvalue, "number")
 
     local ret = self:ConnectMeasurementEdit_(control, minvalue, maxvalue)
 

--- a/src/mixin/FCMCustomLuaWindow.lua
+++ b/src/mixin/FCMCustomLuaWindow.lua
@@ -64,19 +64,19 @@ end
 local function create_handle_methods(event)
     -- Check if methods are available
     props["Register" .. event] = function(self, callback)
-        mixin.assert_argument(callback, "function", 2)
+        mixin_helper.assert_argument_type(2, callback, "function")
 
         private[self][event].Registered = callback
     end
 
     props["Add" .. event] = function(self, callback)
-        mixin.assert_argument(callback, "function", 2)
+        mixin_helper.assert_argument_type(2, callback, "function")
 
         table.insert(private[self][event].Added, callback)
     end
 
     props["Remove" .. event] = function(self, callback)
-        mixin.assert_argument(callback, "function", 2)
+        mixin_helper.assert_argument_type(2, callback, "function")
 
         utils.table_remove_first(private[self][event].Added, callback)
     end
@@ -568,7 +568,7 @@ The callback will not be passed any arguments.
 @ callback (function)
 ]]
 function props:QueueHandleCustom(callback)
-    mixin.assert_argument(callback, "function", 2)
+    mixin_helper.assert_argument_type(2, callback, "function")
 
     table.insert(private[self].HandleCustomQueue, callback)
 end
@@ -589,7 +589,8 @@ Override Changes:
 @ callback (function) See `FCCustomLuaWindow.HandleControlEvent` in the PDK for callback signature.
 ]]
     function props:RegisterHandleControlEvent(control, callback)
-        mixin.assert_argument(callback, "function", 3)
+        mixin_helper.assert_argument_type(2, control, "FCControl", "FCMControl")
+        mixin_helper.assert_argument_type(3, callback, "function")
 
         if not self:RegisterHandleControlEvent_(control, function(ctrl)
             callback(self:FindControl(ctrl:GetControlID()))
@@ -625,7 +626,7 @@ Override Changes:
 @ callback (function) See `HandleTimer` for callback signature (note the change in arguments).
 ]]
     function props:RegisterHandleTimer(callback)
-        mixin.assert_argument(callback, "function", 2)
+        mixin_helper.assert_argument_type(2, callback, "function")
 
         private[self].HandleTimer.Registered = callback
     end
@@ -643,8 +644,8 @@ If a handler is added for a timer that hasn't been set, the timer ID will no lon
 @ callback (function) See `HandleTimer` for callback signature.
 ]]
     function props:AddHandleTimer(timerid, callback)
-        mixin.assert_argument(timerid, "number", 2)
-        mixin.assert_argument(callback, "function", 3)
+        mixin_helper.assert_argument_type(2, timerid, "number")
+        mixin_helper.assert_argument_type(3, callback, "function")
 
         private[self].HandleTimer[timerid] = private[self].HandleTimer[timerid] or {}
 
@@ -663,8 +664,8 @@ Removes a handler added with `AddHandleTimer`.
 @ callback (function)
 ]]
     function props:RemoveHandleTimer(timerid, callback)
-        mixin.assert_argument(timerid, "number", 2)
-        mixin.assert_argument(callback, "function", 3)
+        mixin_helper.assert_argument_type(2, timerid, "number")
+        mixin_helper.assert_argument_type(3, callback, "function")
 
         if not private[self].HandleTimer[timerid] then
             return
@@ -686,8 +687,8 @@ Override Changes:
 @ msinterval (number)
 ]]
     function props:SetTimer(timerid, msinterval)
-        mixin.assert_argument(timerid, "number", 2)
-        mixin.assert_argument(msinterval, "number", 3)
+        mixin_helper.assert_argument_type(2, timerid, "number")
+        mixin_helper.assert_argument_type(3, msinterval, "number")
 
         self:SetTimer_(timerid, msinterval)
 
@@ -724,7 +725,7 @@ Sets a timer using the next available ID (according to `GetNextTimerID`) and ret
 : (number) The ID of the newly created timer.
 ]]
     function props:SetNextTimer(msinterval)
-        mixin.assert_argument(msinterval, "number", 2)
+        mixin_helper.assert_argument_type(2, msinterval, "number")
 
         local timerid = mixin.FCMCustomLuaWindow.GetNextTimerID(self)
         mixin.FCMCustomLuaWindow.SetTimer(self, timerid, msinterval)
@@ -747,7 +748,7 @@ This is disabled by default.
 @ enabled (boolean)
 ]]
     function props:SetEnableAutoRestorePosition(enabled)
-        mixin.assert_argument(enabled, "boolean", 2)
+        mixin_helper.assert_argument_type(2, enabled, "boolean")
 
         private[self].EnableAutoRestorePosition = enabled
     end
@@ -781,10 +782,10 @@ Override Changes:
 @ height (number)
 ]]
     function props:SetRestorePositionData(x, y, width, height)
-        mixin.assert_argument(x, "number", 2)
-        mixin.assert_argument(y, "number", 3)
-        mixin.assert_argument(width, "number", 4)
-        mixin.assert_argument(height, "number", 5)
+        mixin_helper.assert_argument_type(2, x, "number")
+        mixin_helper.assert_argument_type(3, y, "number")
+        mixin_helper.assert_argument_type(4, width, "number")
+        mixin_helper.assert_argument_type(5, height, "number")
 
         self:SetRestorePositionOnlyData_(x, y, width, height)
 
@@ -807,8 +808,8 @@ Override Changes:
 @ y (number)
 ]]
     function props:SetRestorePositionOnlyData(x, y)
-        mixin.assert_argument(x, "number", 2)
-        mixin.assert_argument(y, "number", 3)
+        mixin_helper.assert_argument_type(2, x, "number")
+        mixin_helper.assert_argument_type(3, y, "number")
 
         self:SetRestorePositionOnlyData_(x, y)
 
@@ -832,7 +833,7 @@ This is disabled by default.
 @ enabled (boolean)
 ]]
 function props:SetEnableDebugClose(enabled)
-    mixin.assert_argument(enabled, "boolean", 2)
+    mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].EnableDebugClose = enabled and true or false
 end
@@ -861,7 +862,7 @@ This is disabled by default.
 @ enabled (boolean) `true` to enable, `false` to disable.
 ]]
 function props:SetRestoreControlState(enabled)
-    mixin.assert_argument(enabled, "boolean", 2)
+    mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].RestoreControlState = enabled and true or false
 end
@@ -904,7 +905,7 @@ Override Changes:
 : (number)
 ]]
 function props:ExecuteModal(parent)
-  if mixin.is_instance_of(parent, "FCMCustomLuaWindow") and private[self].UseParentMeasurementUnit then
+    if mixin_helper.is_instance_of(parent, "FCMCustomLuaWindow") and private[self].UseParentMeasurementUnit then
         self:SetMeasurementUnit(parent:GetMeasurementUnit())
     end
 
@@ -998,7 +999,7 @@ All controls that have an `UpdateMeasurementUnit` method will have that method c
 @ unit (number) One of the finale MEASUREMENTUNIT constants.
 ]]
 function props:SetMeasurementUnit(unit)
-    mixin.assert_argument(unit, "number", 2)
+    mixin_helper.assert_argument_type(2, unit, "number")
 
     if unit == private[self].MeasurementUnit then
         return
@@ -1058,7 +1059,7 @@ Sets whether to use the parent window's measurement unit when opening this windo
 @ enabled (boolean)
 ]]
 function props:SetUseParentMeasurementUnit(enabled)
-    mixin.assert_argument(enabled, "boolean", 2)
+    mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].UseParentMeasurementUnit = enabled and true or false
 end
@@ -1121,9 +1122,9 @@ Creates an `FCXCtrlMeasurementEdit` control.
 : (FCXCtrlMeasurementEdit)
 ]]
 function props:CreateMeasurementEdit(x, y, control_name)
-    mixin.assert_argument(x, "number", 2)
-    mixin.assert_argument(y, "number", 3)
-    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+    mixin_helper.assert_argument_type(2, x, "number")
+    mixin_helper.assert_argument_type(3, y, "number")
+    mixin_helper.assert_argument_type(4, control_name, "string", "nil")
 
     local edit = mixin.FCMCustomWindow.CreateEdit(self, x, y, control_name)
     return mixin.subclass(edit, "FCXCtrlMeasurementEdit")
@@ -1141,9 +1142,9 @@ Creates a popup which allows the user to change the window's measurement unit.
 : (FCXCtrlMeasurementUnitPopup)
 ]]
 function props:CreateMeasurementUnitPopup(x, y, control_name)
-    mixin.assert_argument(x, "number", 2)
-    mixin.assert_argument(y, "number", 3)
-    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+    mixin_helper.assert_argument_type(2, x, "number")
+    mixin_helper.assert_argument_type(3, y, "number")
+    mixin_helper.assert_argument_type(4, control_name, "string", "nil")
 
     local popup = mixin.FCMCustomWindow.CreatePopup(self, x, y, control_name)
     return mixin.subclass(popup, "FCXCtrlMeasurementUnitPopup")
@@ -1161,9 +1162,9 @@ Creates a popup which allows the user to select a page size.
 : (FCXCtrlPageSizePopup)
 ]]
 function props:CreatePageSizePopup(x, y, control_name)
-    mixin.assert_argument(x, "number", 2)
-    mixin.assert_argument(y, "number", 3)
-    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+    mixin_helper.assert_argument_type(2, x, "number")
+    mixin_helper.assert_argument_type(3, y, "number")
+    mixin_helper.assert_argument_type(4, control_name, "string", "nil")
 
     local popup = mixin.FCMCustomWindow.CreatePopup(self, x, y, control_name)
     return mixin.subclass(popup, "FCXCtrlPageSizePopup")

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -9,6 +9,7 @@ Summary of modifications:
 - Added `Each` method for iterating over controls by class name.
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local private = setmetatable({}, {__mode = "k"})
 local props = {}
@@ -53,7 +54,7 @@ Add optional `control_name` parameter.
 -- Also adds an optional parameter at the end for a control name
 for _, f in ipairs({"CancelButton", "OkButton"}) do
     props["Create" .. f] = function(self, control_name)
-        mixin.assert_argument(control_name, {"string", "nil", "FCString"}, 2)
+        mixin_helper.assert_argument_type(2, control_name, "string", "nil", "FCString")
 
         local control = self["Create" .. f .. "_"](self)
         private[self].Controls[control:GetControlID()] = control
@@ -221,9 +222,9 @@ for _, f in ipairs(
         "Button", "Checkbox", "DataList", "Edit", "ListBox", "Popup", "Slider", "Static", "Switcher", "Tree", "UpDown",
     }) do
     props["Create" .. f] = function(self, x, y, control_name)
-        mixin.assert_argument(x, "number", 2)
-        mixin.assert_argument(y, "number", 3)
-        mixin.assert_argument(control_name, {"string", "nil", "FCString"}, 4)
+        mixin_helper.assert_argument_type(2, x, "number")
+        mixin_helper.assert_argument_type(3, y, "number")
+        mixin_helper.assert_argument_type(4, control_name, "string", "nil", "FCString")
 
         local control = self["Create" .. f .. "_"](self, x, y)
         private[self].Controls[control:GetControlID()] = control
@@ -273,10 +274,10 @@ Add optional `control_name` parameter.
 
 for _, f in ipairs({"HorizontalLine", "VerticalLine"}) do
     props["Create" .. f] = function(self, x, y, length, control_name)
-        mixin.assert_argument(x, "number", 2)
-        mixin.assert_argument(y, "number", 3)
-        mixin.assert_argument(length, "number", 4)
-        mixin.assert_argument(control_name, {"string", "nil", "FCString"}, 5)
+        mixin_helper.assert_argument_type(2, x, "number")
+        mixin_helper.assert_argument_type(3, y, "number")
+        mixin_helper.assert_argument_type(4, length, "number")
+        mixin_helper.assert_argument_type(5, control_name, "string", "nil", "FCString")
 
         local control = self["Create" .. f .. "_"](self, x, y, length)
         private[self].Controls[control:GetControlID()] = control
@@ -307,7 +308,7 @@ Finds a control based on its ID.
 : (FCMControl|nil)
 ]]
 function props:FindControl(control_id)
-    mixin.assert_argument(control_id, "number", 2)
+    mixin_helper.assert_argument_type(2, control_id, "number")
 
     return private[self].Controls[control_id]
 end
@@ -322,7 +323,8 @@ Finds a control based on its name.
 : (FCMControl|nil)
 ]]
 function props:GetControl(control_name)
-    mixin.assert_argument(control_name, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, control_name, "string", "FCString")
+
     return private[self].NamedControls[control_name]
 end
 
@@ -342,7 +344,7 @@ function props:Each(class_filter)
         repeat
             i = i + 1
             v = mixin.FCMCustomWindow.GetItemAt(self, i)
-        until not v or not class_filter or mixin.is_instance_of(v, class_filter)
+        until not v or not class_filter or mixin_helper.is_instance_of(v, class_filter)
 
         return v
     end
@@ -379,9 +381,9 @@ Add optional `control_name` parameter.
 ]]
 if finenv.MajorVersion > 0 or finenv.MinorVersion >= 56 then
     function props.CreateCloseButton(self, x, y, control_name)
-        mixin.assert_argument(x, "number", 2)
-        mixin.assert_argument(y, "number", 3)
-        mixin.assert_argument(control_name, {"string", "nil", "FCString"}, 4)
+        mixin_helper.assert_argument_type(2, x, "number")
+        mixin_helper.assert_argument_type(3, y, "number")
+        mixin_helper.assert_argument_type(4, control_name, "string", "nil", "FCString")
 
         local control = self:CreateCloseButton_(x, y)
         private[self].Controls[control:GetControlID()] = control

--- a/src/mixin/FCMNoteEntry.lua
+++ b/src/mixin/FCMNoteEntry.lua
@@ -7,6 +7,7 @@ Summary of modifications:
 - Added methods to keep parent collection in scope
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local private = setmetatable({}, {__mode = "k"})
 local props = {}
@@ -32,7 +33,7 @@ Registers the collection to which this object belongs.
 @ parent (FCNoteEntryCell)
 ]]
 function props:RegisterParent(parent)
-    mixin.assert_argument(parent, 'FCNoteEntryCell', 2)
+    mixin_helper.assert_argument_type(2, parent, "FCNoteEntryCell")
 
     if not private[self].Parent then
         private[self].Parent = parent

--- a/src/mixin/FCMNoteEntryCell.lua
+++ b/src/mixin/FCMNoteEntryCell.lua
@@ -8,6 +8,7 @@ Summary of modifications:
 ]] --
 
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
@@ -23,7 +24,7 @@ This allows the item to be used outside of a `mixin.eachentry` loop.
 : (FCMNoteEntry|nil)
 ]]
 function props:GetItemAt(index)
-    mixin.assert_argument(index, "number", 2)
+    mixin_helper.assert_argument_type(2, index, "number")
 
     local item = self:GetItemAt_(index)
     if item then

--- a/src/mixin/FCMPage.lua
+++ b/src/mixin/FCMPage.lua
@@ -8,6 +8,7 @@ Summary of modifications:
 - Added method for checking if the page is blank.
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 local page_size = require("library.page_size")
 
 local props = {}
@@ -34,8 +35,8 @@ Sets the dimensions of this page to match the given size. Page orientation will 
 @ size (string) A defined page size.
 ]]
 function props:SetSize(size)
-    mixin.assert_argument(size, "string", 2)
-    mixin.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
+    mixin_helper.assert_argument_type(2, size, "string")
+    mixin_helper.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
 
     page_size.set_page_size(self, size)
 end

--- a/src/mixin/FCMString.lua
+++ b/src/mixin/FCMString.lua
@@ -11,6 +11,7 @@ Summary of modifications:
 - Added `*Measurement10000th` methods for setting and retrieving values in 10,000ths of an EVPU (eg for piano brace settings, slur tip width, etc)
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 local measurement = require("library.measurement")
 
@@ -53,7 +54,7 @@ Also changes handling of overrides to match the behaviour of `FCCtrlEdit` on Win
 : (number) EVPUs with decimal part.
 ]]
 function props:GetMeasurement(measurementunit)
-    mixin.assert_argument(measurementunit, "number", 2)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     -- Normalise decimal separator
     local value = string.gsub(self.LuaString, "%" .. mixin.UI():GetDecimalSeparator(), '.')
@@ -126,9 +127,9 @@ See `FCMString.GetMeasurement`.
 : (number)
 ]]
 function props:GetRangeMeasurement(measurementunit, minimum, maximum)
-    mixin.assert_argument(measurementunit, "number", 2)
-    mixin.assert_argument(minimum, "number", 3)
-    mixin.assert_argument(maximum, "number", 4)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
+    mixin_helper.assert_argument_type(3, minimum, "number")
+    mixin_helper.assert_argument_type(4, maximum, "number")
 
     return utils.clamp(mixin.FCMString.GetMeasurement(measurementunit), minimum, maximum)
 end
@@ -145,8 +146,8 @@ Emulates the behaviour of `FCCtrlEdit.SetMeasurement` on Windows while the windo
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT_*` constants.
 ]]
 function props:SetMeasurement(value, measurementunit)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(measurementunit, "number", 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, measurementunit, "number")
 
     if measurementunit == finale.MEASUREMENTUNIT_PICAS then
         local whole = math.floor(value / 48)
@@ -182,7 +183,7 @@ Returns the measurement in whole EVPUs.
 : (number)
 ]]
 function props:GetMeasurementInteger(measurementunit)
-    mixin.assert_argument(measurementunit, "number", 2)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit))
 end
@@ -200,9 +201,9 @@ Also ensures that any decimal places in `minimum` are correctly taken into accou
 : (number)
 ]]
 function props:GetRangeMeasurementInteger(measurementunit, minimum, maximum)
-    mixin.assert_argument(measurementunit, "number", 2)
-    mixin.assert_argument(minimum, "number", 3)
-    mixin.assert_argument(maximum, "number", 4)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
+    mixin_helper.assert_argument_type(3, minimum, "number")
+    mixin_helper.assert_argument_type(4, maximum, "number")
 
     return utils.clamp(mixin.FCMString.GetMeasurementInteger(measurementunit), math.ceil(minimum), math.floor(maximum))
 end
@@ -218,8 +219,8 @@ Sets a measurement in whole EVPUs.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
 function props:SetMeasurementInteger(value, measurementunit)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(measurementunit, "number", 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, measurementunit, "number")
 
     mixin.FCMString.SetMeasurement(self, utils.round(value), measurementunit)
 end
@@ -234,7 +235,7 @@ Returns the measurement in whole EFIXes (1/64th of an EVPU)
 : (number)
 ]]
 function props:GetMeasurementEfix(measurementunit)
-    mixin.assert_argument(measurementunit, "number", 2)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit) * 64)
 end
@@ -251,9 +252,9 @@ Returns the measurement in whole EFIXes (1/64th of an EVPU), clamped between two
 : (number)
 ]]
 function props:GetRangeMeasurementEfix(measurementunit, minimum, maximum)
-    mixin.assert_argument(measurementunit, "number", 2)
-    mixin.assert_argument(minimum, "number", 3)
-    mixin.assert_argument(maximum, "number", 4)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
+    mixin_helper.assert_argument_type(3, minimum, "number")
+    mixin_helper.assert_argument_type(4, maximum, "number")
 
     return utils.clamp(mixin.FCMString.GetMeasurementEfix(measurementunit), math.ceil(minimum), math.floor(maximum))
 end
@@ -269,8 +270,8 @@ Sets a measurement in whole EFIXes.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
 function props:SetMeasurementEfix(value, measurementunit)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(measurementunit, "number", 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, measurementunit, "number")
 
     mixin.FCMString.SetMeasurement(self, utils.round(value) / 64, measurementunit)
 end
@@ -285,7 +286,7 @@ Returns the measurement in 10,000ths of an EVPU.
 : (number)
 ]]
 function props:GetMeasurement10000th(measurementunit)
-    mixin.assert_argument(measurementunit, "number", 2)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit) * 10000)
 end
@@ -303,9 +304,9 @@ Also ensures that any decimal places in `minimum` are handled correctly instead 
 : (number)
 ]]
 function props:GetRangeMeasurement10000th(measurementunit, minimum, maximum)
-    mixin.assert_argument(measurementunit, "number", 2)
-    mixin.assert_argument(minimum, "number", 3)
-    mixin.assert_argument(maximum, "number", 4)
+    mixin_helper.assert_argument_type(2, measurementunit, "number")
+    mixin_helper.assert_argument_type(3, minimum, "number")
+    mixin_helper.assert_argument_type(4, maximum, "number")
 
     return utils.clamp(mixin.FCMString.GetMeasurement10000th(self, measurementunit), math.ceil(minimum), math.floor(maximum))
 end
@@ -321,8 +322,8 @@ Sets a measurement in 10,000ths of an EVPU.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
 function props:SetMeasurement10000th(value, measurementunit)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(measurementunit, "number", 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, measurementunit, "number")
 
     mixin.FCMString.SetMeasurement(self, utils.round(value) / 10000, measurementunit)
 end

--- a/src/mixin/FCMStrings.lua
+++ b/src/mixin/FCMStrings.lua
@@ -8,6 +8,7 @@ Summary of modifications:
 - Setters that accept `FCStrings` now also accept multiple arguments of `FCString`, Lua `string`, or `number`.
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 local library = require("library.general_library")
 
 local props = {}
@@ -25,7 +26,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 : (boolean) True on success.
 ]]
 function props:AddCopy(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)
@@ -48,7 +49,7 @@ Same as `AddCopy`, but accepts multiple arguments so that multiple strings can b
 function props:AddCopies(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
-        mixin.assert_argument(v, {"FCStrings", "FCString", "string", "number"}, i + 1)
+        mixin_helper.assert_argument_type(i + 1, v, "FCStrings", "FCString", "string", "number")
         if type(v) == "userdata" and v:ClassName() == "FCStrings" then
             for str in each(v) do
                 v:AddCopy_(str)
@@ -74,7 +75,7 @@ Accepts multiple arguments.
 function props:CopyFrom(...)
     local num_args = select("#", ...)
     local first = select(1, ...)
-    mixin.assert_argument(first, {"FCStrings", "FCString", "string", "number"}, 2)
+    mixin_helper.assert_argument_type(2, first, "FCStrings", "FCString", "string", "number")
 
     if library.is_finale_object(first) and first:ClassName() == "FCStrings" then
         self:CopyFrom_(first)
@@ -85,7 +86,7 @@ function props:CopyFrom(...)
 
     for i = 2, num_args do
         local v = select(i, ...)
-        mixin.assert_argument(v, {"FCStrings", "FCString", "string", "number"}, i + 1)
+        mixin_helper.assert_argument_type(i + 1, v, "FCStrings", "FCString", "string", "number")
 
         if type(v) == "userdata" then
             if v:ClassName() == "FCString" then
@@ -115,7 +116,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 : (FCMString|nil)
 ]]
 function props:Find(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)
@@ -136,7 +137,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 : (FCMString|nil)
 ]]
 function props:FindNocase(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)
@@ -157,7 +158,7 @@ Accepts Lua `string` in addition to `FCString`.
 : (boolean) True on success.
 ]]
 function props:LoadFolderFiles(folderstring)
-    mixin.assert_argument(folderstring, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, folderstring, "string", "FCString")
 
     if type(folderstring) ~= "userdata" then
         temp_str.LuaString = tostring(folderstring)
@@ -178,7 +179,7 @@ Accepts Lua `string` in addition to `FCString`.
 : (boolean) True on success.
 ]]
 function props:LoadSubfolders(folderstring)
-    mixin.assert_argument(folderstring, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, folderstring, "string", "FCString")
 
     if type(folderstring) ~= "userdata" then
         temp_str.LuaString = tostring(folderstring)
@@ -200,8 +201,8 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 ]]
 if finenv.MajorVersion > 0 or finenv.MinorVersion >= 59 then
     function props:InsertStringAt(str, index)
-        mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
-        mixin.assert_argument(index, "number", 3)
+        mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
+        mixin_helper.assert_argument_type(3, index, "number")
 
         if type(str) ~= "userdata" then
             temp_str.LuaString = tostring(str)

--- a/src/mixin/FCMTextExpressionDef.lua
+++ b/src/mixin/FCMTextExpressionDef.lua
@@ -34,7 +34,7 @@ Override Changes:
 ]]
 
 function public:SaveNewTextBlock(str)
-    mixin.assert_argument(str, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
     mixin_helper.boolean_to_error(self, "SaveNewTextBlock", str)
@@ -53,7 +53,7 @@ Override Changes:
 ]]
 
 function public:AssignToCategory(cat_def)
-    mixin.assert_argument(cat_def, "FCCategoryDef", 2)
+    mixin_helper.assert_argument_type(2, cat_def, "FCCategoryDef")
 
     mixin_helper.boolean_to_error(self, "AssignToCategory", cat_def)
 end
@@ -71,7 +71,7 @@ Override Changes:
 ]]
 
 function public:SetUseCategoryPos(enable)
-    mixin.assert_argument(enable, "boolean", 2)
+    mixin_helper.assert_argument_type(2, enable, "boolean")
 
     mixin_helper.boolean_to_error(self, "SetUseCategoryPos", enable)
 end
@@ -89,7 +89,7 @@ Override Changes:
 ]]
 
 function public:SetUseCategoryFont(enable)
-    mixin.assert_argument(enable, "boolean", 2)
+    mixin_helper.assert_argument_type(2, enable, "boolean")
 
     mixin_helper.boolean_to_error(self, "SetUseCategoryFont", enable)
 end
@@ -118,10 +118,10 @@ function public:MakeRehearsalMark(str, measure)
         str = temp_str
         do_return = true
     else
-        mixin.assert_argument(str, "FCString", 2)
+        mixin_helper.assert_argument_type(2, str, "FCString")
     end
 
-    mixin.assert_argument(measure, "number", do_return and 2 or 3)
+    mixin_helper.assert_argument_type(do_return and 2 or 3, measure, "number")
 
     mixin_helper.boolean_to_error(self, "MakeRehearsalMark", str, measure)
 
@@ -144,7 +144,7 @@ Override Changes:
 ]]
 
 function public:SaveTextString(str)
-    mixin.assert_argument(str, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
     mixin_helper.boolean_to_error(self, "SaveTextString", str)
@@ -180,7 +180,7 @@ Override Changes:
 ]]
 
 function public:SetDescription(str)
-    mixin.assert_argument(str, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
     self:SetDescription_(str)
@@ -200,7 +200,7 @@ Override Changes:
 ]]
 
 function public:GetDescription(str)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local do_return = not str
     str = str or temp_str
@@ -224,7 +224,7 @@ Override Changes:
 ]]
 
 function public:DeepSaveAs(item_num)
-    mixin.assert_argument(item_num, "number", 2)
+    mixin_helper.assert_argument_type(2, item_num, "number")
 
     mixin_helper.boolean_to_error(self, "DeepSaveAs", item_num)
 end

--- a/src/mixin/FCMTreeNode.lua
+++ b/src/mixin/FCMTreeNode.lua
@@ -8,6 +8,7 @@ Summary of modifications:
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
@@ -24,7 +25,7 @@ Returns a Lua `string` and makes passing an `FCString` optional.
 : (string)
 ]]
 function props:GetText(str)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     if not str then
         str = temp_str
@@ -45,7 +46,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 @ str (FCString|string|number)
 ]]
 function props:SetText(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     if type(str) ~= "userdata" then
         temp_str.LuaString = tostring(str)

--- a/src/mixin/FCMUI.lua
+++ b/src/mixin/FCMUI.lua
@@ -7,6 +7,7 @@ Summary of modifications:
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
@@ -23,7 +24,7 @@ Returns a Lua `string` and makes passing an `FCString` optional.
 : (string)
 ]]
 function props:GetDecimalSeparator(str)
-    mixin.assert_argument(str, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     if not str then
         str = temp_str

--- a/src/mixin/FCXCtrlMeasurementEdit.lua
+++ b/src/mixin/FCXCtrlMeasurementEdit.lua
@@ -65,7 +65,7 @@ end
 ]]
 function props:Init()
     local parent = self:GetParent()
-    mixin.assert(mixin.is_instance_of(parent, "FCXCustomLuaWindow"), "FCXCtrlMeasurementEdit must have a parent window that is an instance of FCXCustomLuaWindow")
+    mixin_helper.assert(function() return mixin_helper.is_instance_of(parent, "FCXCustomLuaWindow") end, "FCXCtrlMeasurementEdit must have a parent window that is an instance of FCXCustomLuaWindow")
 
     private[self] = private[self] or {
         Type = "MeasurementInteger",
@@ -107,11 +107,11 @@ Ensures that the overridden `Change` event is triggered.
 
 for method, valid_types in pairs({
     Text = {"string", "number", "FCString"},
-    Integer = "number",
-    Float = "number",
+    Integer = {"number"},
+    Float = {"number"},
 }) do
     props["Set" .. method] = function(self, value)
-        mixin.assert_argument(value, valid_types, 2)
+        mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         mixin.FCMCtrlEdit["Set" .. method](self, value)
         trigger_change(self)
@@ -340,10 +340,10 @@ This means that the getters & setters used in events, measurement unit changes, 
 ]]
 
 for method, valid_types in pairs({
-    Measurement = "number",
-    MeasurementInteger = "number",
-    MeasurementEfix = "number",
-    Measurement10000th = "number",
+    Measurement = {"number"},
+    MeasurementInteger = {"number"},
+    MeasurementEfix = {"number"},
+    Measurement10000th = {"number"},
 }) do
     props["Get" .. method] = function(self)
         local text = mixin.FCMCtrlEdit.GetText(self)
@@ -356,8 +356,8 @@ for method, valid_types in pairs({
     end
 
     props["GetRange" .. method] = function(self, minimum, maximum)
-        mixin.assert_argument(minimum, "number", 2)
-        mixin.assert_argument(maximum, "number", 3)
+        mixin_helper.assert_argument_type(2, minimum, "number")
+        mixin_helper.assert_argument_type(3, maximum, "number")
 
         minimum = method ~= "Measurement" and math.ceil(minimum) or minimum
         maximum = method ~= "Measurement" and math.floor(maximum) or maximum
@@ -365,7 +365,7 @@ for method, valid_types in pairs({
     end
 
     props["Set" .. method] = function (self, value)
-        mixin.assert_argument(value, valid_types, 2)
+        mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         private[self].Value = convert_type(value, method, private[self].Type)
         mixin.FCMCtrlEdit["Set" .. private[self].Type](self, private[self].Value, private[self].LastMeasurementUnit)

--- a/src/mixin/FCXCtrlMeasurementUnitPopup.lua
+++ b/src/mixin/FCXCtrlMeasurementUnitPopup.lua
@@ -55,7 +55,7 @@ mixin_helper.disable_methods(
 @ self (FCXCtrlMeasurementUnitPopup)
 ]]
 function props:Init()
-    mixin.assert(mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"), "FCXCtrlMeasurementUnitPopup must have a parent window that is an instance of FCXCustomLuaWindow")
+    mixin_helper.assert(function() return mixin_helper.is_instance_of(self:GetParent(), "FCXCustomLuaWindow") end, "FCXCtrlMeasurementUnitPopup must have a parent window that is an instance of FCXCustomLuaWindow")
 
     for _, v in ipairs(unit_order) do
         mixin.FCMCtrlPopup.AddString(self, measurement.get_unit_name(v))

--- a/src/mixin/FCXCtrlPageSizePopup.lua
+++ b/src/mixin/FCXCtrlPageSizePopup.lua
@@ -45,7 +45,7 @@ mixin_helper.disable_methods(props, "Clear", "AddString", "AddStrings", "SetStri
     "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange", "RemoveHandleSelectionChange")
 
 local function repopulate(control)
-    local unit = mixin.is_instance_of(control:GetParent(), "FCXCustomLuaWindow") and control:GetParent():GetMeasurementUnit() or measurement.get_real_default_unit()
+    local unit = mixin_helper.is_instance_of(control:GetParent(), "FCXCustomLuaWindow") and control:GetParent():GetMeasurementUnit() or measurement.get_real_default_unit()
 
     if private[control].LastUnit == unit then
         return
@@ -111,9 +111,9 @@ Sets the selected page size. Must be a valid page size.
 @ size (FCString|string)
 ]]
 function props:SetSelectedPageSize(size)
-    mixin.assert_argument(size, {"string", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, size, "string", "FCString")
     size = type(size) == "userdata" and size.LuaString or tostring(size)
-    mixin.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
+    mixin_helper.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
 
     local index = 0
     for s in page_size.pairs() do

--- a/src/mixin/FCXCtrlStatic.lua
+++ b/src/mixin/FCXCtrlStatic.lua
@@ -10,6 +10,7 @@ Summary of changes:
 - Added methods for setting and displaying measurements
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 local measurement = require("library.measurement")
 local utils = require("library.utils")
 
@@ -36,7 +37,7 @@ end
 @ self (FCXCtrlStatic)
 ]]
 function props:Init()
-    mixin.assert(mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"), "FCXCtrlStatic must have a parent window that is an instance of FCXCustomLuaWindow")
+    mixin_helper.assert(function() return mixin_helper.is_instance_of(self:GetParent(), "FCXCustomLuaWindow") end, "FCXCtrlStatic must have a parent window that is an instance of FCXCustomLuaWindow")
 
     private[self] = private[self] or {
         ShowMeasurementSuffix = true,
@@ -54,7 +55,7 @@ Switches the control's measurement status off.
 @ str (FCString|string|number)
 ]]
 function props:SetText(str)
-    mixin.assert_argument(str, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     mixin.FCMCtrlStatic.SetText(self, str)
 
@@ -72,7 +73,7 @@ Sets a measurement in EVPUs which will be displayed in the parent window's curre
 @ value (number) Value in EVPUs
 ]]
 function props:SetMeasurement(value)
-    mixin.assert_argument(value, "number", 2)
+    mixin_helper.assert_argument_type(2, value, "number")
 
     local unit = self:GetParent():GetMeasurementUnit()
     temp_str:SetMeasurement(value, unit)
@@ -94,7 +95,7 @@ Sets a measurement in whole EVPUs which will be displayed in the parent window's
 @ value (number) Value in whole EVPUs (fractional part will be rounded to nearest integer)
 ]]
 function props:SetMeasurementInteger(value)
-    mixin.assert_argument(value, "number", 2)
+    mixin_helper.assert_argument_type(2, value, "number")
 
     value = utils.round(value)
     local unit = self:GetParent():GetMeasurementUnit()
@@ -117,7 +118,7 @@ Sets a measurement in EFIXes which will be displayed in the parent window's curr
 @ value (number) Value in EFIXes
 ]]
 function props:SetMeasurementEfix(value)
-    mixin.assert_argument(value, "number", 2)
+    mixin_helper.assert_argument_type(2, value, "number")
 
     local evpu = value / 64
     local unit = self:GetParent():GetMeasurementUnit()
@@ -140,7 +141,7 @@ Sets whether to show a suffix at the end of a measurement (eg `cm` in `2.54cm`).
 @ enabled (boolean)
 ]]
 function props:SetShowMeasurementSuffix(enabled)
-    mixin.assert_argument(enabled, "boolean", 2)
+    mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].ShowMeasurementSuffix = enabled and true or false
     mixin.FCXCtrlStatic.UpdateMeasurementUnit(self)

--- a/src/mixin/FCXCtrlUpDown.lua
+++ b/src/mixin/FCXCtrlUpDown.lua
@@ -63,9 +63,7 @@ local default_efix_steps = {
 @ self (FCXCtrlUpDown)
 ]]
 function props:Init()
-    mixin.assert(
-        mixin.is_instance_of(self:GetParent(), "FCXCustomLuaWindow"),
-        "FCXCtrlUpDown must have a parent window that is an instance of FCXCustomLuaWindow")
+    mixin_helper.assert(function() return mixin_helper.is_instance_of(self:GetParent(), "FCXCustomLuaWindow") end, "FCXCtrlUpDown must have a parent window that is an instance of FCXCustomLuaWindow")
     private[self] = private[self] or {IntegerStepSize = 1, MeasurementSteps = {}, AlignWhenMoving = true}
 
     self:AddHandlePress(
@@ -169,12 +167,10 @@ The underlying methods used in `GetValue` and `SetValue` will be `GetRangeIntege
 @ maximum (maximum)
 ]]
 function props:ConnectIntegerEdit(control, minimum, maximum)
-    mixin.assert_argument(control, "FCMCtrlEdit", 2)
-    mixin.assert_argument(minimum, "number", 3)
-    mixin.assert_argument(maximum, "number", 4)
-    mixin.assert(
-        not mixin.is_instance_of(control, "FCXCtrlMeasurementEdit"),
-        "A measurement edit cannot be connected as an integer edit.")
+    mixin_helper.assert_argument_type(2, control, "FCMCtrlEdit")
+    mixin_helper.assert_argument_type(3, minimum, "number")
+    mixin_helper.assert_argument_type(4, maximum, "number")
+    mixin_helper.assert(function() return not mixin_helper.is_instance_of(control, "FCXCtrlMeasurementEdit") end, "A measurement edit cannot be connected as an integer edit.")
 
     private[self].ConnectedEdit = control
     private[self].ConnectedEditType = "Integer"
@@ -195,9 +191,9 @@ The underlying methods used in `GetValue` and `SetValue` will depend on the meas
 @ maximum (maximum)
 ]]
 function props:ConnectMeasurementEdit(control, minimum, maximum)
-    mixin.assert_argument(control, "FCXCtrlMeasurementEdit", 2)
-    mixin.assert_argument(minimum, "number", 3)
-    mixin.assert_argument(maximum, "number", 4)
+    mixin_helper.assert_argument_type(2, control, "FCXCtrlMeasurementEdit")
+    mixin_helper.assert_argument_type(3, minimum, "number")
+    mixin_helper.assert_argument_type(4, maximum, "number")
 
     private[self].ConnectedEdit = control
     private[self].ConnectedEditType = "Measurement"
@@ -215,7 +211,7 @@ Sets the step size for integer edits.
 @ value (number)
 ]]
 function props:SetIntegerStepSize(value)
-    mixin.assert_argument(value, "number", 2)
+    mixin_helper.assert_argument_type(2, value, "number")
 
     private[self].IntegerStepSize = value
 end
@@ -230,7 +226,7 @@ Sets the step size for measurement edits that are currently displaying in EVPUs.
 @ value (number)
 ]]
 function props:SetEVPUsStepSize(value)
-    mixin.assert_argument(value, "number", 2)
+    mixin_helper.assert_argument_type(2, value, "number")
 
     private[self].MeasurementSteps[finale.MEASUREMENTUNIT_EVPUS] = {value = value, is_evpus = true}
 end
@@ -246,8 +242,8 @@ Sets the step size for measurement edits that are currently displaying in Inches
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Inches.
 ]]
 function props:SetInchesStepSize(value, is_evpus)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
     private[self].MeasurementSteps[finale.MEASUREMENTUNIT_INCHES] = {
         value = value,
@@ -266,8 +262,8 @@ Sets the step size for measurement edits that are currently displaying in Centim
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Centimeters.
 ]]
 function props:SetCentimetersStepSize(value, is_evpus)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
     private[self].MeasurementSteps[finale.MEASUREMENTUNIT_CENTIMETERS] = {
         value = value,
@@ -286,8 +282,8 @@ Sets the step size for measurement edits that are currently displaying in Points
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Points.
 ]]
 function props:SetPointsStepSize(value, is_evpus)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
     private[self].MeasurementSteps[finale.MEASUREMENTUNIT_POINTS] = {
         value = value,
@@ -306,7 +302,7 @@ Sets the step size for measurement edits that are currently displaying in Picas.
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Picas.
 ]]
 function props:SetPicasStepSize(value, is_evpus)
-    mixin.assert_argument(value, {"number", "string"}, 2)
+    mixin_helper.assert_argument_type(2, value, "number", "string")
 
     if not is_evpus then
         temp_str:SetText(tostring(value))
@@ -327,8 +323,8 @@ Sets the step size for measurement edits that are currently displaying in Spaces
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Spaces.
 ]]
 function props:SetSpacesStepSize(value, is_evpus)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert_argument(is_evpus, {"boolean", "nil"}, 3)
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
     private[self].MeasurementSteps[finale.MEASUREMENTUNIT_SPACES] = {
         value = value,
@@ -346,7 +342,7 @@ Sets whether to align to the next multiple of a step when moving.
 @ on (boolean)
 ]]
 function props:SetAlignWhenMoving(on)
-    mixin.assert_argument(on, "boolean", 2)
+    mixin_helper.assert_argument_type(2, on, "boolean")
 
     private[self].AlignWhenMoving = on
 end
@@ -396,8 +392,8 @@ Different types of connected edits will accept different types and use different
 @ value (number) An integer for an integer edit, EVPUs for a measurement edit, whole EVPUs for a measurement integer edit, or EFIXes for a measurement EFIX edit.
 ]]
 function props:SetValue(value)
-    mixin.assert_argument(value, "number", 2)
-    mixin.assert(private[self].ConnectedEdit, "Unable to set value: no connected edit.")
+    mixin_helper.assert_argument_type(2, value, "number")
+    mixin_helper.assert(private[self].ConnectedEdit, "Unable to set value: no connected edit.")
 
     -- Clamp the value
     value = value < private[self].Minimum and private[self].Minimum or value
@@ -447,8 +443,8 @@ end
 @ maximum (number) An integer for integer edits or EVPUs for measurement edits.
 ]]
 function props:SetRange(minimum, maximum)
-    mixin.assert_argument(minimum, "number", 2)
-    mixin.assert_argument(maximum, "number", 3)
+    mixin_helper.assert_argument_type(2, minimum, "number")
+    mixin_helper.assert_argument_type(3, maximum, "number")
 
     private[self].Minimum = minimum
     private[self].Maximum = maximum

--- a/src/mixin/FCXCustomLuaWindow.lua
+++ b/src/mixin/FCXCustomLuaWindow.lua
@@ -42,9 +42,9 @@ Creates an `FCXCtrlStatic` control.
 : (FCXCtrlStatic)
 ]]
 function props:CreateStatic(x, y, control_name)
-    mixin.assert_argument(x, "number", 2)
-    mixin.assert_argument(y, "number", 3)
-    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+    mixin_helper.assert_argument_type(2, x, "number")
+    mixin_helper.assert_argument_type(3, y, "number")
+    mixin_helper.assert_argument_type(4, control_name, "string", "nil")
 
     local popup = mixin.FCMCustomWindow.CreateStatic(self, x, y, control_name)
     return mixin.subclass(popup, "FCXCtrlStatic")
@@ -63,9 +63,9 @@ Creates an `FCXCtrlUpDown` control.
 : (FCXCtrlUpDown)
 ]]
 function props:CreateUpDown(x, y, control_name)
-    mixin.assert_argument(x, "number", 2)
-    mixin.assert_argument(y, "number", 3)
-    mixin.assert_argument(control_name, {"string", "nil"}, 4)
+    mixin_helper.assert_argument_type(2, x, "number")
+    mixin_helper.assert_argument_type(3, y, "number")
+    mixin_helper.assert_argument_type(4, control_name, "string", "nil")
 
     local updown = mixin.FCMCustomWindow.CreateUpDown(self, x, y, control_name)
     return mixin.subclass(updown, "FCXCtrlUpDown")

--- a/src/mixin/__FCMUserWindow.lua
+++ b/src/mixin/__FCMUserWindow.lua
@@ -8,6 +8,7 @@ Summary of modifications:
 - In getters with an `FCString` parameter, the parameter is now optional and a Lua `string` is returned. 
 ]] --
 local mixin = require("library.mixin")
+local mixin_helper = require("library.mixin_helper")
 
 local props = {}
 
@@ -24,7 +25,7 @@ Returns a Lua `string` and makes passing an `FCString` optional.
 : (string)
 ]]
 function props:GetTitle(title)
-    mixin.assert_argument(title, {"nil", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, title, "nil", "FCString")
 
     if not title then
         title = temp_str
@@ -45,7 +46,7 @@ Accepts Lua `string` and `number` in addition to `FCString`.
 @ title (FCString|string|number)
 ]]
 function props:SetTitle(title)
-    mixin.assert_argument(title, {"string", "number", "FCString"}, 2)
+    mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
 
     if type(title) ~= "userdata" then
         temp_str.LuaString = tostring(title)


### PR DESCRIPTION
This PR moves some things around so that all mixin helper functions actually reside in `mixin_helper.lua`. I also updated some helper function signatures.

Change list:
- Moved `is_instance_of`, `assert_argument`, `force_assert_argument`, `assert` and `force_assert` from `mixin.lua` to `mixin_helper.lua`.
- Renamed `assert_argument` to `assert_argument_type` and `force_assert_argument` to `force_assert_argument_type`
- As part of that move, `get_parent_class` and `get_class_name` were moved to the general library from being private functions in `mixin.lua`.
- Changed the class name validating functions to public in `mixin.lua`.
- Rewrote `is_instance_of` so that it can be passed multiple class names to check against. Also improved its documentation.
- Changed the signature of `assert_argument_type` so that it makes more sense. It now also utilizes the updated `is_instance_of` to allow argument types to be specified at any level in the class hierarchy. 
- Filled in some missing `assert_argument_type` calls that weren't possible before this PR.
- A couple of things to get rid of linting errors.

I've marked this as draft pending the merging of #433  so that I can update `assert_argument` in `FCMTextExpressionDef` as part of this PR as well.

Tagging @cv-on-hub so that you're aware of the changes to `assert_argument`.