### PR TITLE
Remove href from notes

### DIFF
--- a/src/document_options_as_json.lua
+++ b/src/document_options_as_json.lua
@@ -27,7 +27,7 @@ function plugindef()
         JSON file. You can then use a diff program to compare the JSON files generated from 
         two Finale documents, or you can keep track of how the settings in a document have changed 
         over time. The script will also let you import settings from a full or partial JSON file.
-        Please see <a href="https://url.sherber.com/finalelua/options-as-json">url.sherber.com/finalelua/options-as-json</a>
+        Please see https://url.sherber.com/finalelua/options-as-json
         for more information.
         
         The focus is on document-specific settings, rather than program-wide ones, and in particular on 


### PR DESCRIPTION
Since the doc generator didn't recognize the url in my notes, I tried to get clever and use an explicit `<a href=>`. But that didn't work either, so I'm taking it out.

Something else that would be nice in #472.