### PR TITLE
Options as JSON: Resync categories

### DIFF
--- a/src/document_options_as_json.lua
+++ b/src/document_options_as_json.lua
@@ -5,8 +5,8 @@ function plugindef()
     finaleplugin.Author = "Aaron Sherber"
     finaleplugin.AuthorURL = "https://aaron.sherber.com"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "2.1.1"
-    finaleplugin.Date = "2023-03-16"
+    finaleplugin.Version = "2.1.2"
+    finaleplugin.Date = "2023-03-25"
     finaleplugin.CategoryTags = "Report"   
     finaleplugin.Id = "9c05a4c4-9508-4608-bb1b-2819cba96101" 
     finaleplugin.AdditionalMenuOptions = [[
@@ -16,6 +16,7 @@ function plugindef()
         action = "import"
     ]]
     finaleplugin.RevisionNotes = [[
+        v2.1.2      Resync expression definitions
         v2.1.1      Add music spacing allotments (requires RGPLua v0.66)
         v2.0.1      Add ability to import
         v1.2.1      Add Grid/Guide snap-tos; better organization of SmartShapes
@@ -27,8 +28,7 @@ function plugindef()
         JSON file. You can then use a diff program to compare the JSON files generated from 
         two Finale documents, or you can keep track of how the settings in a document have changed 
         over time. The script will also let you import settings from a full or partial JSON file.
-        Please see <a href="https://url.sherber.com/finalelua/options-as-json">url.sherber.com/finalelua/options-as-json</a>
-        for more information.
+        Please see https://url.sherber.com/finalelua/options-as-json for more information.
         
         The focus is on document-specific settings, rather than program-wide ones, and in particular on 
         the ones that affect the look of a document. Most of these come from the Document Options dialog 
@@ -62,6 +62,7 @@ local debug = {
 
 local mixin = require('library.mixin')
 local json = require("lunajson.lunajson")
+local expr = require("library.expression")
 
 -- region DIALOGS
 
@@ -675,6 +676,10 @@ function save_all_raw_prefs(prefs_table)
                 obj.handler(obj.prefs, prefs_table[tag], false)
             end
         end
+    end
+
+    for cat in loadall(finale.FCCategoryDefs()) do
+        expr.resync_expressions_for_category(cat.ID)
     end
 end
 

--- a/src/document_options_as_json.lua
+++ b/src/document_options_as_json.lua
@@ -1202,7 +1202,15 @@ function options_import_from_json()
         if file then
             local prefs_json = file:read("*a")
             file:close()
-            local prefs_to_import = json.decode(prefs_json)
+            
+            local prefs_to_import
+            local ok, err_msg = pcall(function() prefs_to_import = json.decode(prefs_json) end)
+            if not ok then
+                err_msg = err_msg or "Unknown error"
+                err_msg = err_msg:gsub("^.-%d:", "")
+                finenv.UI():AlertError(err_msg, "JSON Error")
+                return
+            end
             
             if confirm_file_import(prefs_to_import["@Meta"]) then
                 local raw_prefs = transform_to_raw(prefs_to_import)

--- a/src/library/expression.lua
+++ b/src/library/expression.lua
@@ -154,4 +154,58 @@ function expression.is_dynamic(exp)
     return false
 end
 
+--[[
+% resync_expressions_for_category
+
+Updates the fonts and positioning of all expression definitions linked to a category after making changes to the category.
+
+@ category_id (number)
+]]
+
+function expression.resync_expressions_for_category(category_id)
+    for expression_def in loadall(finale.FCTextExpressionDefs()) do
+        if expression_def.CategoryID == category_id then
+            expression.resync_to_category(expression_def)
+        end
+    end
+end
+
+--[[
+% resync_to_category
+
+Updates the fonts and positioning of an expression definition to match its category after making changes to the category.
+
+@ expression_def (FCTextExpessionDef)
+]]
+
+function expression.resync_to_category(expression_def)
+    local cat = finale.FCCategoryDef()
+    cat:Load(expression_def.CategoryID)
+    
+    if expression_def.UseCategoryFont then
+        local str = expression_def:CreateTextString()
+        if str then
+            str:ReplaceCategoryFonts(cat, finale.CATEGORYMODE_TEXT, false)
+            str:ReplaceCategoryFonts(cat, finale.CATEGORYMODE_MUSIC, false)
+            str:ReplaceCategoryFonts(cat, finale.CATEGORYMODE_NUMBER, false)
+            expression_def:SaveTextString(str)
+        end
+    end
+
+    if expression_def.UseCategoryPos then
+        local pos_props = {
+            "HorizontalJustification",
+            "HorizontalAlignmentPoint",
+            "HorizontalOffset",
+            "VerticalAlignmentPoint",
+            "VerticalBaselineOffset",
+            "VerticalEntryOffset"
+        }
+        for _, prop in pairs(pos_props) do
+            expression_def[prop] = cat[prop]
+        end
+        expression_def:Save()
+    end
+end 
+
 return expression


### PR DESCRIPTION
@rpatters1 I took a slightly different tack from what you suggested, for a few reasons.

* I used "resync" in the method names instead of "set", because I think it better expresses what's going on. The expression definition already says "I want to use category fonts/positioning", and the method just makes sure that it actually is.
* I didn't include an optional param for the category ID, because the only use case is making sure that the expression agrees with the category it's already assigned to.
* I made just a single method to work on an expression rather than two, because I can't see a case where an expression uses both category fonts and positioning and you only want to make sure that one of them matches the category.
* I included a second method `resync_expressions_for_category()`, because while it's a simple loop, I expect that this will be the primary use case: programmatically make changes to a category and then propagate those changes to all the expressions in the category.

If you're thinking of use cases that I haven't considered, I'm happy to revisit.

The other change in the PR, wrapping json decode in `pcall`, just lets me display clear error messages when the user tries to import a defective json file, getting rid of the reference to the line number in the Lua code file.