### PR TITLE
Update smartshape.lua

### DIFF
--- a/src/library/smartshape.lua
+++ b/src/library/smartshape.lua
@@ -48,13 +48,13 @@ Creates an entry based SmartShape based on two input notes. If a type is not spe
 function smartshape.add_entry_based_smartshape(start_note, end_note, shape_type)
     local smartshape = finale.FCSmartShape()
     smartshape:SetEntryAttachedFlags(true)
+
     local shape
-    if shape_type and type(shape_type) == "number" then -- legit finale.SMARTSHAPE_TYPES number provided
-        shape = shape_type
+    if shape_type and type(shape_type) == "number" and shape_type <= finale.SMARTSHAPE_DASHEDSLURAUTO then
+        shape = shape_type -- legit finale.SMARTSHAPE_TYPES number provided
     else
         shape_type = shape_type or "slur"
-        shape_type = string.lower(shape_type)
-        shape = smartshape_type[shape_type]
+        shape = smartshape_type[string.lower(shape_type)]
     end
     smartshape:SetShapeType(shape)
     smartshape.PresetShape = true
@@ -125,12 +125,11 @@ Creates an entry based SmartShape based on two input notes. If a type is not spe
 ]]
 function smartshape.delete_entry_based_smartshape(music_region, shape_type)
     local shape
-    if shape_type and type(shape_type) == "number" then -- legit finale.SMARTSHAPE_TYPES number provided
-        shape = shape_type
+    if shape_type and type(shape_type) == "number" and shape_type <= finale.SMARTSHAPE_DASHEDSLURAUTO then
+        shape = shape_type -- legit finale.SMARTSHAPE_TYPES number provided
     else
         shape_type = shape_type or "slur"
-        shape_type = string.lower(shape_type)
-        shape = smartshape_type[shape_type]
+        shape = smartshape_type[string.lower(shape_type)]
     end
     for noteentry in eachentrysaved(music_region) do
         local smartshape_entry_marks = finale.FCSmartShapeEntryMarks(noteentry)

--- a/src/library/smartshape.lua
+++ b/src/library/smartshape.lua
@@ -43,15 +43,19 @@ Creates an entry based SmartShape based on two input notes. If a type is not spe
 
 @ start_note (FCNoteEntry) Starting note for SmartShape.
 @ end_note (FCNoteEntry) Ending note for SmartShape.
-@ shape_type (string) The type of shape to add, pulled from table.
+@ shape_type (string) or (number) The type of shape to add, pulled from table, or finale.SMARTSHAPE_TYPES number
 ]]
 function smartshape.add_entry_based_smartshape(start_note, end_note, shape_type)
     local smartshape = finale.FCSmartShape()
     smartshape:SetEntryAttachedFlags(true)
-    shape_type = shape_type or "slur"
-    --
-    shape_type = string.lower(shape_type)
-    local shape = smartshape_type[shape_type]
+    local shape
+    if shape_type and type(shape_type) == "number" then -- legit finale.SMARTSHAPE_TYPES number provided
+        shape = shape_type
+    else
+        shape_type = shape_type or "slur"
+        shape_type = string.lower(shape_type)
+        shape = smartshape_type[shape_type]
+    end
     smartshape:SetShapeType(shape)
     smartshape.PresetShape = true
     if smartshape:IsAutoSlur() then
@@ -102,7 +106,7 @@ function smartshape.add_entry_based_smartshape(start_note, end_note, shape_type)
             end
         end
         local staff_pos_difference = start_note_staff_pos - end_note_staff_pos
-        if accidentals > 0 then 
+        if accidentals > 0 then
             offset_x_add = offset_x_add + 28
         end
         right_segment:SetEndpointOffsetX(right_segment.EndpointOffsetX - offset_x_add)
@@ -117,10 +121,17 @@ end
 Creates an entry based SmartShape based on two input notes. If a type is not specified, creates a slur.
 
 @ music_region (FCMusicregion) The region to process.
-@ shape_type (string) The type of shape to add, pulled from table.
+@ shape_type (string) or (number) The type of shape to add, pulled from table, or finale.SMARTSHAPE_TYPES number
 ]]
 function smartshape.delete_entry_based_smartshape(music_region, shape_type)
-    local shape = smartshape_type[shape_type]
+    local shape
+    if shape_type and type(shape_type) == "number" then -- legit finale.SMARTSHAPE_TYPES number provided
+        shape = shape_type
+    else
+        shape_type = shape_type or "slur"
+        shape_type = string.lower(shape_type)
+        shape = smartshape_type[shape_type]
+    end
     for noteentry in eachentrysaved(music_region) do
         local smartshape_entry_marks = finale.FCSmartShapeEntryMarks(noteentry)
         smartshape_entry_marks:LoadAll(music_region)
@@ -144,12 +155,12 @@ Deletes all slurs, dashed slurs, and dashed curves.
 ]]
 function smartshape.delete_all_slurs(music_region)
     local slurs = {
-        "slurauto", 
-        "slurdown", 
-        "slurup", 
-        "dashed", 
+        "slurauto",
+        "slurdown",
+        "slurup",
+        "dashed",
         "dashedslurdown",
-        "dashedslurup", 
+        "dashedslurup",
         "dashedcurve",
         "dashedcurvedown",
         "dashedcurveup"


### PR DESCRIPTION
The previous version would ONLY accept shape_type in one of the pre-determined “key” values. not as the actual finale.SMARTSHAPE_TYPES integer. Amended here to accept either.