### PR TITLE
Add Lua 5.4 compatibility library

### DIFF
--- a/src/library/lua_compatibility.lua
+++ b/src/library/lua_compatibility.lua
@@ -1,0 +1,34 @@
+--  Author: Edward Koltun
+--  Date: April 9, 2023
+--[[
+$module Lua Compatibility
+
+This library assists in providing compatibility across Lua versions by polyfilling standard library functions in older Lua versions.
+
+The following functions are polyfilled:
+```
+Function         | Lua Versions Polyfilled
+-------------------------------------------
+math.tointeger   | < 5.3
+math.type        | < 5 3
+```
+]] --
+
+if not math.type then
+    math.type = function(value)
+        if type(value) == "number" then
+            local _, fractional = math.modf(value)
+            return fractional == 0 and "integer" or "float"
+        end
+
+        return nil
+    end
+end
+
+if not math.tointeger then
+    math.tointeger = function(value)
+        return type(value) == "number" and math.floor(value) or nil
+    end
+end
+
+return true

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -75,7 +75,23 @@ Rounds a number to the nearest integer or the specified number of decimal places
 function utils.round(value, places)
     places = places or 0
     local multiplier = 10^places
-    return math.floor(value * multiplier + 0.5) / multiplier
+    local ret = math.floor(value * multiplier + 0.5)
+    -- Ensures that a real integer type is returned as needed
+    return places == 0 and ret or ret / multiplier
+end
+
+--[[
+% to_integer_if_whole
+
+Takes a number and if it is an integer or whole float (eg 12 or 12.0), returns an integer.
+All other floats will be returned as passed.
+
+@ value (number)
+: (number)
+]]
+function utils.to_integer_if_whole(value)
+    local int = math.floor(value)
+    return value == int and int or value
 end
 
 --[[ 

--- a/src/mixin/FCMString.lua
+++ b/src/mixin/FCMString.lua
@@ -160,7 +160,7 @@ function public:SetMeasurement(value, measurementunit)
         local whole = math.floor(value / 48)
         local fractional = value - whole * 48
         fractional = fractional < 0 and fractional * -1 or fractional
-        self.LuaString = whole .. "p" .. utils.round(fractional / 4, 4)
+        self.LuaString = whole .. "p" .. utils.to_integer_if_whole(utils.round(fractional / 4, 4))
         return
     end
 
@@ -177,7 +177,7 @@ function public:SetMeasurement(value, measurementunit)
         value = value / 288 * 25.4
     end
 
-    self.LuaString = tostring(utils.round(value, 5))
+    self.LuaString = tostring(utils.to_integer_if_whole(utils.round(value, 5)))
 end
 
 --[[


### PR DESCRIPTION
Fixes #493 

This should address the Lua 5.4 integer issues. More functions can be added to the `lua_compatibility` library as needed.

I also added `float` and `integer` as types for argument type assertion.

If anyone has a better name than `whole_float_to_integer` I'm happy to change it.

Here's a quick test script:
```lua
local mixin = require("library.mixin")
local dialog = mixin.FCXCustomLuaWindow()
dualog:CreateMeasurementEdit(10, 10):SetMeasurementInteger(12)
dialog:CreateMeasurementUnitPopup(10, 50)
dialog:ExecuteModal()

```