### PR TITLE
add hash computation to deploy.yml as well as deleting the dist folder.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,6 @@ jobs:
                   rm -rf ./lua/hash
                   mkdir ./lua/hash
                   cd ./lua/dist
-                  for file in *; do sha512sum "$file"; done
                   for file in *; do sha512sum "$file" > "../hash/$(basename "$file" .lua).hash"; done
                   cd ../../
             - name: parse scripts


### PR DESCRIPTION
This PR modifies `deploy.yml` to

- delete the contents of the `dist` folder before building the dist versions of the scripts.
- calculate the SHA-512 hash for each file int the `dist` folder, storing them in the `hash` folder.
