### PR TITLE
Mixin Update

### DIFF
--- a/src/library/mixin_helper.lua
+++ b/src/library/mixin_helper.lua
@@ -201,24 +201,6 @@ function mixin_helper.force_assert(condition, message, level)
     assert_func(condition, message, level == 0 and 0 or 2 + (level or 2))
 end
 
-local disabled_method = function()
-    error("Attempt to call disabled method 'tryfunczzz'", 2)
-end
-
---[[
-% disable_methods
-
-Disables mixin methods by setting an empty function that throws an error.
-
-@ props (table) The mixin's props table.
-@ ... (string) The names of the methods to replace
-]]
-function mixin_helper.disable_methods(props, ...)
-    for i = 1, select("#", ...) do
-        props[select(i, ...)] = disabled_method
-    end
-end
-
 --[[
 % create_standard_control_event
 
@@ -453,7 +435,7 @@ function mixin_helper.create_custom_control_change_event(...)
             not event.callback_exists(self, callback), "The callback has already been added as a handler.")
 
         init_window(window)
-        event.add(self, callback, not window:WindowExists_())
+        event.add(self, callback, not window:WindowExists__())
     end
 
     local function remove_func(self, callback)
@@ -469,7 +451,7 @@ function mixin_helper.create_custom_control_change_event(...)
 
         local window = control:GetParent()
 
-        if window:WindowExists_() then
+        if window:WindowExists__() then
             window:QueueHandleCustom(
                 function()
                     queued[control] = nil
@@ -531,7 +513,7 @@ function mixin_helper.create_custom_window_change_event(...)
     end
 
     local function trigger_helper(window)
-        if not event.has_callbacks(window) or queued[window] or not window:WindowExists_() then
+        if not event.has_callbacks(window) or queued[window] or not window:WindowExists__() then
             return
         end
 
@@ -597,7 +579,7 @@ This function captures that result and throws an error in case of failure.
 ]]
 
 function mixin_helper.boolean_to_error(object, method, ...)
-    if not object[method .. "_"](object, ...) then
+    if not object[method .. "__"](object, ...) then
         error("'" .. object.MixinClass .. "." .. method .. "' has encountered an error.", 3)
     end
 end

--- a/src/mixin/FCMControl.lua
+++ b/src/mixin/FCMControl.lua
@@ -13,8 +13,8 @@ $module FCMControl
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 -- So as not to prevent the window (and by extension the controls) from being garbage collected in the normal way, use weak keys and values for storing the parent window
 local parent = setmetatable({}, {__mode = "kv"})
@@ -28,7 +28,7 @@ local temp_str = finale.FCString()
 
 @ self (FCMControl)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -48,7 +48,7 @@ Returns the control's parent window.
 @ self (FCMControl)
 : (FCMCustomWindow)
 ]]
-function public:GetParent()
+function methods:GetParent()
     return parent[self]
 end
 
@@ -64,7 +64,7 @@ Used to register the parent window when the control is created.
 @ self (FCMControl)
 @ window (FCMCustomWindow)
 ]]
-function public:RegisterParent(window)
+function methods:RegisterParent(window)
     mixin_helper.assert_argument_type(2, window, "FCMCustomWindow", "FCMCustomLuaWindow")
 
     if parent[self] then
@@ -225,15 +225,15 @@ for method, valid_types in pairs({
     Height = {"number"},
     Width = {"number"},
 }) do
-    public["Get" .. method] = function(self)
+    methods["Get" .. method] = function(self)
         if mixin.FCMControl.UseStoredState(self) then
             return private[self][method]
         end
 
-        return self["Get" .. method .. "_"](self)
+        return self["Get" .. method .. "__"](self)
     end
 
-    public["Set" .. method] = function(self, value)
+    methods["Set" .. method] = function(self, value)
         mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         if mixin.FCMControl.UseStoredState(self) then
@@ -241,11 +241,11 @@ for method, valid_types in pairs({
         else
             -- Fix bug with text box content being cleared on Mac when Enabled or Visible state is changed
             if (method == "Enable" or method == "Visible") and finenv.UI():IsOnMac() and finenv.MajorVersion == 0 and finenv.MinorVersion < 63 then
-                self:GetText_(temp_str)
-                self:SetText_(temp_str)
+                self:GetText__(temp_str)
+                self:SetText__(temp_str)
             end
 
-            self["Set" .. method .. "_"](self, value)
+            self["Set" .. method .. "__"](self, value)
         end
     end
 end
@@ -264,7 +264,7 @@ Override Changes:
 @ [str] (FCString)
 : (string) Returned if `str` is omitted.
 ]]
-function public:GetText(str)
+function methods:GetText(str)
     mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local do_return = false
@@ -277,7 +277,7 @@ function public:GetText(str)
     if mixin.FCMControl.UseStoredState(self) then
         str.LuaString = private[self].Text
     else
-        self:GetText_(str)
+        self:GetText__(str)
     end
 
     if do_return then
@@ -297,7 +297,7 @@ Override Changes:
 @ self (FCMControl)
 @ str (FCString | string | number)
 ]]
-function public:SetText(str)
+function methods:SetText(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
@@ -305,7 +305,7 @@ function public:SetText(str)
     if mixin.FCMControl.UseStoredState(self) then
         private[self].Text = str.LuaString
     else
-        self:SetText_(str)
+        self:SetText__(str)
     end
 end
 
@@ -321,7 +321,7 @@ Checks if this control should use its stored state instead of the live state fro
 @ self (FCMControl)
 : (boolean)
 ]]
-function public:UseStoredState()
+function methods:UseStoredState()
     local parent = self:GetParent()
     return mixin_helper.is_instance_of(parent, "FCMCustomLuaWindow") and parent:GetRestoreControlState() and not parent:WindowExists() and parent:HasBeenShown()
 end
@@ -337,15 +337,15 @@ Stores the control's current state.
 
 @ self (FCMControl)
 ]]
-function public:StoreState()
-    self:GetText_(temp_str)
+function methods:StoreState()
+    self:GetText__(temp_str)
     private[self].Text = temp_str.LuaString
-    private[self].Enable = self:GetEnable_()
-    private[self].Visible = self:GetVisible_()
-    private[self].Left = self:GetLeft_()
-    private[self].Top = self:GetTop_()
-    private[self].Height = self:GetHeight_()
-    private[self].Width = self:GetWidth_()
+    private[self].Enable = self:GetEnable__()
+    private[self].Visible = self:GetVisible__()
+    private[self].Left = self:GetLeft__()
+    private[self].Top = self:GetTop__()
+    private[self].Height = self:GetHeight__()
+    private[self].Width = self:GetWidth__()
 end
 
 --[[
@@ -359,17 +359,17 @@ Restores the control's stored state.
 
 @ self (FCMControl)
 ]]
-function public:RestoreState()
-    self:SetEnable_(private[self].Enable)
-    self:SetVisible_(private[self].Visible)
-    self:SetLeft_(private[self].Left)
-    self:SetTop_(private[self].Top)
-    self:SetHeight_(private[self].Height)
-    self:SetWidth_(private[self].Width)
+function methods:RestoreState()
+    self:SetEnable__(private[self].Enable)
+    self:SetVisible__(private[self].Visible)
+    self:SetLeft__(private[self].Left)
+    self:SetTop__(private[self].Top)
+    self:SetHeight__(private[self].Height)
+    self:SetWidth__(private[self].Width)
 
     -- Call SetText last to work around the Mac text box issue described above
     temp_str.LuaString = private[self].Text
-    self:SetText_(temp_str)
+    self:SetText__(temp_str)
 end
 
 --[[
@@ -393,6 +393,6 @@ Removes a handler added with `AddHandleCommand`.
 @ self (FCMControl)
 @ callback (function)
 ]]
-public.AddHandleCommand, public.RemoveHandleCommand = mixin_helper.create_standard_control_event("HandleCommand")
+methods.AddHandleCommand, methods.RemoveHandleCommand = mixin_helper.create_standard_control_event("HandleCommand")
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlButton.lua
+++ b/src/mixin/FCMCtrlButton.lua
@@ -10,11 +10,8 @@ As `FCCtrlButton` inherits from `FCCtrlCheckbox`, the following methods have bee
 
 To handle button presses, use `AddHandleCommand`, inherited from `FCMControl`.
 ]] --
-local mixin_helper = require("library.mixin_helper")
+local class = {}
 
-local meta = {}
-local public = {}
+class.Disabled = {"AddHandleCheckChange", "RemoveHandleCheckChange"}
 
-mixin_helper.disable_methods(public, "AddHandleCheckChange", "RemoveHandleCheckChange")
-
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlCheckbox.lua
+++ b/src/mixin/FCMCtrlCheckbox.lua
@@ -9,8 +9,8 @@ $module FCMCtrlCheckbox
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local trigger_check_change
 local each_last_check_change
@@ -26,10 +26,10 @@ Override Changes:
 @ self (FCMCtrlCheckbox)
 @ checked (number)
 ]]
-function public:SetCheck(checked)
+function methods:SetCheck(checked)
     mixin_helper.assert_argument_type(2, checked, "number")
 
-    self:SetCheck_(checked)
+    self:SetCheck__(checked)
 
     trigger_check_change(self)
 end
@@ -68,10 +68,14 @@ Removes a handler added with `AddHandleCheckChange`.
 @ self (FCMCtrlCheckbox)
 @ callback (function)
 ]]
-public.AddHandleCheckChange, public.RemoveHandleCheckChange, trigger_check_change, each_last_check_change =
-    mixin_helper.create_custom_control_change_event(
-        -- initial could be set to -1 to force the event to fire on InitWindow, but unlike other controls, -1 is not a valid checkstate.
-        -- If it becomes necessary to force this event to fire when the window is created, change to -1
-        {name = "last_check", get = "GetCheck_", initial = 0})
+methods.AddHandleCheckChange, methods.RemoveHandleCheckChange, trigger_check_change, each_last_check_change = mixin_helper.create_custom_control_change_event(
+    -- initial could be set to -1 to force the event to fire on InitWindow, but unlike other controls, -1 is not a valid checkstate.
+    -- If it becomes necessary to force this event to fire when the window is created, change to -1
+    {
+        name = "last_check",
+        get = "GetCheck__",
+        initial = 0,
+    }
+)
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlDataList.lua
+++ b/src/mixin/FCMCtrlDataList.lua
@@ -10,8 +10,8 @@ $module FCMCtrlDataList
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local temp_str = finale.FCString()
 
@@ -27,11 +27,11 @@ Override Changes:
 @ title (FCString | string | number)
 @ columnwidth (number)
 ]]
-function public:AddColumn(title, columnwidth)
+function methods:AddColumn(title, columnwidth)
     mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
     mixin_helper.assert_argument_type(3, columnwidth, "number")
 
-    self:AddColumn_(mixin_helper.to_fcstring(title, temp_str), columnwidth)
+    self:AddColumn__(mixin_helper.to_fcstring(title, temp_str), columnwidth)
 end
 
 --[[
@@ -46,11 +46,11 @@ Override Changes:
 @ columnindex (number)
 @ title (FCString | string | number)
 ]]
-function public:SetColumnTitle(columnindex, title)
+function methods:SetColumnTitle(columnindex, title)
     mixin_helper.assert_argument_type(2, columnindex, "number")
     mixin_helper.assert_argument_type(3, title, "string", "number", "FCString")
 
-    self:SetColumnTitle_(columnindex, mixin_helper.to_fcstring(title, temp_str))
+    self:SetColumnTitle__(columnindex, mixin_helper.to_fcstring(title, temp_str))
 end
 
 --[[
@@ -74,7 +74,7 @@ Removes a handler added with `AddHandleCheck`.
 @ self (FCMCtrlDataList)
 @ callback (function)
 ]]
-public.AddHandleCheck, public.RemoveHandleCheck = mixin_helper.create_standard_control_event("HandleDataListCheck")
+methods.AddHandleCheck, methods.RemoveHandleCheck = mixin_helper.create_standard_control_event("HandleDataListCheck")
 
 --[[
 % AddHandleSelect
@@ -97,6 +97,6 @@ Removes a handler added with `AddHandleSelect`.
 @ self (FCMCtrlDataList)
 @ callback (function)
 ]]
-public.AddHandleSelect, public.RemoveHandleSelect = mixin_helper.create_standard_control_event("HandleDataListSelect")
+methods.AddHandleSelect, methods.RemoveHandleSelect = mixin_helper.create_standard_control_event("HandleDataListSelect")
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlEdit.lua
+++ b/src/mixin/FCMCtrlEdit.lua
@@ -12,8 +12,8 @@ local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local trigger_change
 local each_last_change
@@ -30,7 +30,7 @@ Override Changes:
 @ self (FCMCtrlEdit)
 @ str (FCString | string | number)
 ]]
-function public:SetText(str)
+function methods:SetText(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     mixin.FCMControl.SetText(self, str)
@@ -90,13 +90,13 @@ for method, valid_types in pairs({
     Integer = {"number"},
     Float = {"number"},
 }) do
-    public["Get" .. method] = function(self)
+    methods["Get" .. method] = function(self)
         -- This is the long way around, but it ensures that the correct control value is used
         mixin.FCMControl.GetText(self, temp_str)
         return temp_str["Get" .. method](temp_str, 0)
     end
 
-    public["Set" .. method] = function(self, value)
+    methods["Set" .. method] = function(self, value)
         mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         temp_str["Set" .. method](temp_str, value)
@@ -269,14 +269,14 @@ for method, valid_types in pairs({
     MeasurementInteger = {"number"},
     Measurement10000th = {"number"},
 }) do
-    public["Get" .. method] = function(self, measurementunit)
+    methods["Get" .. method] = function(self, measurementunit)
         mixin_helper.assert_argument_type(2, measurementunit, "number")
 
         mixin.FCMControl.GetText(self, temp_str)
         return temp_str["Get" .. method](temp_str, measurementunit)
     end
 
-    public["GetRange" .. method] = function(self, measurementunit, minimum, maximum)
+    methods["GetRange" .. method] = function(self, measurementunit, minimum, maximum)
         mixin_helper.assert_argument_type(2, measurementunit, "number")
         mixin_helper.assert_argument_type(3, minimum, "number")
         mixin_helper.assert_argument_type(4, maximum, "number")
@@ -285,7 +285,7 @@ for method, valid_types in pairs({
         return temp_str["GetRange" .. method](temp_str, measurementunit, minimum, maximum)
     end
 
-    public["Set" .. method] = function(self, value, measurementunit)
+    methods["Set" .. method] = function(self, value, measurementunit)
         mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
         mixin_helper.assert_argument_type(3, measurementunit, "number")
 
@@ -309,7 +309,7 @@ Override Changes:
 @ maximum (number)
 : (number)
 ]]
-function public:GetRangeInteger(minimum, maximum)
+function methods:GetRangeInteger(minimum, maximum)
     mixin_helper.assert_argument_type(2, minimum, "number")
     mixin_helper.assert_argument_type(3, maximum, "number")
 
@@ -350,7 +350,7 @@ Removes a handler added with `AddHandleChange`.
 @ self (FCMCtrlEdit)
 @ callback (function)
 ]]
-public.AddHandleChange, public.RemoveHandleChange, trigger_change, each_last_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandleChange, methods.RemoveHandleChange, trigger_change, each_last_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_value",
         get = mixin.FCMControl.GetText,
@@ -358,4 +358,4 @@ public.AddHandleChange, public.RemoveHandleChange, trigger_change, each_last_cha
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlListBox.lua
+++ b/src/mixin/FCMCtrlListBox.lua
@@ -16,8 +16,8 @@ local mixin_helper = require("library.mixin_helper")
 local library = require("library.general_library")
 local utils = require("library.utils")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local trigger_selection_change
@@ -31,7 +31,7 @@ local temp_str = finale.FCString()
 
 @ self (FCMCtrlListBox)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -53,9 +53,9 @@ Override Changes:
 
 @ self (FCMCtrlListBox)
 ]]
-function public:StoreState()
+function methods:StoreState()
     mixin.FCMControl.StoreState(self)
-    private[self].SelectedItem = self:GetSelectedItem_()
+    private[self].SelectedItem = self:GetSelectedItem__()
 end
 
 --[[
@@ -70,16 +70,16 @@ Override Changes:
 
 @ self (FCMCtrlListBox)
 ]]
-function public:RestoreState()
+function methods:RestoreState()
     mixin.FCMControl.RestoreState(self)
 
-    self:Clear_()
+    self:Clear__()
     for _, str in ipairs(private[self].Items) do
         temp_str.LuaString = str
-        self:AddString_(temp_str)
+        self:AddString__(temp_str)
     end
 
-    self:SetSelectedItem_(private[self].SelectedItem)
+    self:SetSelectedItem__(private[self].SelectedItem)
 end
 
 --[[
@@ -93,9 +93,9 @@ Override Changes:
 
 @ self (FCMCtrlListBox)
 ]]
-function public:Clear()
+function methods:Clear()
     if not mixin.FCMControl.UseStoredState(self) then
-        self:Clear_()
+        self:Clear__()
     end
 
     private[self].Items = {}
@@ -120,12 +120,12 @@ Override Changes:
 @ self (FCMCtrlListBox)
 : (number)
 ]]
-function public:GetCount()
+function methods:GetCount()
     if mixin.FCMControl.UseStoredState(self) then
         return #private[self].Items
     end
 
-    return self:GetCount_()
+    return self:GetCount__()
 end
 
 --[[
@@ -139,12 +139,12 @@ Override Changes:
 @ self (FCMCtrlListBox)
 : (number)
 ]]
-function public:GetSelectedItem()
+function methods:GetSelectedItem()
     if mixin.FCMControl.UseStoredState(self) then
         return private[self].SelectedItem
     end
 
-    return self:GetSelectedItem_()
+    return self:GetSelectedItem__()
 end
 
 --[[
@@ -159,13 +159,13 @@ Override Changes:
 @ self (FCMCtrlListBox)
 @ index (number)
 ]]
-function public:SetSelectedItem(index)
+function methods:SetSelectedItem(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
     if mixin.FCMControl.UseStoredState(self) then
         private[self].SelectedItem = index
     else
-        self:SetSelectedItem_(index)
+        self:SetSelectedItem__(index)
     end
 
     trigger_selection_change(self)
@@ -183,7 +183,7 @@ Override Changes:
 @ self (FCMCtrlListBox)
 : (boolean) `true` if a selection was possible.
 ]]
-function public:SetSelectedLast()
+function methods:SetSelectedLast()
     local return_value
 
     if mixin.FCMControl.UseStoredState(self) then
@@ -191,7 +191,7 @@ function public:SetSelectedLast()
         mixin.FCMCtrlListBox.SetSelectedItem(self, count - 1)
         return_value = count > 0 and true or false
     else
-        return_value = self:SetSelectedLast_()
+        return_value = self:SetSelectedLast__()
     end
 
     trigger_selection_change(self)
@@ -206,7 +206,7 @@ Checks if the popup has a selection. If the parent window does not exist (ie `Wi
 @ self (FCMCtrlListBox)
 : (boolean) `true` if something is selected, `false` if no selection.
 ]]
-function public:HasSelection()
+function methods:HasSelection()
     return mixin.FCMCtrlListBox.GetSelectedItem(self) >= 0
 end
 
@@ -219,7 +219,7 @@ Checks if there is an item at the specified index.
 @ index (number) 0-based item index.
 : (boolean) `true` if the item exists, `false` if it does not exist.
 ]]
-function public:ItemExists(index)
+function methods:ItemExists(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
     return private[self].Items[index + 1] and true or false
@@ -237,13 +237,13 @@ Override Changes:
 @ self (FCMCtrlListBox)
 @ str (FCString | string | number)
 ]]
-function public:AddString(str)
+function methods:AddString(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:AddString_(str)
+        self:AddString__(str)
     end
 
     -- Since we've made it here without errors, str must be an FCString
@@ -260,7 +260,7 @@ Adds multiple strings to the list box.
 @ self (FCMCtrlListBox)
 @ ... (FCStrings | FCString | string | number)
 ]]
-function public:AddStrings(...)
+function methods:AddStrings(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
         mixin_helper.assert_argument_type(i + 1, v, "string", "number", "FCString", "FCStrings")
@@ -286,7 +286,7 @@ Returns a copy of all strings in the list box.
 @ [strs] (FCStrings) An optional `FCStrings` object to populate with strings.
 : (table) If `strs` is omitted, a table of strings (1-indexed - beware if accessing by key!).
 ]]
-function public:GetStrings(strs)
+function methods:GetStrings(strs)
     mixin_helper.assert_argument_type(2, strs, "nil", "FCStrings")
 
     if strs then
@@ -309,7 +309,7 @@ Override Changes:
 @ self (FCMCtrlListBox)
 @ ... (FCStrings | FCString | string | number) `number`s will be automatically cast to `string`
 ]]
-function public:SetStrings(...)
+function methods:SetStrings(...)
     for i = 1, select("#", ...) do
         mixin_helper.assert_argument_type(i + 1, select(i, ...), "FCStrings", "FCString", "string", "number")
     end
@@ -321,7 +321,7 @@ function public:SetStrings(...)
     end
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetStrings_(strs)
+        self:SetStrings__(strs)
     end
 
     -- Call statically, since there's no guarantee that strs is mixin-enabled
@@ -349,7 +349,7 @@ This method works in all JW/RGP Lua versions and irrespective of whether `InitWi
 @ [str] (FCString) Optional `FCString` object to populate with text.
 : (string) Returned if `str` is omitted.
 ]]
-function public:GetItemText(index, str)
+function methods:GetItemText(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "nil", "FCString")
 
@@ -378,7 +378,7 @@ Override Changes:
 @ index (number) 0-based index of item.
 @ str (FCString | string | number)
 ]]
-function public:SetItemText(index, str)
+function methods:SetItemText(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
@@ -397,14 +397,14 @@ function public:SetItemText(index, str)
 
     if not mixin.FCMControl.UseStoredState(self) then
         -- SetItemText was added to RGPLua in v0.56 and only works once the window has been created
-        if self.SetItemText_ and self:GetParent():WindowExists_() then
-            self:SetItemText_(index, str)
+        if self.SetItemText__ and self:GetParent():WindowExists__() then
+            self:SetItemText__(index, str)
 
         -- Otherwise, use a polyfill
         else
             local curr_item = mixin.FCMCtrlListBox.GetSelectedItem(self)
-            self:SetStrings_(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
-            self:SetSelectedItem_(curr_item)
+            self:SetStrings__(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
+            self:SetSelectedItem__(curr_item)
         end
     end
 end
@@ -420,7 +420,7 @@ Returns the text for the item that is currently selected.
 @ [str] (FCString) Optional `FCString` object to populate with text. If no item is currently selected, it will be populated with an empty string.
 : (string | nil) Returned if `str` is omitted. `nil` if no item is selected.
 ]]
-function public:GetSelectedString(str)
+function methods:GetSelectedString(str)
     mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local index = mixin.FCMCtrlListBox.GetSelectedItem(self)
@@ -443,7 +443,7 @@ If no match is found, the current selected item will remain selected. Matches ar
 @ self (FCMCtrlListBox)
 @ str (FCString | string | number)
 ]]
-function public:SetSelectedString(str)
+function methods:SetSelectedString(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = type(str) == "userdata" and str.LuaString or tostring(str)
@@ -469,7 +469,7 @@ If index is >= GetCount(), will insert at the end.
 @ index (number) 0-based index to insert new item.
 @ str (FCString | string | number) The value to insert.
 ]]
-function public:InsertItem(index, str)
+function methods:InsertItem(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
@@ -485,7 +485,7 @@ function public:InsertItem(index, str)
     local current_selection = mixin.FCMCtrlListBox.GetSelectedItem(self)
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetStrings_(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
+        self:SetStrings__(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
     end
 
     local new_selection = current_selection + (index <= current_selection and 1 or 0)
@@ -508,7 +508,7 @@ If the currently selected item is deleted, items will be deselected (ie set to -
 @ self (FCMCtrlListBox)
 @ index (number) 0-based index of item to delete.
 ]]
-function public:DeleteItem(index)
+function methods:DeleteItem(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
     if index < 0 or index >= mixin.FCMCtrlListBox.GetCount(self) then
@@ -520,7 +520,7 @@ function public:DeleteItem(index)
     local current_selection = mixin.FCMCtrlListBox.GetSelectedItem(self)
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetStrings_(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
+        self:SetStrings__(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
     end
 
     local new_selection
@@ -588,7 +588,7 @@ Removes a handler added with `AddHandleSelectionChange`.
 @ self (FCMCtrlListBox)
 @ callback (function) Handler to remove.
 ]]
-public.AddHandleSelectionChange, public.RemoveHandleSelectionChange, trigger_selection_change, each_last_selection_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandleSelectionChange, methods.RemoveHandleSelectionChange, trigger_selection_change, each_last_selection_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_item",
         get = function(ctrl)
@@ -610,4 +610,4 @@ public.AddHandleSelectionChange, public.RemoveHandleSelectionChange, trigger_sel
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlPopup.lua
+++ b/src/mixin/FCMCtrlPopup.lua
@@ -16,8 +16,8 @@ local mixin_helper = require("library.mixin_helper")
 local library = require("library.general_library")
 local utils = require("library.utils")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local trigger_selection_change
@@ -32,7 +32,7 @@ local temp_str = finale.FCString()
 
 @ self (FCMCtrlPopup)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -55,9 +55,9 @@ Override Changes:
 
 @ self (FCMCtrlPopup)
 ]]
-function public:StoreState()
+function methods:StoreState()
     mixin.FCMControl.StoreState(self)
-    private[self].SelectedItem = self:GetSelectedItem_()
+    private[self].SelectedItem = self:GetSelectedItem__()
 end
 
 --[[
@@ -72,16 +72,16 @@ Override Changes:
 
 @ self (FCMCtrlPopup)
 ]]
-function public:RestoreState()
+function methods:RestoreState()
     mixin.FCMControl.RestoreState(self)
 
-    self:Clear_()
+    self:Clear__()
     for _, str in ipairs(private[self].Items) do
         temp_str.LuaString = str
-        self:AddString_(temp_str)
+        self:AddString__(temp_str)
     end
 
-    self:SetSelectedItem_(private[self].SelectedItem)
+    self:SetSelectedItem__(private[self].SelectedItem)
 end
 
 --[[
@@ -95,9 +95,9 @@ Override Changes:
 
 @ self (FCMCtrlPopup)
 ]]
-function public:Clear()
+function methods:Clear()
     if not mixin.FCMControl.UseStoredState(self) then
-        self:Clear_()
+        self:Clear__()
     end
 
     private[self].Items = {}
@@ -123,12 +123,12 @@ Override Changes:
 @ self (FCMCtrlPopup)
 : (number)
 ]]
-function public:GetCount()
+function methods:GetCount()
     if mixin.FCMControl.UseStoredState(self) then
         return #private[self].Items
     end
 
-    return self:GetCount_()
+    return self:GetCount__()
 end
 
 --[[
@@ -142,12 +142,12 @@ Override Changes:
 @ self (FCMCtrlPopup)
 : (number)
 ]]
-function public:GetSelectedItem()
+function methods:GetSelectedItem()
     if mixin.FCMControl.UseStoredState(self) then
         return private[self].SelectedItem
     end
 
-    return self:GetSelectedItem_()
+    return self:GetSelectedItem__()
 end
 
 --[[
@@ -162,13 +162,13 @@ Override Changes:
 @ self (FCMCtrlPopup)
 @ index (number)
 ]]
-function public:SetSelectedItem(index)
+function methods:SetSelectedItem(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
     if mixin.FCMControl.UseStoredState(self) then
         private[self].SelectedItem = index
     else
-        self:SetSelectedItem_(index)
+        self:SetSelectedItem__(index)
     end
 
     trigger_selection_change(self)
@@ -183,7 +183,7 @@ Selects the last item in the popup. If the popup is empty, `SelectedItem` will b
 
 @ self (FCMCtrlPopup)
 ]]
-function public:SetSelectedLast()
+function methods:SetSelectedLast()
     mixin.FCMCtrlPopup.SetSelectedItem(self, mixin.FCMCtrlPopup.GetCount(self) - 1)
 end
 
@@ -195,7 +195,7 @@ Checks if the popup has a selection. If the parent window does not exist (ie `Wi
 @ self (FCMCtrlPopup)
 : (boolean) `true` if something is selected, `false` if no selection.
 ]]
-function public:HasSelection()
+function methods:HasSelection()
     return mixin.FCMCtrlPopup.GetSelectedItem(self) >= 0
 end
 
@@ -208,7 +208,7 @@ Checks if there is an item at the specified index.
 @ index (number) 0-based item index.
 : (boolean) `true` if the item exists, `false` if it does not exist.
 ]]
-function public:ItemExists(index)
+function methods:ItemExists(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
     return private[self].Items[index + 1] and true or false
@@ -226,13 +226,13 @@ Override Changes:
 @ self (FCMCtrlPopup)
 @ str (FCString | string | number)
 ]]
-function public:AddString(str)
+function methods:AddString(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:AddString_(str)
+        self:AddString__(str)
     end
 
     -- Since we've made it here without errors, str must be an FCString
@@ -249,7 +249,7 @@ Adds multiple strings to the popup.
 @ self (FCMCtrlPopup)
 @ ... (FCStrings | FCString | string | number)
 ]]
-function public:AddStrings(...)
+function methods:AddStrings(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
         mixin_helper.assert_argument_type(i + 1, v, "string", "number", "FCString", "FCStrings")
@@ -275,7 +275,7 @@ Returns a copy of all strings in the popup.
 @ [strs] (FCStrings) An optional `FCStrings` object to populate with strings.
 : (table) Returned if `strs` is omitted. A table of strings (1-indexed - beware when accessing by key!).
 ]]
-function public:GetStrings(strs)
+function methods:GetStrings(strs)
     mixin_helper.assert_argument_type(2, strs, "nil", "FCStrings")
 
     if strs then
@@ -298,7 +298,7 @@ Override Changes:
 @ self (FCMCtrlPopup)
 @ ... (FCStrings | FCString | string | number) `number`s will be automatically cast to `string`
 ]]
-function public:SetStrings(...)
+function methods:SetStrings(...)
     for i = 1, select("#", ...) do
         mixin_helper.assert_argument_type(i + 1, select(i, ...), "FCStrings", "FCString", "string", "number")
     end
@@ -310,7 +310,7 @@ function public:SetStrings(...)
     end
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetStrings_(strs)
+        self:SetStrings__(strs)
     end
 
     -- Call statically, since there's no guarantee that strs is mixin-enabled
@@ -337,7 +337,7 @@ Returns the text for an item in the popup.
 @ [str] (FCString) Optional `FCString` object to populate with text.
 : (string | nil) Returned if `str` is omitted. `nil` if the item doesn't exist
 ]]
-function public:GetItemText(index, str)
+function methods:GetItemText(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "nil", "FCString")
 
@@ -367,7 +367,7 @@ Port Changes:
 @ index (number) 0-based index of the item.
 @ str (FCString | string | number)
 ]]
-function public:SetItemText(index, str)
+function methods:SetItemText(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
@@ -386,8 +386,8 @@ function public:SetItemText(index, str)
 
     if not mixin.FCMControl.UseStoredState(self) then
         local curr_item = self:GetSelectedItem_()
-        self:SetStrings_(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
-        self:SetSelectedItem_(curr_item)
+        self:SetStrings__(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
+        self:SetSelectedItem__(curr_item)
     end
 end
 
@@ -402,7 +402,7 @@ Returns the text for the item that is currently selected.
 @ [str] (FCString) Optional `FCString` object to populate with text. If no item is currently selected, it will be populated with an empty string.
 : (string | nil) Returned if `str` is omitted. `nil` if no item is currently selected.
 ]]
-function public:GetSelectedString(str)
+function methods:GetSelectedString(str)
     mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local index = mixin.FCMCtrlPopup.GetSelectedItem(self)
@@ -426,7 +426,7 @@ If no match is found, the current selected item will remain selected. Matching i
 @ self (FCMCtrlPopup)
 @ str (FCString | string | number)
 ]]
-function public:SetSelectedString(str)
+function methods:SetSelectedString(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     str = type(str) == "userdata" and str.LuaString or tostring(str)
@@ -456,7 +456,7 @@ Port Changes:
 @ index (number) 0-based index to insert new item.
 @ str (FCString | string | number) The value to insert.
 ]]
-function public:InsertString(index, str)
+function methods:InsertString(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "string", "number", "FCString")
 
@@ -472,7 +472,7 @@ function public:InsertString(index, str)
     local current_selection = mixin.FCMCtrlPopup.GetSelectedItem(self)
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetStrings_(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
+        self:SetStrings__(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
     end
 
     local new_selection = current_selection + (index <= current_selection and 1 or 0)
@@ -496,7 +496,7 @@ If the currently selected item is deleted, it will be deselected (ie `SelectedIt
 @ self (FCMCtrlPopup)
 @ index (number) 0-based index of item to delete.
 ]]
-function public:DeleteItem(index)
+function methods:DeleteItem(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
     if index < 0 or index >= mixin.FCMCtrlPopup.GetCount(self) then
@@ -508,7 +508,7 @@ function public:DeleteItem(index)
     local current_selection = mixin.FCMCtrlPopup.GetSelectedItem(self)
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetStrings_(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
+        self:SetStrings__(mixin.FCMStrings():CopyFromStringTable(private[self].Items))
     end
 
     local new_selection
@@ -576,7 +576,7 @@ Removes a handler added with `AddHandleSelectionChange`.
 @ self (FCMCtrlPopup)
 @ callback (function) Handler to remove.
 ]]
-public.AddHandleSelectionChange, public.RemoveHandleSelectionChange, trigger_selection_change, each_last_selection_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandleSelectionChange, methods.RemoveHandleSelectionChange, trigger_selection_change, each_last_selection_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_item",
         get = function(ctrl)
@@ -598,4 +598,4 @@ public.AddHandleSelectionChange, public.RemoveHandleSelectionChange, trigger_sel
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlSlider.lua
+++ b/src/mixin/FCMCtrlSlider.lua
@@ -14,8 +14,8 @@ Command events do not fire for `FCCtrlSlider` controls before RGPLua 0.64, so a 
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local windows = setmetatable({}, {__mode = "k"})
 
 local trigger_thumb_position_change
@@ -55,7 +55,7 @@ Override Changes:
 @ self (FCMCtrlSlider)
 @ window (FCMCustomWindow)
 ]]
-function public:RegisterParent(window)
+function methods:RegisterParent(window)
     mixin.FCMControl.RegisterParent(self, window)
 
     if finenv.MajorVersion == 0 and finenv.MinorVersion < 64 and not windows[window] and mixin_helper.is_instance_of(window, "FCMCustomLuaWindow") then
@@ -82,10 +82,10 @@ Override Changes:
 @ self (FCMCtrlSlider)
 @ position (number)
 ]]
-function public:SetThumbPosition(position)
+function methods:SetThumbPosition(position)
     mixin_helper.assert_argument_type(2, position, "number")
 
-    self:SetThumbPosition_(position)
+    self:SetThumbPosition__(position)
 
     trigger_thumb_position_change(self)
 end
@@ -101,10 +101,10 @@ Override Changes:
 @ self (FCMCtrlSlider)
 @ minvalue (number)
 ]]
-function public:SetMinValue(minvalue)
+function methods:SetMinValue(minvalue)
     mixin_helper.assert_argument_type(2, minvalue, "number")
 
-    self:SetMinValue_(minvalue)
+    self:SetMinValue__(minvalue)
 
     trigger_thumb_position_change(self)
 end
@@ -120,10 +120,10 @@ Override Changes:
 @ self (FCMCtrlSlider)
 @ maxvalue (number)
 ]]
-function public:SetMaxValue(maxvalue)
+function methods:SetMaxValue(maxvalue)
     mixin_helper.assert_argument_type(2, maxvalue, "number")
 
-    self:SetMaxValue_(maxvalue)
+    self:SetMaxValue__(maxvalue)
 
     trigger_thumb_position_change(self)
 end
@@ -138,7 +138,7 @@ end
 ]]
 
 --[[
-% AddHandleChange
+% AddHandleThumbPositionChange
 
 **[Fluid]**
 
@@ -162,12 +162,12 @@ Removes a handler added with `AddHandleThumbPositionChange`.
 @ self (FCMCtrlSlider)
 @ callback (function)
 ]]
-public.AddHandleThumbPositionChange, public.RemoveHandleThumbPositionChange, trigger_thumb_position_change, each_last_thumb_position_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandleThumbPositionChange, methods.RemoveHandleThumbPositionChange, trigger_thumb_position_change, each_last_thumb_position_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_position",
-        get = "GetThumbPosition_",
+        get = "GetThumbPosition__",
         initial = -1,
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlStatic.lua
+++ b/src/mixin/FCMCtrlStatic.lua
@@ -13,8 +13,8 @@ local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 local measurement = require("library.measurement")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local temp_str = mixin.FCMString()
@@ -50,7 +50,7 @@ end
 
 @ self (FCMCtrlStatic)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -75,7 +75,7 @@ Override Changes:
 @ self (FCMCtrlStatic)
 @ window (FCMCustomWindow)
 ]]
-function public:RegisterParent(window)
+function methods:RegisterParent(window)
     mixin.FCMControl.RegisterParent(self, window)
 
     private[self].MeasurementEnabled = mixin_helper.is_instance_of(window, "FCMCustomLuaWindow")
@@ -95,7 +95,7 @@ Override Changes:
 @ green (number)
 @ blue (number)
 ]]
-function public:SetTextColor(red, green, blue)
+function methods:SetTextColor(red, green, blue)
     mixin_helper.assert_argument_type(2, red, "number")
     mixin_helper.assert_argument_type(3, green, "number")
     mixin_helper.assert_argument_type(4, blue, "number")
@@ -103,7 +103,7 @@ function public:SetTextColor(red, green, blue)
     private[self].TextColor = {red, green, blue}
 
     if not mixin.FCMControl.UseStoredState(self) then
-        self:SetTextColor_(red, green, blue)
+        self:SetTextColor__(red, green, blue)
 
         -- If a new text color is set after the window has been shown, the visible color will not change until new text is set
         -- Getting and setting the text makes the new text color visible immediately
@@ -123,7 +123,7 @@ Override Changes:
 
 @ self (FCMCtrlStatic)
 ]]
-function public:RestoreState()
+function methods:RestoreState()
     mixin.FCMControl.RestoreState(self)
 
     -- Only need to restore color if it has been changed from the default
@@ -143,7 +143,7 @@ Override Changes:
 @ self (FCMCtrlStatic)
 @ str (FCString | string|  number)
 ]]
-function public:SetText(str)
+function methods:SetText(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     mixin.FCMControl.SetText(self, str)
@@ -164,7 +164,7 @@ If using the parent window's measurement unit, it will be automatically updated 
 @ value (number) Value in EVPUs
 @ [measurementunit] (number | nil) Forces the value to be displayed in this measurement unit. Can only be omitted if parent window is `FCMCustomLuaWindow`.
 ]]
-function public:SetMeasurement(value, measurementunit)
+function methods:SetMeasurement(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number", "nil")
 
@@ -183,7 +183,7 @@ If using the parent window's measurement unit, it will be automatically updated 
 @ value (number) Value in whole EVPUs
 @ [measurementunit] (number | nil) Forces the value to be displayed in this measurement unit. Can only be omitted if parent window is `FCMCustomLuaWindow`.
 ]]
-function public:SetMeasurementInteger(value, measurementunit)
+function methods:SetMeasurementInteger(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number", "nil")
 
@@ -202,7 +202,7 @@ If using the parent window's measurement unit, it will be automatically updated 
 @ value (number) Value in EFIXes
 @ [measurementunit] (number | nil) Forces the value to be displayed in this measurement unit. Can only be omitted if parent window is `FCMCustomLuaWindow`.
 ]]
-function public:SetMeasurementEfix(value, measurementunit)
+function methods:SetMeasurementEfix(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number", "nil")
 
@@ -221,7 +221,7 @@ If using the parent window's measurement unit, it will be automatically updated 
 @ value (number) Value in 10000ths of an EVPU
 @ [measurementunit] (number | nil) Forces the value to be displayed in this measurement unit. Can only be omitted if parent window is `FCMCustomLuaWindow`.
 ]]
-function public:SetMeasurementEfix(value, measurementunit)
+function methods:SetMeasurementEfix(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number", "nil")
 
@@ -238,7 +238,7 @@ Sets whether to show a suffix at the end of a measurement (eg `cm` in `2.54cm`).
 @ self (FCMCtrlStatic)
 @ enabled (boolean)
 ]]
-function public:SetShowMeasurementSuffix(enabled)
+function methods:SetShowMeasurementSuffix(enabled)
     mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].ShowMeasurementSuffix = enabled and true or false
@@ -254,7 +254,7 @@ Sets the measurement suffix to the shortest form used by Finale's measurement ov
 
 @ self (FCMCtrlStatic)
 ]]
-function public:SetMeasurementSuffixShort()
+function methods:SetMeasurementSuffixShort()
     private[self].MeasurementSuffixType = 1
     mixin.FCMCtrlStatic.UpdateMeasurementUnit(self)
 end
@@ -270,7 +270,7 @@ Sets the measurement suffix to commonly known abbrevations (eg `in`, `cm`, `pt`,
 
 @ self (FCMCtrlStatic)
 ]]
-function public:SetMeasurementSuffixAbbreviated()
+function methods:SetMeasurementSuffixAbbreviated()
     private[self].MeasurementSuffixType = 2
     mixin.FCMCtrlStatic.UpdateMeasurementUnit(self)
 end
@@ -284,7 +284,7 @@ Sets the measurement suffix to the full unit name. (eg `inches`, `centimeters`, 
 
 @ self (FCMCtrlStatic)
 ]]
-function public:SetMeasurementSuffixFull()
+function methods:SetMeasurementSuffixFull()
     private[self].MeasurementSuffixType = 3
     mixin.FCMCtrlStatic.UpdateMeasurementUnit(self)
 end
@@ -298,10 +298,10 @@ Updates the displayed measurement unit in line with the parent window.
 
 @ self (FCMCtrlStatic)
 ]]
-function public:UpdateMeasurementUnit()
+function methods:UpdateMeasurementUnit()
     if private[self].Measurement then
         mixin.FCMCtrlStatic["Set" .. private[self].MeasurementType](self, private[self].Measurement)
     end
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlSwitcher.lua
+++ b/src/mixin/FCMCtrlSwitcher.lua
@@ -12,8 +12,8 @@ $module FCMCtrlSwitcher
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local trigger_page_change
@@ -27,7 +27,7 @@ local temp_str = finale.FCString()
 
 @ self (FCMCtrlSwitcher)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -49,12 +49,12 @@ Override Changes:
 @ self (FCMCtrlSwitcher)
 @ title (FCString | string | number)
 ]]
-function public:AddPage(title)
+function methods:AddPage(title)
     mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
 
     title = mixin_helper.to_fcstring(title, temp_str)
 
-    self:AddPage_(title)
+    self:AddPage__(title)
     table.insert(private[self].Index, title.LuaString)
     private[self].TitleIndex[title.LuaString] = #private[self].Index - 1
 end
@@ -69,7 +69,7 @@ Adds multiple pages, one page for each argument.
 @ self (FCMCtrlSwitcher)
 @ ... (FCString | string | number)
 ]]
-function public:AddPages(...)
+function methods:AddPages(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
         mixin_helper.assert_argument_type(i + 1, v, "string", "number", "FCString")
@@ -89,7 +89,7 @@ Override Changes:
 @ control (FCControl | FCMControl)
 @ pageindex (number)
 ]]
-function public:AttachControl(control, pageindex)
+function methods:AttachControl(control, pageindex)
     mixin_helper.assert_argument_type(2, control, "FCControl", "FCMControl")
     mixin_helper.assert_argument_type(3, pageindex, "number")
 
@@ -107,7 +107,7 @@ Attaches a control to a page by its title.
 @ control (FCControl | FCMControl) The control to attach.
 @ title (FCString | string | number) The title of the page. Must be an exact match.
 ]]
-function public:AttachControlByTitle(control, title)
+function methods:AttachControlByTitle(control, title)
     mixin_helper.assert_argument_type(2, control, "FCControl", "FCMControl")
     mixin_helper.assert_argument_type(3, title, "string", "number", "FCString")
 
@@ -131,10 +131,10 @@ Override Changes:
 @ self (FCMCtrlSwitcher)
 @ index (number)
 ]]
-function public:SetSelectedPage(index)
+function methods:SetSelectedPage(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
-    self:SetSelectedPage_(index)
+    self:SetSelectedPage__(index)
 
     trigger_page_change(self)
 end
@@ -149,7 +149,7 @@ Set the selected page by its title. If the page is not found, an error will be t
 @ self (FCMCtrlSwitcher)
 @ title (FCString | string | number) Title of page to select. Must be an exact, case-sensitive match.
 ]]
-function public:SetSelectedPageByTitle(title)
+function methods:SetSelectedPageByTitle(title)
     mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
 
     title = type(title) == "userdata" and title.LuaString or tostring(title)
@@ -170,10 +170,10 @@ Retrieves the title of the currently selected page.
 @ [title] (FCString) Optional `FCString` object to populate.
 : (string | nil) Returned if `title` is omitted. `nil` if no page is selected
 ]]
-function public:GetSelectedPageTitle(title)
+function methods:GetSelectedPageTitle(title)
     mixin_helper.assert_argument_type(2, title, "nil", "FCString")
 
-    local index = self:GetSelectedPage_()
+    local index = self:GetSelectedPage__()
 
     if index == -1 then
         if title then
@@ -198,7 +198,7 @@ Retrieves the title of a page.
 @ [str] (FCString) An optional `FCString` object to populate.
 : (string) Returned if `str` is omitted.
 ]]
-function public:GetPageTitle(index, str)
+function methods:GetPageTitle(index, str)
     mixin_helper.assert_argument_type(2, index, "number")
     mixin_helper.assert_argument_type(3, str, "nil", "FCString")
 
@@ -247,10 +247,10 @@ Removes a handler added with `AddHandlePageChange`.
 @ self (FCMCtrlSwitcher)
 @ callback (function)
 ]]
-public.AddHandlePageChange, public.RemoveHandlePageChange, trigger_page_change, each_last_page_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandlePageChange, methods.RemoveHandlePageChange, trigger_page_change, each_last_page_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_page",
-        get = "GetSelectedPage_",
+        get = "GetSelectedPage__",
         initial = -1
     },
     {
@@ -263,4 +263,4 @@ public.AddHandlePageChange, public.RemoveHandlePageChange, trigger_page_change, 
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlTree.lua
+++ b/src/mixin/FCMCtrlTree.lua
@@ -9,8 +9,8 @@ $module FCMCtrlTree
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local props = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local temp_str = finale.FCString()
 
@@ -28,12 +28,12 @@ Override Changes:
 @ text (FCString | string | number)
 : (FCMTreeNode)
 ]]
-function public:AddNode(parentnode, iscontainer, text)
+function methods:AddNode(parentnode, iscontainer, text)
     mixin_helper.assert_argument_type(2, parentnode, "nil", "FCTreeNode")
     mixin_helper.assert_argument_type(3, iscontainer, "boolean")
     mixin_helper.assert_argument_type(4, text, "string", "number", "FCString")
 
-    return self:AddNode_(parentnode, iscontainer, mixin_helper.to_fcstring(text, temp_str))
+    return self:AddNode__(parentnode, iscontainer, mixin_helper.to_fcstring(text, temp_str))
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCtrlUpDown.lua
+++ b/src/mixin/FCMCtrlUpDown.lua
@@ -11,8 +11,8 @@ $module FCMCtrlUpDown
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 --[[
@@ -22,7 +22,7 @@ local private = setmetatable({}, {__mode = "k"})
 
 @ self (FCMCtrlUpDown)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -41,7 +41,7 @@ Override Changes:
 @ self (FCMCtrlUpDown)
 : (FCMCtrlEdit | nil) `nil` if there is no edit connected.
 ]]
-function public:GetConnectedEdit()
+function methods:GetConnectedEdit()
     return private[self].ConnectedEdit
 end
 
@@ -59,7 +59,7 @@ Override Changes:
 @ minvalue (number)
 @ maxvalue (number)
 ]]
-function public:ConnectIntegerEdit(control, minvalue, maxvalue)
+function methods:ConnectIntegerEdit(control, minvalue, maxvalue)
     mixin_helper.assert_argument_type(2, control, "FCMCtrlEdit")
     mixin_helper.assert_argument_type(3, minvalue, "number")
     mixin_helper.assert_argument_type(4, maxvalue, "number")
@@ -84,7 +84,7 @@ Override Changes:
 @ minvalue (number)
 @ maxvalue (number)
 ]]
-function public:ConnectMeasurementEdit(control, minvalue, maxvalue)
+function methods:ConnectMeasurementEdit(control, minvalue, maxvalue)
     mixin_helper.assert_argument_type(2, control, "FCMCtrlEdit")
     mixin_helper.assert_argument_type(3, minvalue, "number")
     mixin_helper.assert_argument_type(4, maxvalue, "number")
@@ -114,6 +114,6 @@ Removes a handler added with `AddHandlePress`.
 @ self (FCMCtrlUpDown)
 @ callback (function)
 ]]
-public.AddHandlePress, public.RemoveHandlePress = mixin_helper.create_standard_control_event("HandleUpDownPressed")
+methods.AddHandlePress, methods.RemoveHandlePress = mixin_helper.create_standard_control_event("HandleUpDownPressed")
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCustomLuaWindow.lua
+++ b/src/mixin/FCMCustomLuaWindow.lua
@@ -23,8 +23,8 @@ local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 local measurement = require("library.measurement")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local trigger_measurement_unit_change
@@ -46,7 +46,7 @@ end
 local function restore_position(self)
     if private[self].HasBeenShown and private[self].EnableAutoRestorePosition and self.StorePosition then
         self:StorePosition(false)
-        self:SetRestorePositionOnlyData_(private[self].StoredX, private[self].StoredY)
+        self:SetRestorePositionOnlyData__(private[self].StoredX, private[self].StoredY)
         self:RestorePosition()
     end
 end
@@ -65,19 +65,19 @@ end
 
 local function create_handle_methods(event)
     -- Check if methods are available
-    public["Register" .. event] = function(self, callback)
+    methods["Register" .. event] = function(self, callback)
         mixin_helper.assert_argument_type(2, callback, "function")
 
         private[self][event].Registered = callback
     end
 
-    public["Add" .. event] = function(self, callback)
+    methods["Add" .. event] = function(self, callback)
         mixin_helper.assert_argument_type(2, callback, "function")
 
         table.insert(private[self][event].Added, callback)
     end
 
-    public["Remove" .. event] = function(self, callback)
+    methods["Remove" .. event] = function(self, callback)
         mixin_helper.assert_argument_type(2, callback, "function")
 
         utils.table_remove_first(private[self][event].Added, callback)
@@ -91,7 +91,7 @@ end
 
 @ self (FCMCustomLuaWindow)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -113,11 +113,11 @@ function meta:Init()
     for _, event in ipairs(control_events) do
         private[self][event] = {Added = {}}
 
-        if self["Register" .. event .. "_"] then
+        if self["Register" .. event .. "__"] then
             -- Handlers sometimes run twice, the second while the first is still running, so this flag prevents race conditions and concurrency issues.
             local is_running = false
 
-            self["Register" .. event .. "_"](self, function(control, ...)
+            self["Register" .. event .. "__"](self, function(control, ...)
                 if is_running then
                     return
                 end
@@ -150,12 +150,12 @@ function meta:Init()
     for _, event in ipairs(window_events) do
         private[self][event] = {Added = {}}
 
-        if not self["Register" .. event .. "_"] then
+        if not self["Register" .. event .. "__"] then
             goto continue
         end
 
         if event == "InitWindow" then
-            self["Register" .. event .. "_"](self, function(...)
+            self["Register" .. event .. "__"](self, function(...)
                 if private[self].HasBeenShown and private[self].RestoreControlState then
                     for control in each(self) do
                         control:RestoreState()
@@ -165,7 +165,7 @@ function meta:Init()
                 dispatch_event_handlers(self, event, self, ...)
             end)
         elseif event == "CloseWindow" then
-            self["Register" .. event .. "_"](self, function(...)
+            self["Register" .. event .. "__"](self, function(...)
                 if private[self].EnableDebugClose and finenv.RetainLuaState ~= nil then
                     if finenv.DebugEnabled and (self:QueryLastCommandModifierKeys(finale.CMDMODKEY_ALT) or self:QueryLastCommandModifierKeys(finale.CMDMODKEY_SHIFT)) then
                         finenv.RetainLuaState = false
@@ -194,7 +194,7 @@ function meta:Init()
                 end
             end)
         else
-            self["Register" .. event .. "_"](self, function(...)
+            self["Register" .. event .. "__"](self, function(...)
                 dispatch_event_handlers(self, event, self, ...)
             end)
         end
@@ -203,8 +203,8 @@ function meta:Init()
     end
 
     -- Register proxy for HandlerTimer if it's available in this RGPLua version.
-    if self.RegisterHandleTimer_ then
-        self:RegisterHandleTimer_(function(timerid)
+    if self.RegisterHandleTimer__ then
+        self:RegisterHandleTimer__(function(timerid)
             -- Call registered handler if there is one
             if private[self].HandleTimer.Registered then
                 -- Pass window as first parameter
@@ -571,7 +571,7 @@ The callback will not be passed any arguments.
 @ self (FCMCustomLuaWindow)
 @ callback (function)
 ]]
-function public:QueueHandleCustom(callback)
+function methods:QueueHandleCustom(callback)
     mixin_helper.assert_argument_type(2, callback, "function")
 
     table.insert(private[self].HandleCustomQueue, callback)
@@ -592,7 +592,7 @@ Override Changes:
 @ control (FCMControl)
 @ callback (function) See `FCCustomLuaWindow.HandleControlEvent` in the PDK for callback signature.
 ]]
-    function public:RegisterHandleControlEvent(control, callback)
+    function methods:RegisterHandleControlEvent(control, callback)
         mixin_helper.assert_argument_type(2, control, "FCControl", "FCMControl")
         mixin_helper.assert_argument_type(3, callback, "function")
 
@@ -629,7 +629,7 @@ Override Changes:
 @ self (FCMCustomLuaWindow)
 @ callback (function) See `HandleTimer` for callback signature (note the change in arguments).
 ]]
-    function public:RegisterHandleTimer(callback)
+    function methods:RegisterHandleTimer(callback)
         mixin_helper.assert_argument_type(2, callback, "function")
 
         private[self].HandleTimer.Registered = callback
@@ -647,7 +647,7 @@ If a handler is added for a timer that hasn't been set, the timer ID will no lon
 @ timerid (number)
 @ callback (function) See `HandleTimer` for callback signature.
 ]]
-    function public:AddHandleTimer(timerid, callback)
+    function methods:AddHandleTimer(timerid, callback)
         mixin_helper.assert_argument_type(2, timerid, "number")
         mixin_helper.assert_argument_type(3, callback, "function")
 
@@ -667,7 +667,7 @@ Removes a handler added with `AddHandleTimer`.
 @ timerid (number)
 @ callback (function)
 ]]
-    function public:RemoveHandleTimer(timerid, callback)
+    function methods:RemoveHandleTimer(timerid, callback)
         mixin_helper.assert_argument_type(2, timerid, "number")
         mixin_helper.assert_argument_type(3, callback, "function")
 
@@ -690,11 +690,11 @@ Override Changes:
 @ timerid (number)
 @ msinterval (number)
 ]]
-    function public:SetTimer(timerid, msinterval)
+    function methods:SetTimer(timerid, msinterval)
         mixin_helper.assert_argument_type(2, timerid, "number")
         mixin_helper.assert_argument_type(3, msinterval, "number")
 
-        self:SetTimer_(timerid, msinterval)
+        self:SetTimer__(timerid, msinterval)
 
         private[self].HandleTimer[timerid] = private[self].HandleTimer[timerid] or {}
     end
@@ -709,7 +709,7 @@ Returns the next available timer ID.
 @ self (FCMCustomLuaWindow)
 : (number)
 ]]
-    function public:GetNextTimerID()
+    function methods:GetNextTimerID()
         while private[self].HandleTimer[private[self].NextTimerID] do
             private[self].NextTimerID = private[self].NextTimerID + 1
         end
@@ -728,7 +728,7 @@ Sets a timer using the next available ID (according to `GetNextTimerID`) and ret
 @ msinterval (number)
 : (number) The ID of the newly created timer.
 ]]
-    function public:SetNextTimer(msinterval)
+    function methods:SetNextTimer(msinterval)
         mixin_helper.assert_argument_type(2, msinterval, "number")
 
         local timerid = mixin.FCMCustomLuaWindow.GetNextTimerID(self)
@@ -751,7 +751,7 @@ This is disabled by default.
 @ self (FCMCustomLuaWindow)
 @ enabled (boolean)
 ]]
-    function public:SetEnableAutoRestorePosition(enabled)
+    function methods:SetEnableAutoRestorePosition(enabled)
         mixin_helper.assert_argument_type(2, enabled, "boolean")
 
         private[self].EnableAutoRestorePosition = enabled
@@ -767,7 +767,7 @@ Returns whether automatic restoration of window position is enabled.
 @ self (FCMCustomLuaWindow)
 : (boolean) `true` if enabled, `false` if disabled.
 ]]
-    function public:GetEnableAutoRestorePosition()
+    function methods:GetEnableAutoRestorePosition()
         return private[self].EnableAutoRestorePosition
     end
 
@@ -785,13 +785,13 @@ Override Changes:
 @ width (number)
 @ height (number)
 ]]
-    function public:SetRestorePositionData(x, y, width, height)
+    function methods:SetRestorePositionData(x, y, width, height)
         mixin_helper.assert_argument_type(2, x, "number")
         mixin_helper.assert_argument_type(3, y, "number")
         mixin_helper.assert_argument_type(4, width, "number")
         mixin_helper.assert_argument_type(5, height, "number")
 
-        self:SetRestorePositionOnlyData_(x, y, width, height)
+        self:SetRestorePositionOnlyData__(x, y, width, height)
 
         if private[self].HasBeenShown and not self:WindowExists() then
             private[self].StoredX = x
@@ -811,11 +811,11 @@ Override Changes:
 @ x (number)
 @ y (number)
 ]]
-    function public:SetRestorePositionOnlyData(x, y)
+    function methods:SetRestorePositionOnlyData(x, y)
         mixin_helper.assert_argument_type(2, x, "number")
         mixin_helper.assert_argument_type(3, y, "number")
 
-        self:SetRestorePositionOnlyData_(x, y)
+        self:SetRestorePositionOnlyData__(x, y)
 
         if private[self].HasBeenShown and not self:WindowExists() then
             private[self].StoredX = x
@@ -836,7 +836,7 @@ This is disabled by default.
 @ self (FCMCustomLuaWindow)
 @ enabled (boolean)
 ]]
-function public:SetEnableDebugClose(enabled)
+function methods:SetEnableDebugClose(enabled)
     mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].EnableDebugClose = enabled and true or false
@@ -850,7 +850,7 @@ Returns the enabled state of the `DebugClose` option.
 @ self (FCMCustomLuaWindow)
 : (boolean) `true` if enabled, `false` if disabled.
 ]]
-function public:GetEnableDebugClose()
+function methods:GetEnableDebugClose()
     return private[self].EnableDebugClose
 end
 
@@ -865,7 +865,7 @@ This is disabled by default.
 @ self (FCMCustomLuaWindow)
 @ enabled (boolean) `true` to enable, `false` to disable.
 ]]
-function public:SetRestoreControlState(enabled)
+function methods:SetRestoreControlState(enabled)
     mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].RestoreControlState = enabled and true or false
@@ -879,7 +879,7 @@ Checks if control state restoration is enabled.
 @ self (FCMCustomLuaWindow)
 : (boolean) `true` if enabled, `false` if disabled.
 ]]
-function public:GetRestoreControlState()
+function methods:GetRestoreControlState()
     return private[self].RestoreControlState
 end
 
@@ -891,7 +891,7 @@ Checks if the window has been shown at least once prior, either as a modal or mo
 @ self (FCMCustomLuaWindow)
 : (boolean) `true` if it has been shown, `false` if not
 ]]
-function public:HasBeenShown()
+function methods:HasBeenShown()
     return private[self].HasBeenShown
 end
 
@@ -908,7 +908,7 @@ Override Changes:
 @ parent (FCCustomWindow | FCMCustomWindow | nil)
 : (number)
 ]]
-function public:ExecuteModal(parent)
+function methods:ExecuteModal(parent)
     if mixin_helper.is_instance_of(parent, "FCMCustomLuaWindow") and private[self].UseParentMeasurementUnit then
         self:SetMeasurementUnit(parent:GetMeasurementUnit())
     end
@@ -929,10 +929,10 @@ Override Changes:
 @ self (FCMCustomLuaWindow)
 : (boolean)
 ]]
-function public:ShowModeless()
+function methods:ShowModeless()
     finenv.RegisterModelessDialog(self)
     restore_position(self)
-    return self:ShowModeless_()
+    return self:ShowModeless__()
 end
 
 --[[
@@ -950,7 +950,7 @@ Runs the window as a self-contained modeless plugin, performing the following st
 @ [selection_not_required] (boolean) If `true` and showing as a modal, will skip checking if a region is selected.
 @ [default_action_override] (boolean | function) If `false`, there will be no default action. If a `function`, overrides the registered `OkButtonPressed` handler as the default action.
 ]]
-function public:RunModeless(selection_not_required, default_action_override)
+function methods:RunModeless(selection_not_required, default_action_override)
     local modifier_keys_on_invoke = finenv.QueryInvokedModifierKeys and (finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT) or finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_SHIFT))
     local default_action = default_action_override == nil and private[self].HandleOkButtonPressed.Registered or default_action_override
 
@@ -986,7 +986,7 @@ Returns the window's current measurement unit.
 @ self (FCMCustomLuaWindow)
 : (number) The value of one of the finale MEASUREMENTUNIT constants.
 ]]
-function public:GetMeasurementUnit()
+function methods:GetMeasurementUnit()
     return private[self].MeasurementUnit
 end
 
@@ -1002,7 +1002,7 @@ All controls that have an `UpdateMeasurementUnit` method will have that method c
 @ self (FCMCustomLuaWindow)
 @ unit (number) One of the finale MEASUREMENTUNIT constants.
 ]]
-function public:SetMeasurementUnit(unit)
+function methods:SetMeasurementUnit(unit)
     mixin_helper.assert_argument_type(2, unit, "number")
 
     if unit == private[self].MeasurementUnit then
@@ -1036,7 +1036,7 @@ Returns the name of the window's current measurement unit.
 @ self (FCMCustomLuaWindow)
 : (string)
 ]]
-function public:GetMeasurementUnitName()
+function methods:GetMeasurementUnitName()
     return measurement.get_unit_name(private[self].MeasurementUnit)
 end
 
@@ -1048,7 +1048,7 @@ Returns a boolean indicating whether this window will use the measurement unit o
 @ self (FCMCustomLuaWindow)
 : (boolean)
 ]]
-function public:GetUseParentMeasurementUnit(enabled)
+function methods:GetUseParentMeasurementUnit(enabled)
     return private[self].UseParentMeasurementUnit
 end
 
@@ -1062,7 +1062,7 @@ Sets whether to use the parent window's measurement unit when opening this windo
 @ self (FCMCustomLuaWindow)
 @ enabled (boolean)
 ]]
-function public:SetUseParentMeasurementUnit(enabled)
+function methods:SetUseParentMeasurementUnit(enabled)
     mixin_helper.assert_argument_type(2, enabled, "boolean")
 
     private[self].UseParentMeasurementUnit = enabled and true or false
@@ -1104,7 +1104,7 @@ Removes a handler added with `AddHandleMeasurementUnitChange`.
 @ self (FCMCustomLuaWindow)
 @ callback (function)
 ]]
-public.AddHandleMeasurementUnitChange, public.RemoveHandleMeasurementUnitChange, trigger_measurement_unit_change, each_last_measurement_unit_change = mixin_helper.create_custom_window_change_event(
+methods.AddHandleMeasurementUnitChange, methods.RemoveHandleMeasurementUnitChange, trigger_measurement_unit_change, each_last_measurement_unit_change = mixin_helper.create_custom_window_change_event(
     {
         name = "last_unit",
         get = function(window)
@@ -1125,7 +1125,7 @@ Creates an `FCXCtrlMeasurementEdit` control.
 @ [control_name] (string)
 : (FCXCtrlMeasurementEdit)
 ]]
-function public:CreateMeasurementEdit(x, y, control_name)
+function methods:CreateMeasurementEdit(x, y, control_name)
     mixin_helper.assert_argument_type(2, x, "number")
     mixin_helper.assert_argument_type(3, y, "number")
     mixin_helper.assert_argument_type(4, control_name, "string", "nil")
@@ -1145,7 +1145,7 @@ Creates a popup which allows the user to change the window's measurement unit.
 @ [control_name] (string)
 : (FCXCtrlMeasurementUnitPopup)
 ]]
-function public:CreateMeasurementUnitPopup(x, y, control_name)
+function methods:CreateMeasurementUnitPopup(x, y, control_name)
     mixin_helper.assert_argument_type(2, x, "number")
     mixin_helper.assert_argument_type(3, y, "number")
     mixin_helper.assert_argument_type(4, control_name, "string", "nil")
@@ -1165,7 +1165,7 @@ Creates a popup which allows the user to select a page size.
 @ [control_name] (string)
 : (FCXCtrlPageSizePopup)
 ]]
-function public:CreatePageSizePopup(x, y, control_name)
+function methods:CreatePageSizePopup(x, y, control_name)
     mixin_helper.assert_argument_type(2, x, "number")
     mixin_helper.assert_argument_type(3, y, "number")
     mixin_helper.assert_argument_type(4, control_name, "string", "nil")
@@ -1174,4 +1174,4 @@ function public:CreatePageSizePopup(x, y, control_name)
     return mixin.subclass(popup, "FCXCtrlPageSizePopup")
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -11,12 +11,12 @@ $module FCMCustomWindow
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local function create_control(self, func, num_args, ...)
-    local control = self["Create" .. func .. "_"](self, ...)
+    local control = self["Create" .. func .. "__"](self, ...)
     private[self].Controls[control:GetControlID()] = control
     control:RegisterParent(self)
 
@@ -41,7 +41,7 @@ end
 
 @ self (FCMCustomWindow)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -319,7 +319,7 @@ for num_args, ctrl_types in pairs({
             goto continue
         end
 
-        public["Create" .. control_type] = function(self, ...)
+        methods["Create" .. control_type] = function(self, ...)
             for i = 1, num_args do
                 mixin_helper.assert_argument_type(i + 1, select(i, ...), "number")
             end
@@ -346,7 +346,7 @@ Port Changes:
 @ control_id (number)
 : (FCMControl | nil)
 ]]
-function public:FindControl(control_id)
+function methods:FindControl(control_id)
     mixin_helper.assert_argument_type(2, control_id, "number")
 
     return private[self].Controls[control_id]
@@ -361,7 +361,7 @@ Finds a control based on its name.
 @ control_name (FCString | string)
 : (FCMControl | nil)
 ]]
-function public:GetControl(control_name)
+function methods:GetControl(control_name)
     mixin_helper.assert_argument_type(2, control_name, "string", "FCString")
 
     return private[self].NamedControls[control_name]
@@ -376,7 +376,7 @@ An iterator for controls that can filter by class.
 @ [class_filter] (string) A class name, can be a parent class. See documentation `mixin.is_instance_of` for details on class filtering.
 : (function) An iterator function.
 ]]
-function public:Each(class_filter)
+function methods:Each(class_filter)
     local i = -1
     local v
     local iterator = function()
@@ -403,8 +403,8 @@ Override Changes:
 @ index (number)
 : (FCMControl)
 ]]
-function public:GetItemAt(index)
-    local item = self:GetItemAt_(index)
+function methods:GetItemAt(index)
+    local item = self:GetItemAt__(index)
     return item and private[self].Controls[item:GetControlID()] or item
 end
 
@@ -418,7 +418,7 @@ Returns the parent window. The parent will only be available while the window is
 @ self (FCMCustomWindow)
 : (FCMCustomWindow | nil) `nil` if no parent
 ]]
-function public:GetParent()
+function methods:GetParent()
     return private[self].Parent
 end
 
@@ -434,11 +434,11 @@ Override Changes:
 @ parent (FCCustomWindow | FCMCustomWindow | nil)
 : (number)
 ]]
-function public:ExecuteModal(parent)
+function methods:ExecuteModal(parent)
     private[self].Parent = parent
-    local ret = self:ExecuteModal_(parent)
+    local ret = self:ExecuteModal__(parent)
     private[self].Parent = nil
     return ret
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMNoteEntry.lua
+++ b/src/mixin/FCMNoteEntry.lua
@@ -9,8 +9,8 @@ $module FCMNoteEntry
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 --[[
@@ -20,7 +20,7 @@ local private = setmetatable({}, {__mode = "k"})
 
 @ self (FCMNoteEntry)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -38,7 +38,7 @@ Registers the collection to which this object belongs.
 @ self (FCMNoteEntry)
 @ parent (FCNoteEntryCell)
 ]]
-function public:RegisterParent(parent)
+function methods:RegisterParent(parent)
     mixin_helper.assert_argument_type(2, parent, "FCNoteEntryCell")
 
     if not private[self].Parent then
@@ -54,8 +54,8 @@ Returns the collection to which this object belongs.
 @ self (FCMNoteEntry)
 : (FCMNoteEntryCell | nil)
 ]]
-function public:GetParent()
+function methods:GetParent()
     return private[self].Parent
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMNoteEntryCell.lua
+++ b/src/mixin/FCMNoteEntryCell.lua
@@ -10,8 +10,8 @@ Summary of modifications:
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 --[[
 % GetItemAt
@@ -26,10 +26,10 @@ This allows the item to be used outside of a `mixin.eachentry` loop.
 @ index (number)
 : (FCMNoteEntry | nil)
 ]]
-function public:GetItemAt(index)
+function methods:GetItemAt(index)
     mixin_helper.assert_argument_type(2, index, "number")
 
-    local item = self:GetItemAt_(index)
+    local item = self:GetItemAt__(index)
     if item then
         item:RegisterParent(self)
     end
@@ -37,4 +37,4 @@ function public:GetItemAt(index)
     return item
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMPage.lua
+++ b/src/mixin/FCMPage.lua
@@ -11,8 +11,8 @@ local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local page_size = require("library.page_size")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 --[[
 % GetSize
@@ -22,7 +22,7 @@ Returns the size of the page.
 @ self (FCMPage)
 : (string | nil) The page size or `nil` if there is no defined size that matches the dimensions of this page.
 ]]
-function public:GetSize()
+function methods:GetSize()
     return page_size.get_page_size(self)
 end
 
@@ -35,7 +35,7 @@ Sets the dimensions of this page to match the given size. Page orientation will 
 @ self (FCMPage)
 @ size (string) A defined page size.
 ]]
-function public:SetSize(size)
+function methods:SetSize(size)
     mixin_helper.assert_argument_type(2, size, "string")
     mixin_helper.assert(page_size.is_size(size), "'" .. size .. "' is not a valid page size.")
 
@@ -50,8 +50,8 @@ Checks if this is a blank page (ie it contains no systems).
 @ self (FCMPage)
 : (boolean) `true` if this page is blank
 ]]
-function public:IsBlank()
+function methods:IsBlank()
     return self:GetFirstSystem() == -1
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMString.lua
+++ b/src/mixin/FCMString.lua
@@ -15,8 +15,8 @@ local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 local measurement = require("library.measurement")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 -- Potential optimisation: reduce checked overrides to necessary minimum
 local unit_overrides = {
@@ -56,7 +56,7 @@ Override Changes:
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT_*` constants.
 : (number) EVPUs with decimal part.
 ]]
-function public:GetMeasurement(measurementunit)
+function methods:GetMeasurement(measurementunit)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     -- Normalise decimal separator
@@ -131,7 +131,7 @@ Override Changes:
 @ maximum (number)
 : (number)
 ]]
-function public:GetRangeMeasurement(measurementunit, minimum, maximum)
+function methods:GetRangeMeasurement(measurementunit, minimum, maximum)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
     mixin_helper.assert_argument_type(3, minimum, "number")
     mixin_helper.assert_argument_type(4, maximum, "number")
@@ -152,7 +152,7 @@ Override Changes:
 @ value (number) The value to set in EVPUs.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT_*` constants.
 ]]
-function public:SetMeasurement(value, measurementunit)
+function methods:SetMeasurement(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number")
 
@@ -189,7 +189,7 @@ Returns the measurement in whole EVPUs.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 : (number)
 ]]
-function public:GetMeasurementInteger(measurementunit)
+function methods:GetMeasurementInteger(measurementunit)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit))
@@ -207,7 +207,7 @@ Also ensures that any decimal places in `minimum` are correctly taken into accou
 @ maximum (number)
 : (number)
 ]]
-function public:GetRangeMeasurementInteger(measurementunit, minimum, maximum)
+function methods:GetRangeMeasurementInteger(measurementunit, minimum, maximum)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
     mixin_helper.assert_argument_type(3, minimum, "number")
     mixin_helper.assert_argument_type(4, maximum, "number")
@@ -226,7 +226,7 @@ Sets a measurement in whole EVPUs.
 @ value (number) The value in whole EVPUs.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
-function public:SetMeasurementInteger(value, measurementunit)
+function methods:SetMeasurementInteger(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number")
 
@@ -242,7 +242,7 @@ Returns the measurement in whole EFIXes (1/64th of an EVPU)
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 : (number)
 ]]
-function public:GetMeasurementEfix(measurementunit)
+function methods:GetMeasurementEfix(measurementunit)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit) * 64)
@@ -259,7 +259,7 @@ Returns the measurement in whole EFIXes (1/64th of an EVPU), clamped between two
 @ maximum (number)
 : (number)
 ]]
-function public:GetRangeMeasurementEfix(measurementunit, minimum, maximum)
+function methods:GetRangeMeasurementEfix(measurementunit, minimum, maximum)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
     mixin_helper.assert_argument_type(3, minimum, "number")
     mixin_helper.assert_argument_type(4, maximum, "number")
@@ -278,7 +278,7 @@ Sets a measurement in whole EFIXes.
 @ value (number) The value in EFIXes (1/64th of an EVPU)
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
-function public:SetMeasurementEfix(value, measurementunit)
+function methods:SetMeasurementEfix(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number")
 
@@ -294,7 +294,7 @@ Returns the measurement in 10,000ths of an EVPU.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 : (number)
 ]]
-function public:GetMeasurement10000th(measurementunit)
+function methods:GetMeasurement10000th(measurementunit)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
 
     return utils.round(mixin.FCMString.GetMeasurement(self, measurementunit) * 10000)
@@ -312,7 +312,7 @@ Also ensures that any decimal places in `minimum` are handled correctly instead 
 @ maximum (number)
 : (number)
 ]]
-function public:GetRangeMeasurement10000th(measurementunit, minimum, maximum)
+function methods:GetRangeMeasurement10000th(measurementunit, minimum, maximum)
     mixin_helper.assert_argument_type(2, measurementunit, "number")
     mixin_helper.assert_argument_type(3, minimum, "number")
     mixin_helper.assert_argument_type(4, maximum, "number")
@@ -331,11 +331,11 @@ Sets a measurement in 10,000ths of an EVPU.
 @ value (number) The value in 10,000ths of an EVPU.
 @ measurementunit (number) One of the `finale.MEASUREMENTUNIT*_` constants.
 ]]
-function public:SetMeasurement10000th(value, measurementunit)
+function methods:SetMeasurement10000th(value, measurementunit)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, measurementunit, "number")
 
     mixin.FCMString.SetMeasurement(self, utils.round(value) / 10000, measurementunit)
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMStrings.lua
+++ b/src/mixin/FCMStrings.lua
@@ -13,8 +13,8 @@ local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local library = require("library.general_library")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local temp_str = finale.FCString()
 
@@ -30,7 +30,7 @@ Override Changes:
 @ self (FCMStrings)
 @ str (FCString | string | number)
 ]]
-function public:AddCopy(str)
+function methods:AddCopy(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     mixin_helper.boolean_to_error(self, "AddCopy", mixin_helper.to_fcstring(str, temp_str))
@@ -44,13 +44,13 @@ Same as `AddCopy`, but accepts multiple arguments so that multiple values can be
 @ self (FCMStrings)
 @ ... (FCStrings | FCString | string | number) `number`s will be cast to `string`
 ]]
-function public:AddCopies(...)
+function methods:AddCopies(...)
     for i = 1, select("#", ...) do
         local v = select(i, ...)
         mixin_helper.assert_argument_type(i + 1, v, "FCStrings", "FCString", "string", "number")
         if mixin_helper.is_instance_of(v, "FCStrings") then
             for str in each(v) do
-                self:AddCopy_(str)
+                self:AddCopy__(str)
             end
         else
             mixin.FCStrings.AddCopy(self, v)
@@ -70,7 +70,7 @@ Override Changes:
 @ str (FCString | string | number)
 : (FCMString | nil)
 ]]
-function public:Find(str)
+function methods:Find(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
     return self:Find_(mixin_helper.to_fcstring(str, temp_str))
@@ -88,10 +88,10 @@ Override Changes:
 @ str (FCString | string | number)
 : (FCMString | nil)
 ]]
-function public:FindNocase(str)
+function methods:FindNocase(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
-    return self:FindNocase_(mixin_helper.to_fcstring(str, temp_str))
+    return self:FindNocase__(mixin_helper.to_fcstring(str, temp_str))
 end
 
 --[[
@@ -106,7 +106,7 @@ Override Changes:
 @ self (FCMStrings)
 @ folderstring (FCString | string)
 ]]
-function public:LoadFolderFiles(folderstring)
+function methods:LoadFolderFiles(folderstring)
     mixin_helper.assert_argument_type(2, folderstring, "string", "FCString")
 
     mixin_helper.boolean_to_error(self, "LoadFolderFiles", mixin_helper.to_fcstring(folderstring, temp_str))
@@ -124,7 +124,7 @@ Override Changes:
 @ self (FCMStrings)
 @ folderstring (FCString | string)
 ]]
-function public:LoadSubfolders(folderstring)
+function methods:LoadSubfolders(folderstring)
     mixin_helper.assert_argument_type(2, folderstring, "string", "FCString")
 
     mixin_helper.boolean_to_error(self, "LoadSubfolders", mixin_helper.to_fcstring(folderstring, temp_str))
@@ -140,7 +140,7 @@ Override Changes:
 
 @ self (FCMStrings)
 ]]
-function public:LoadSymbolFonts()
+function methods:LoadSymbolFonts()
     mixin_helper.boolean_to_error(self, "LoadSymbolFonts")
 end
 
@@ -154,7 +154,7 @@ Override Changes:
 
 @ self (FCMStrings)
 ]]
-function public:LoadSystemFontNames()
+function methods:LoadSystemFontNames()
     mixin_helper.boolean_to_error(self, "LoadSystemFontNames")
 end
 
@@ -171,11 +171,11 @@ Override Changes:
 @ index (number)
 ]]
 if finenv.MajorVersion > 0 or finenv.MinorVersion >= 59 then
-    function public:InsertStringAt(str, index)
+    function methods:InsertStringAt(str, index)
         mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
         mixin_helper.assert_argument_type(3, index, "number")
 
-        self:InsertStringAt_(mixin_helper.to_fcstring(str, temp_str), index)
+        self:InsertStringAt__(mixin_helper.to_fcstring(str, temp_str), index)
     end
 end
 
@@ -191,10 +191,10 @@ Polyfills `FCStrings.CopyFromStringTable` for earlier RGP/JWLua versions.
 @ self (FCMStrings | FCStrings)
 @ strings (table)
 ]]
-function public:CopyFromStringTable(strings)
+function methods:CopyFromStringTable(strings)
     mixin_helper.assert_argument_type(2, strings, "table")
 
-    local suffix = self.MixinClass and "_" or ""
+    local suffix = self.MixinClass and "__" or ""
 
     if finenv.MajorVersion == 0 and finenv.MinorVersion < 64 then
         self:ClearAll()
@@ -217,7 +217,7 @@ Creates a table of Lua `string`s from the `FCString`s in this collection.
 @ self (FCMStrings | FCStrings)
 : (table)
 ]]
-function public:CreateStringTable()
+function methods:CreateStringTable()
     local t = {}
     for str in each(self) do
         table.insert(t, str.LuaString)
@@ -225,4 +225,4 @@ function public:CreateStringTable()
     return t
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMTextExpressionDef.lua
+++ b/src/mixin/FCMTextExpressionDef.lua
@@ -13,8 +13,8 @@ $module FCMTextExpressionDef
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local temp_str = finale.FCString()
@@ -33,7 +33,7 @@ Override Changes:
 @ str (string | FCString) The initializing string
 ]]
 
-function public:SaveNewTextBlock(str)
+function methods:SaveNewTextBlock(str)
     mixin_helper.assert_argument_type(2, str, "string", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
@@ -52,7 +52,7 @@ Override Changes:
 @ cat_def (FCCategoryDef) the parent Category Definition
 ]]
 
-function public:AssignToCategory(cat_def)
+function methods:AssignToCategory(cat_def)
     mixin_helper.assert_argument_type(2, cat_def, "FCCategoryDef")
 
     mixin_helper.boolean_to_error(self, "AssignToCategory", cat_def)
@@ -70,7 +70,7 @@ Override Changes:
 @ enable (boolean)
 ]]
 
-function public:SetUseCategoryPos(enable)
+function methods:SetUseCategoryPos(enable)
     mixin_helper.assert_argument_type(2, enable, "boolean")
 
     mixin_helper.boolean_to_error(self, "SetUseCategoryPos", enable)
@@ -88,7 +88,7 @@ Override Changes:
 @ enable (boolean)
 ]]
 
-function public:SetUseCategoryFont(enable)
+function methods:SetUseCategoryFont(enable)
     mixin_helper.assert_argument_type(2, enable, "boolean")
 
     mixin_helper.boolean_to_error(self, "SetUseCategoryFont", enable)
@@ -109,7 +109,7 @@ Override Changes:
 : (string) If `FCString` is omitted.
 ]]
 
-function public:MakeRehearsalMark(str, measure)
+function methods:MakeRehearsalMark(str, measure)
 
     local do_return = false
 
@@ -143,7 +143,7 @@ Override Changes:
 @ str (string | FCString) The initializing string
 ]]
 
-function public:SaveTextString(str)
+function methods:SaveTextString(str)
     mixin_helper.assert_argument_type(2, str, "string", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
@@ -162,7 +162,7 @@ Override Changes:
 @ self (FCMTextExpressionDef)
 ]]
 
-function public:DeleteTextBlock()
+function methods:DeleteTextBlock()
     mixin_helper.boolean_to_error(self, "DeleteTextBlock")
 end
 
@@ -179,11 +179,11 @@ Override Changes:
 @ str (string | FCString) The initializing string
 ]]
 
-function public:SetDescription(str)
+function methods:SetDescription(str)
     mixin_helper.assert_argument_type(2, str, "string", "FCString")
 
     str = mixin_helper.to_fcstring(str, temp_str)
-    self:SetDescription_(str)
+    self:SetDescription__(str)
 end
 
 --[[
@@ -199,12 +199,12 @@ Override Changes:
 : (string) Returned if `str` is omitted.
 ]]
 
-function public:GetDescription(str)
+function methods:GetDescription(str)
     mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local do_return = not str
     str = str or temp_str
-    self:GetDescription_(str)
+    self:GetDescription__(str)
 
     if do_return then
         return str.LuaString
@@ -223,7 +223,7 @@ Override Changes:
 @ item_num (integer)
 ]]
 
-function public:DeepSaveAs(item_num)
+function methods:DeepSaveAs(item_num)
     mixin_helper.assert_argument_type(2, item_num, "number")
 
     mixin_helper.boolean_to_error(self, "DeepSaveAs", item_num)
@@ -240,9 +240,9 @@ Override Changes:
 @ self (FCMTextExpressionDef)
 ]]
 
-function public:DeepDeleteData()
+function methods:DeepDeleteData()
     mixin_helper.boolean_to_error(self, "DeepDeleteData")
 end
 
 
-return {meta, public}
+return class

--- a/src/mixin/FCMTreeNode.lua
+++ b/src/mixin/FCMTreeNode.lua
@@ -10,8 +10,8 @@ $module FCMTreeNode
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local temp_str = finale.FCString()
 
@@ -27,7 +27,7 @@ Override Changes:
 @ [str] (FCString)
 : (string) Returned if `str` is omitted.
 ]]
-function public:GetText(str)
+function methods:GetText(str)
     mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local do_return = false
@@ -36,7 +36,7 @@ function public:GetText(str)
         do_return = true
     end
 
-    self:GetText_(str)
+    self:GetText__(str)
 
     if do_return then
         return str.LuaString
@@ -54,10 +54,10 @@ Override Changes:
 @ self (FCMTreeNode)
 @ str (FCString | string | number)
 ]]
-function public:SetText(str)
+function methods:SetText(str)
     mixin_helper.assert_argument_type(2, str, "string", "number", "FCString")
 
-    self:SetText_(mixin_helper.to_fcstring(str, temp_str))
+    self:SetText__(mixin_helper.to_fcstring(str, temp_str))
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCMUI.lua
+++ b/src/mixin/FCMUI.lua
@@ -9,8 +9,8 @@ $module FCMUI
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local temp_str = finale.FCString()
 
@@ -26,7 +26,7 @@ Override Changes:
 @ [str] (FCString)
 : (string)
 ]]
-function public:GetDecimalSeparator(str)
+function methods:GetDecimalSeparator(str)
     mixin_helper.assert_argument_type(2, str, "nil", "FCString")
 
     local do_return = false
@@ -35,11 +35,11 @@ function public:GetDecimalSeparator(str)
         do_return = true
     end
 
-    self:GetDecimalSeparator_(str)
+    self:GetDecimalSeparator__(str)
 
     if do_return then
         return str.LuaString
     end
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCXCtrlMeasurementEdit.lua
+++ b/src/mixin/FCXCtrlMeasurementEdit.lua
@@ -20,8 +20,8 @@ local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local utils = require("library.utils")
 
-local meta = {Parent = "FCMCtrlEdit"}
-local public = {}
+local class = {Parent = "FCMCtrlEdit", Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local trigger_change
@@ -64,7 +64,7 @@ end
 
 @ self (FCXCtrlMeasurementEdit)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -121,7 +121,7 @@ for method, valid_types in pairs({
     Integer = {"number"},
     Float = {"number"},
 }) do
-    public["Set" .. method] = function(self, value)
+    methods["Set" .. method] = function(self, value)
         mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         mixin.FCMCtrlEdit["Set" .. method](self, value)
@@ -138,7 +138,7 @@ The default type is `"MeasurementInteger"`.
 @ self (FCXCtrlMeasurementEdit)
 : (string) `"Measurement"`, `"MeasurementInteger"`, `"MeasurementEfix"`, or `"Measurement10000th"`
 ]]
-function public:GetType()
+function methods:GetType()
     return private[self].Type
 end
 
@@ -384,7 +384,7 @@ for method, valid_types in pairs({
     MeasurementEfix = {"number"},
     Measurement10000th = {"number"},
 }) do
-    public["Get" .. method] = function(self)
+    methods["Get" .. method] = function(self)
         local text = mixin.FCMCtrlEdit.GetText(self)
         if (text ~= private[self].LastText) then
             private[self].Value = mixin.FCMCtrlEdit["Get" .. private[self].Type](self, private[self].LastMeasurementUnit)
@@ -394,7 +394,7 @@ for method, valid_types in pairs({
         return convert_type(private[self].Value, private[self].Type, method)
     end
 
-    public["GetRange" .. method] = function(self, minimum, maximum)
+    methods["GetRange" .. method] = function(self, minimum, maximum)
         mixin_helper.assert_argument_type(2, minimum, "number")
         mixin_helper.assert_argument_type(3, maximum, "number")
 
@@ -403,7 +403,7 @@ for method, valid_types in pairs({
         return utils.clamp(mixin.FCXCtrlMeasurementEdit["Get" .. method](self), minimum, maximum)
     end
 
-    public["Set" .. method] = function (self, value)
+    methods["Set" .. method] = function (self, value)
         mixin_helper.assert_argument_type(2, value, table.unpack(valid_types))
 
         private[self].Value = convert_type(value, method, private[self].Type)
@@ -412,11 +412,11 @@ for method, valid_types in pairs({
         trigger_change(self)
     end
 
-    public["IsType" .. method] = function(self)
+    methods["IsType" .. method] = function(self)
         return private[self].Type == method
     end
 
-    public["SetType" .. method] = function(self)
+    methods["SetType" .. method] = function(self)
         private[self].Value = convert_type(private[self].Value, private[self].Type, method)
         for v in each_last_change(self) do
             v.last_value = convert_type(v.last_value, private[self].Type, method)
@@ -435,7 +435,7 @@ Checks the parent window for a change in measurement unit and updates the contro
 
 @ self (FCXCtrlMeasurementEdit)
 ]]
-function public:UpdateMeasurementUnit()
+function methods:UpdateMeasurementUnit()
     local new_unit = self:GetParent():GetMeasurementUnit()
 
     if private[self].LastMeasurementUnit ~= new_unit then
@@ -484,7 +484,7 @@ Override Changes:
 @ self (FCXCtrlMeasurementEdit)
 @ callback (function)
 ]]
-public.AddHandleChange, public.RemoveHandleChange, trigger_change, each_last_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandleChange, methods.RemoveHandleChange, trigger_change, each_last_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_value",
         get = function(self)
@@ -494,4 +494,4 @@ public.AddHandleChange, public.RemoveHandleChange, trigger_change, each_last_cha
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCXCtrlMeasurementUnitPopup.lua
+++ b/src/mixin/FCXCtrlMeasurementUnitPopup.lua
@@ -31,8 +31,8 @@ local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 local measurement = require("library.measurement")
 
-local meta = {Parent = "FCMCtrlPopup"}
-local public = {}
+local class = {Parent = "FCMCtrlPopup", Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local unit_order = {
@@ -46,10 +46,8 @@ for k, v in ipairs(unit_order) do
 end
 
 -- Disabled methods
-mixin_helper.disable_methods(
-    public, "Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetSelectedLast",
-    "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange",
-    "RemoveHandleSelectionChange")
+class.Disabled = {"Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetSelectedLast",
+    "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange", "RemoveHandleSelectionChange"}
 
 --[[
 % Init
@@ -58,7 +56,7 @@ mixin_helper.disable_methods(
 
 @ self (FCXCtrlMeasurementUnitPopup)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -87,7 +85,7 @@ Checks the parent window's measurement unit and updates the selection if necessa
 
 @ self (FCXCtrlMeasurementUnitPopup)
 ]]
-function public:UpdateMeasurementUnit()
+function methods:UpdateMeasurementUnit()
     local unit = self:GetParent():GetMeasurementUnit()
 
     if unit == unit_order[mixin.FCMCtrlPopup.GetSelectedItem(self) + 1] then
@@ -97,4 +95,4 @@ function public:UpdateMeasurementUnit()
     mixin.FCMCtrlPopup.SetSelectedItem(self, flipped_unit_order[unit] - 1)
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCXCtrlPageSizePopup.lua
+++ b/src/mixin/FCXCtrlPageSizePopup.lua
@@ -33,8 +33,8 @@ local mixin_helper = require("library.mixin_helper")
 local measurement = require("library.measurement")
 local page_size = require("library.page_size")
 
-local meta = {Parent = "FCMCtrlPopup"}
-local public = {}
+local class = {Parent = "FCMCtrlPopup", Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local trigger_page_size_change
@@ -43,8 +43,8 @@ local each_last_page_size_change
 local temp_str = finale.FCString()
 
 -- Disabled methods
-mixin_helper.disable_methods(public, "Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetSelectedLast",
-    "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange", "RemoveHandleSelectionChange")
+class.Disabled = {"Clear", "AddString", "AddStrings", "SetStrings", "GetSelectedItem", "SetSelectedItem", "SetSelectedLast",
+    "ItemExists", "InsertString", "DeleteItem", "GetItemText", "SetItemText", "AddHandleSelectionChange", "RemoveHandleSelectionChange"}
 
 local function repopulate(control)
     local unit = mixin_helper.is_instance_of(control:GetParent(), "FCXCustomLuaWindow") and control:GetParent():GetMeasurementUnit() or measurement.get_real_default_unit()
@@ -80,7 +80,7 @@ end
 
 @ self (FCXCtrlPageSizePopup)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -101,7 +101,7 @@ Returns the selected page size.
 @ [str] (FCString) Optional `FCString` to populate with page size.
 : (string | nil) Returned if `str` is omitted. The page size or `nil` if nothing is selected.
 ]]
-function public:GetSelectedPageSize(str)
+function methods:GetSelectedPageSize(str)
     mixin_helper.assert_argument_type(2, str, "FCString", "nil")
 
     local size = mixin.FCMCtrlPopup.GetSelectedString(self)
@@ -126,7 +126,7 @@ Sets the selected page size. Must be a valid page size.
 @ self (FCXCtrlPageSizePopup)
 @ size (FCString | string) Name of page size (case-sensitive).
 ]]
-function public:SetSelectedPageSize(size)
+function methods:SetSelectedPageSize(size)
     mixin_helper.assert_argument_type(2, size, "string", "FCString")
     
     size = type(size) == "userdata" and size.LuaString or tostring(size)
@@ -156,7 +156,7 @@ Checks the parent window's measurement and updates the displayed page dimensions
 
 @ self (FCXCtrlPageSizePopup)
 ]]
-function public:UpdateMeasurementUnit()
+function methods:UpdateMeasurementUnit()
     repopulate(self)
 end
 
@@ -195,7 +195,7 @@ Removes a handler added with `AddHandlePageSizeChange`.
 @ self (FCXCtrlPageSizePopup)
 @ callback (function) Handler to remove.
 ]]
-public.AddHandlePageSizeChange, public.RemoveHandlePageSizeChange, trigger_page_size_change, each_last_page_size_change = mixin_helper.create_custom_control_change_event(
+methods.AddHandlePageSizeChange, methods.RemoveHandlePageSizeChange, trigger_page_size_change, each_last_page_size_change = mixin_helper.create_custom_control_change_event(
     {
         name = "last_page_size",
         get = function(ctrl)
@@ -205,4 +205,4 @@ public.AddHandlePageSizeChange, public.RemoveHandlePageSizeChange, trigger_page_
     }
 )
 
-return {meta, public}
+return class

--- a/src/mixin/FCXCtrlUpDown.lua
+++ b/src/mixin/FCXCtrlUpDown.lua
@@ -18,8 +18,8 @@ An up down control that is created by `FCXCustomLuaWindow`.
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {Parent = "FCMCtrlUpDown"}
-local public = {}
+local class = {Parent = "FCMCtrlUpDown", Methods = {}}
+local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local temp_str = finale.FCString()
@@ -64,7 +64,7 @@ local default_efix_steps = {
 
 @ self (FCXCtrlUpDown)
 ]]
-function meta:Init()
+function class:Init()
     if private[self] then
         return
     end
@@ -161,7 +161,7 @@ Override Changes:
 @ self (FCXCtrlUpDown)
 : (FCMCtrlEdit | nil) `nil` if there is no edit connected.
 ]]
-function public:GetConnectedEdit()
+function methods:GetConnectedEdit()
     return private[self].ConnectedEdit
 end
 
@@ -178,7 +178,7 @@ The underlying methods used in `GetValue` and `SetValue` will be `GetRangeIntege
 @ minimum (number)
 @ maximum (maximum)
 ]]
-function public:ConnectIntegerEdit(control, minimum, maximum)
+function methods:ConnectIntegerEdit(control, minimum, maximum)
     mixin_helper.assert_argument_type(2, control, "FCMCtrlEdit")
     mixin_helper.assert_argument_type(3, minimum, "number")
     mixin_helper.assert_argument_type(4, maximum, "number")
@@ -202,7 +202,7 @@ The underlying methods used in `GetValue` and `SetValue` will depend on the meas
 @ minimum (number)
 @ maximum (maximum)
 ]]
-function public:ConnectMeasurementEdit(control, minimum, maximum)
+function methods:ConnectMeasurementEdit(control, minimum, maximum)
     mixin_helper.assert_argument_type(2, control, "FCXCtrlMeasurementEdit")
     mixin_helper.assert_argument_type(3, minimum, "number")
     mixin_helper.assert_argument_type(4, maximum, "number")
@@ -223,7 +223,7 @@ Sets the step size for integer edits.
 @ self (FCXCtrlUpDown)
 @ value (number)
 ]]
-function public:SetIntegerStepSize(value)
+function methods:SetIntegerStepSize(value)
     mixin_helper.assert_argument_type(2, value, "number")
 
     private[self].IntegerStepSize = value
@@ -239,7 +239,7 @@ Sets the step size for measurement edits that are currently displaying in EVPUs.
 @ self (FCXCtrlUpDown)
 @ value (number)
 ]]
-function public:SetEVPUsStepSize(value)
+function methods:SetEVPUsStepSize(value)
     mixin_helper.assert_argument_type(2, value, "number")
 
     private[self].MeasurementSteps[finale.MEASUREMENTUNIT_EVPUS] = {value = value, is_evpus = true}
@@ -256,7 +256,7 @@ Sets the step size for measurement edits that are currently displaying in Inches
 @ value (number)
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Inches.
 ]]
-function public:SetInchesStepSize(value, is_evpus)
+function methods:SetInchesStepSize(value, is_evpus)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
@@ -277,7 +277,7 @@ Sets the step size for measurement edits that are currently displaying in Centim
 @ value (number)
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Centimeters.
 ]]
-function public:SetCentimetersStepSize(value, is_evpus)
+function methods:SetCentimetersStepSize(value, is_evpus)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
@@ -298,7 +298,7 @@ Sets the step size for measurement edits that are currently displaying in Points
 @ value (number)
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Points.
 ]]
-function public:SetPointsStepSize(value, is_evpus)
+function methods:SetPointsStepSize(value, is_evpus)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
@@ -319,7 +319,7 @@ Sets the step size for measurement edits that are currently displaying in Picas.
 @ value (number|string)
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Picas.
 ]]
-function public:SetPicasStepSize(value, is_evpus)
+function methods:SetPicasStepSize(value, is_evpus)
     mixin_helper.assert_argument_type(2, value, "number", "string")
 
     if not is_evpus then
@@ -341,7 +341,7 @@ Sets the step size for measurement edits that are currently displaying in Spaces
 @ value (number)
 @ [is_evpus] (boolean) If `true`, the value will be treated as an EVPU value. If `false` or omitted, the value will be treated in Spaces.
 ]]
-function public:SetSpacesStepSize(value, is_evpus)
+function methods:SetSpacesStepSize(value, is_evpus)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert_argument_type(3, is_evpus, "boolean", "nil")
 
@@ -361,7 +361,7 @@ Sets whether to align to the next multiple of a step when moving.
 @ self (FCXCtrlUpDown)
 @ on (boolean)
 ]]
-function public:SetAlignWhenMoving(on)
+function methods:SetAlignWhenMoving(on)
     mixin_helper.assert_argument_type(2, on, "boolean")
 
     private[self].AlignWhenMoving = on
@@ -383,7 +383,7 @@ Different types of connected edits will return different types and use different
 @ self (FCXCtrlUpDown)
 : (number) An integer for an integer edit, EVPUs for a measurement edit, whole EVPUs for a measurement integer edit, or EFIXes for a measurement EFIX edit.
 ]]
-function public:GetValue()
+function methods:GetValue()
     if not private[self].ConnectedEdit then
         return
     end
@@ -413,7 +413,7 @@ Different types of connected edits will accept different types and use different
 @ self (FCXCtrlUpDown)
 @ value (number) An integer for an integer edit, EVPUs for a measurement edit, whole EVPUs for a measurement integer edit, or EFIXes for a measurement EFIX edit.
 ]]
-function public:SetValue(value)
+function methods:SetValue(value)
     mixin_helper.assert_argument_type(2, value, "number")
     mixin_helper.assert(private[self].ConnectedEdit, "Unable to set value: no connected edit.")
 
@@ -438,7 +438,7 @@ end
 @ self (FCMCtrlUpDown)
 : (number) An integer for integer edits or EVPUs for measurement edits.
 ]]
-function public:GetMinimum()
+function methods:GetMinimum()
     return private[self].Minimum
 end
 
@@ -451,7 +451,7 @@ end
 : (number) An integer for integer edits or EVPUs for measurement edits.
 ]]
 
-function public:GetMaximum()
+function methods:GetMaximum()
     return private[self].Maximum
 end
 
@@ -464,7 +464,7 @@ end
 @ minimum (number) An integer for integer edits or EVPUs for measurement edits.
 @ maximum (number) An integer for integer edits or EVPUs for measurement edits.
 ]]
-function public:SetRange(minimum, maximum)
+function methods:SetRange(minimum, maximum)
     mixin_helper.assert_argument_type(2, minimum, "number")
     mixin_helper.assert_argument_type(3, maximum, "number")
 
@@ -472,4 +472,4 @@ function public:SetRange(minimum, maximum)
     private[self].Maximum = maximum
 end
 
-return {meta, public}
+return class

--- a/src/mixin/FCXCustomLuaWindow.lua
+++ b/src/mixin/FCXCustomLuaWindow.lua
@@ -13,8 +13,8 @@ local utils = require("library.utils")
 local mixin_helper = require("library.mixin_helper")
 local measurement = require("library.measurement")
 
-local meta = {Parent = "FCMCustomLuaWindow"}
-local public = {}
+local class = {Parent = "FCMCustomLuaWindow", Methods = {}}
+local methods = class.Methods
 
 local trigger_measurement_unit_change
 local each_last_measurement_unit_change
@@ -26,7 +26,7 @@ local each_last_measurement_unit_change
 
 @ self (FCXCustomLuaWindow)
 ]]
-function meta:Init()
+function class:Init()
     self:SetEnableDebugClose(true)
 end
 
@@ -44,7 +44,7 @@ Override Changes:
 @ [control_name] (string)
 : (FCXCtrlUpDown)
 ]]
-function public:CreateUpDown(x, y, control_name)
+function methods:CreateUpDown(x, y, control_name)
     mixin_helper.assert_argument_type(2, x, "number")
     mixin_helper.assert_argument_type(3, y, "number")
     mixin_helper.assert_argument_type(4, control_name, "string", "nil")
@@ -53,4 +53,4 @@ function public:CreateUpDown(x, y, control_name)
     return mixin.subclass(updown, "FCXCtrlUpDown")
 end
 
-return {meta, public}
+return class

--- a/src/mixin/__FCMUserWindow.lua
+++ b/src/mixin/__FCMUserWindow.lua
@@ -10,8 +10,8 @@ $module __FCMUserWindow
 local mixin = require("library.mixin")
 local mixin_helper = require("library.mixin_helper")
 
-local meta = {}
-local public = {}
+local class = {Methods = {}}
+local methods = class.Methods
 
 local temp_str = finale.FCString()
 
@@ -27,7 +27,7 @@ Override Changes:
 @ [title] (FCString)
 : (string) Returned if `title` is omitted.
 ]]
-function public:GetTitle(title)
+function methods:GetTitle(title)
     mixin_helper.assert_argument_type(2, title, "nil", "FCString")
 
     local do_return = false
@@ -36,7 +36,7 @@ function public:GetTitle(title)
         do_return = true
     end
 
-    self:GetTitle_(title)
+    self:GetTitle__(title)
 
     if do_return then
         return title.LuaString
@@ -54,10 +54,10 @@ Override Changes:
 @ self (__FCMUserWindow)
 @ title (FCString | string | number)
 ]]
-function public:SetTitle(title)
+function methods:SetTitle(title)
     mixin_helper.assert_argument_type(2, title, "string", "number", "FCString")
 
-    self:SetTitle_(mixin_helper.to_fcstring(title, temp_str))
+    self:SetTitle__(mixin_helper.to_fcstring(title, temp_str))
 end
 
-return {meta, public}
+return class


### PR DESCRIPTION
Originally I had just intended to add properties but then it became apparent that other changes needed be made in order for that to work so this PR has ended up becoming rather large. I would like to be able to call the `mixin.lua` library stable after this PR, so I've tried to get as many potential issues resolved as I can. Updated documentation will come in a follow-up PR.

## Summary of changes

**Updated Format**
I've slightly modified the mixin format again for improved extensibility and future-proofing. It now looks like this:
```lua
-- All fields are optional except for Parent in FCX mixins
local class = {
    Parent = "FCMParentClass", -- FCX only
    Init = function(self) ... end,
    Methods = {...},
    StaticMethods = {...},
    Properties = {...},
    Disabled = {...},
}
...
...
return class
```

**`class.Methods`**
Methods have moved from what was previously a catch-all 'public' table for pretty much any property/method, to a dedicated table for methods. All fields must be functions.

**`class.StaticMethods`**
Static methods are now defined in a `StaticMethods` table. Static methods cannot be accessed through an object, only via the `mixin` namespace.

**`class.Properties`**
Mixins can now have properties with defined getters and setters. Here's a brief example:
```lua
class.Properties = {
    Foo = {
        Get = function(self) return private[self].Foo end,
        Set = function(self, value) private[self].Foo = value end,
    },
}
```
Although not shown in the above example, the main advantages of having get/set functions is to provide control over writability and being able to validate any assigned values.

Properties are inherited and can be overridden in the same way as methods.

Properties can also be accessed statically in the same way as methods if needed:
```lua
local dialog = mixin.FCXCustomLuaWindow()
mixin.FCMCustomLuaWindow.SomeCustomProperty.Set(dialog)
```

**Name Clashes**
A method or a static method or a property cannot share the same name, including clashes that occur via inheritance. Clashing names will result in an error during mixin loading.

**`class.Disabled`**
The mixin library itself now supports disabling properties or methods directly, without needing to rely on helper functions. Disabled properties/methods simply return `nil` and cannot be overwritten (attempting to set a disabled property/method will result in an error).
```lua
-- FCMCustomLuaWindow.lua
class.Disabled = {"MethodOne", "MethodTwo", "PropertyOne"}
...

-- script.lua
local dialog = mixin.FCMCustomLuaWindow()
dialog.MethodOne = function() return true end -- Error: No writable member named 'MethodOne'
dialog.PropertyOne = true -- Error: No writable member named 'PropertyOne'
```

**Reflection**
I have added reflection properties to the `mixin` namespace in a similar vein to the `finale` namespace (`__class` for methods, `__static` for static methods, `__propget` for property getters and `__propset` for property setters). I also added an additional property, `__disabled`, for disabled methods & properties. I don't think there's much of a use for this right now but it should allow all sorts of testing to be done without needing to make any changes to `mixin.lua`.

**Error Checking**
Introduced more stringent validation during the loading of mixins and more helpful error messages.

**`personal_mixins`**
`personal_mixins` will now only be loaded if `finenv.TrustedMode ~= true`.

**Original Method**
Referencing an original `FC` method is now done with a double underscore instead of a single (ie `edit:SetText__(str)`) which is more conventional and visually clearer. Let me know if you see any issues with this.

## Issues to Resolve
I did originally have a longer list but I solved most of them as I went along.

**Checking name and type clashes with `FC` classes**
I started adding checks for clashes between mixins and their underlying `FC` classes (ie not overriding methods with properties and vice versa, parent mixin not having method that is introduced in child `FC`, etc) but it started to turn into quite a large undertaking so I took it out. Rather than adding bloat to `dist` scripts, I'm wondering if that would be better placed in a testing suite?

**Reflected Methods**
Should the original methods be returned via reflection or should they be be proxied (not to be fluid, just for automatic mixin enabling of any returned objects)? At the moment they are proxied and I can't think of any reasons for not doing it, but I thought I'd ask anyway in case I missed something.

**Constants**
Not a blocking issue, but I would like to implement custom constants (something like `mixin.MEASUREMENTSUFFIX_SHORT`) but I haven't worked out a good way of doing it at the global level (ie not just per mixin). Maybe just put them in their own file? Let me know if you have any ideas.

cc @rpatters1 @cv-on-hub