### PR TITLE
add explicit request to be able to modify Finale's menus

### DIFF
--- a/src/finale_lua_menu_organizer.lua
+++ b/src/finale_lua_menu_organizer.lua
@@ -5,6 +5,7 @@ function plugindef()
     finaleplugin.RequireSelection = false
     finaleplugin.NoStore = true
     finaleplugin.ExecuteAtStartup = true
+    finaleplugin.ModifyFinaleMenus = true
     finaleplugin.IncludeInPluginMenu = false
     finaleplugin.LoadLuaOSUtils = true
     finaleplugin.Author = "Robert Patterson"


### PR DESCRIPTION
This PR adds a `plugindef` option to the finale menu organizer that will be required in the next version of RGP Lua.