### PR TITLE
Fix name of function in docs

### DIFF
--- a/src/mixin/FCMCtrlCheckbox.lua
+++ b/src/mixin/FCMCtrlCheckbox.lua
@@ -44,7 +44,7 @@ end
 ]]
 
 --[[
-% AddHandleChange
+% AddHandleCheckChange
 
 **[Fluid]**
 


### PR DESCRIPTION
Incorrect function name given in https://www.finalelua.com/docs/mixin/FCMCtrlCheckbox

I assume the website docs will regenerate after this is merged, right?