### PR TITLE
Add .gitattributes to check out lua with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lua  text eol=lf


### PR DESCRIPTION
This is to fix the issue where Windows checks out files with CRLF, and then the script hashes don't match.