### PR TITLE
Update meter_set_numeric.lua

### DIFF
--- a/src/meter_set_numeric.lua
+++ b/src/meter_set_numeric.lua
@@ -1,185 +1,225 @@
+local info = [[
+"Meter Set Numeric" provides rapid entry of simple or complex 
+time signatures with a few keystrokes. 
+It supports composite numerators like [3+2+3/16] and can join 
+with further composites (e.g. [3+2+3/16]+[1/4]+[5+4/8]). 
+"Display only" time signatures can be equally complex. 
+At startup the time signature of the first selected measure is shown. 
+Click the "Clear All" button to revert to a simple 4/4 with no other options.
+
+All measures in the current selection will be assigned the new time signature. 
+If just one measure is selected only it will be changed.
+
+"Bottom" numbers (denominators) are the usual "note" numbers: 2, 4, 8, 16, 32, 64. 
+"Top" numbers (numerators) are integers, optionally joined by '+' signs for composite meters. 
+Multiples of 3 automatically convert to compound signatures so [9/16] will 
+convert to three groups of dotted 8ths. 
+To prevent automatic compounding, instead of the bottom 'note' number enter its EDU value 
+(quarter note = 1024; eighth note = 512 etc).
+
+Empty and zero "Top" numbers will be ignored. 
+If "Secondary" numbers are zero then "Tertiary" values are ignored. 
+]]
 function plugindef()
 	finaleplugin.RequireSelection = true
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "http://carlvine.com/?cv=lua"
     finaleplugin.Copyright = "https://creativecommons.org/licenses/by/4.0/"
-    finaleplugin.Version = "0.59"
-    finaleplugin.Date = "2023/03/07"
+    finaleplugin.Version = "0.68"
+    finaleplugin.Date = "2023/06/12"
     finaleplugin.MinJWLuaVersion = 0.60
-    finaleplugin.Notes = [[
-        This script is keyboard focussed with minimal mouse action allowing rapid entry of complex time signatures with a few keystrokes. 
-        It supports composite numerators allowing meters like (3+2+3/16) in conjunction with further composites (e.g. (3+2+3/16)+(1/4)+(5+4/8)). 
-        Alternate "display" time signatures can be equally complex. 
-        At startup the script shows the time signature of the first selected measure. 
-        Click the "Clear All" button to revert to a simple 4/4 with no other options or, ideally, 
-        use a keyboard macro app like Keyboard Maestro to click the button in response to a keystroke!)
-
-        All measures in the currently selected region will be assigned the new time signature. 
-        If one measure is selected only it will be affected. 
-        (Unlike the default Finale behaviour of "change every measure until next meter change").
-
-        "Bottom" numbers (denominators) are the usual "note" numbers - 2, 4, 8, 16, 32 or 64. 
-        "Top" numbers (numerators) must be integers, optionally joined by '+' signs. 
-        Multiples of 3 will automatically convert to compound signatures so, for instance, 
-        (9/16) will convert to three groups of dotted 8ths. 
-        To suppress automatic compounding, instead of the bottom 'note' number enter its EDU equivalent 
-        (quarter note = 1024; eighth note = 512 etc) but be careful since Finale can get confused if the number is inappropriate.
-
-        Empty and zero "Top" numbers are ignored. 
-        If the "Secondary" Top is zero, "Tertiary" values are ignored. 
-        Finale's Time Signature tool will also accept "Top" numbers with decimals but I haven't allowed for that in this script.
-    ]]
+    finaleplugin.Notes = info
 	return "Meter Set Numeric", "Meter Set Numeric", "Set the Meter Numerically"
 end
 
-function user_chooses_meter(meters, region)
-    local horiz = { 0, 70, 130, 210, 290, 300 } -- dialog items grid
-    local vert = { 0, 20, 40, 60, 82, 115, 135, 155, 175 }
-    local start = region.StartMeasure
-    local stop = region.EndMeasure
-    local left_shift =  19 -- horizontal shift left for the longer "SECONDARY" name
-    local mac_offset = finenv.UI():IsOnMac() and 3 or 0
-    local user_entry = {} -- compile a bunch of edit fields
-    local message = "m. " .. start -- measure selection information
-    if stop ~= start then  -- multiple measures
-        message = "m" .. message .. "-" .. stop
-    end
-
-    local dialog = finale.FCCustomLuaWindow()
-    local str = finale.FCString()
-    str.LuaString = plugindef() -- get script name
-    dialog:SetTitle(str)
-    dialog:CreateHorizontalLine(horiz[1], vert[6] - 9, horiz[5] + 80)
-
-    local texts = { -- words, horiz, vert position
-        { "TIME SIGNATURE:", horiz[1], vert[1] },
-        { "TOP", horiz[3], vert[1] },               { "BOTTOM", horiz[4], vert[1] },
-        { "PRIMARY", horiz[2], vert[2] },           { "Selection:", horiz[6], vert[2]+ 5 },
-        { "SECONDARY", horiz[2] - left_shift, vert[3] }, { message, horiz[6], vert[3] }, -- "mm. START-STOP"
-        { "TERTIARY", horiz[2] - 3, vert[4] },
-        { "('TOP' entries can include integers joined by '+')", horiz[2] - 30, vert[5] },
-        { "DISPLAY SIGNATURE:", horiz[1], vert[6] },  { "(set to \"0\" for none)", horiz[3], vert[6] },
-        { "PRIMARY", horiz[2], vert[7] },
-        { "SECONDARY", horiz[2] - left_shift, vert[8] },
-        { "TERTIARY", horiz[2] - 3, vert[9] },
+--[[
+    This version uses a new (intelligible!) data structure for composite Time Signatures:
+    local meter = {
+        main = { 
+            top = { {element_1a, element_1b, element_1c}, {element_2a, etc. ...}, {... element_3c} }, 
+            bottom = {group_1, group_2, group_3}
+        },
+        display =  {
+            top = { {element_1a, element_1b, element_1c}, etc. ... }, 
+            bottom = {group_1, group_2, group_3}
+        },
     }
-    for i,v in ipairs(texts) do -- write static text items
-        local static = dialog:CreateStatic(v[2], v[3])
-        str.LuaString = v[1]
-        static:SetText(str)
-        static:SetWidth( (#v[1] * 6) + 20 ) -- wide enough for item text (circa 6 pix per char plus a bit)
+]]
+
+local mixin = require("library.mixin")
+local configuration = require("library.configuration")
+local config = {
+    note_spacing = true,
+    window_pos_x = false,
+    window_pos_y = false,
+}
+local script_name = "meter_set_numeric"
+configuration.get_user_settings(script_name, config, true)
+
+function blank_meter()
+    return { -- empty composite meter record
+        main = { top = {}, bottom = {} },
+        display =  { top = {}, bottom = {} }
+    }
+end
+
+function dialog_set_position(dialog)
+    if config.window_pos_x and config.window_pos_y then
+        dialog:StorePosition()
+        dialog:SetRestorePositionOnlyData(config.window_pos_x, config.window_pos_y)
+        dialog:RestorePosition()
+    end
+end
+
+function dialog_save_position(dialog)
+    dialog:StorePosition()
+    config.window_pos_x = dialog.StoredX
+    config.window_pos_y = dialog.StoredY
+    configuration.save_user_settings(script_name, config)
+end
+
+function user_chooses_meter(meter, rgn)
+    local x = { 0, 70, 130, 210, 280, 290 } -- horizontal grid
+    local label = {"PRIMARY", "(+ SECONDARY)", "(+ TERTIARY)"}
+    local label_off = { 0, -37, -21 } -- horizontal offset for these names (ranged right)
+    local y_middle = 118 -- window vertical mid-point
+    local offset = finenv.UI():IsOnMac() and 3 or 0
+    local message = "m. " .. rgn.StartMeasure -- measure selection information
+    if rgn.StartMeasure ~= rgn.EndMeasure then  -- multiple measures
+        message = "m" .. message .. "-" .. rgn.EndMeasure
+    end
+    local y = 0
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle(plugindef())
+    -- STATIC TEXT ELEMENTS
+    local function cstat(nx, ny, nwide, ntext)
+        local dx = (type(nx) == "number") and x[nx] or tonumber(nx)
+        return dialog:CreateStatic(dx, ny):SetWidth(nwide):SetText(ntext)
+    end
+    local function join(values) -- join integers from the meter.top array with '+' signs
+        if not values or #values == 0 then return "0" end
+        return table.concat(values, "+")
+    end
+    local shadow = cstat("1", y + 1, x[3], "TIME SIGNATURE")
+    if shadow.SetTextColor then shadow:SetTextColor(153, 153, 153) end
+    cstat(1, y, x[3], "TIME SIGNATURE")
+    cstat(3, y, x[3], "TOP")
+    cstat(4, y, x[3], "BOTTOM")
+    cstat(6, 25, 80, "Selection:")
+    cstat(6, 40, 80, message)
+    y = y_middle
+    cstat(x[2] - 30, y - 30, 330, "'TOP' entries can include integers joined by '+' signs")
+    dialog:CreateHorizontalLine(x[1], y - 9, x[5] + 50)
+    dialog:CreateHorizontalLine(x[1], y - 8, x[5] + 50)
+    shadow = cstat("1", y + 1, x[3], "DISPLAY SIGNATURE")
+    if shadow.SetTextColor then shadow:SetTextColor(153, 153, 153) end
+    cstat(1, y, x[3], "DISPLAY SIGNATURE")
+    cstat(3, y, 150, "(set to '0' for none)")
+    dialog:CreateButton(x[5] + 60, y):SetText("?"):SetWidth(20)
+        :AddHandleCommand(function() finenv.UI():AlertInfo(info:gsub(" \n", " "), "INFO: Meter Set Numeric") end)
+
+    -- USER EDIT BOXES
+    y = 0
+    local box = {} -- user's edit-box entry responses
+    for jump = 0, 6, 6 do
+        local t_sig = (jump == 0) and meter.main or meter.display
+        for group = 1, 3 do
+            y = y + 20
+            local id = group + jump
+            box[id] = dialog:CreateEdit(x[3], y - offset, tostring(id))
+                :SetText(join(t_sig.top[group])):SetWidth(65)
+            box[id + 3] = dialog:CreateEdit(x[4], y - offset, tostring(id + 3))
+                :SetInteger(t_sig.bottom[group] or 0):SetWidth(65)
+            cstat(x[2] + label_off[group], y, 95, label[group])
+        end
+        y = y_middle
     end
 
-    for i, v in ipairs(meters) do -- create all meter numeric entry boxes
-        local vert_step = math.floor((i - 1) / 2) + 2
-        if i > 6 then
-            vert_step = vert_step + 2  -- middle two lines are instructions
-        end
-        local top_bottom = 4 - (i % 2) -- 'TOP' or 'BOTTOM' position x-value
-        user_entry[i] = dialog:CreateEdit(horiz[top_bottom], vert[vert_step] - mac_offset)
-        user_entry[i]:SetWidth(70)
-        str.LuaString = tostring(v)
-        if i % 2 == 1 then  -- string for TOP meter number
-            user_entry[i]:SetText(str) -- string for TOP (split into tables later)
-        else    -- plain integer for BOTTOM meter number
-            user_entry[i]:SetInteger(v) -- integer for BOTTOM
-        end
-    end
-
-    -- "CLEAR ALL" button to reset meter defaults
-    local clear_button = dialog:CreateButton(horiz[5], vert[1] - 2)
-    str.LuaString = "Clear All"
-    clear_button:SetWidth(80)
-    clear_button:SetText(str)
-
-    dialog:RegisterHandleControlEvent ( clear_button,
-        function()
-            local str2 = finale.FCString()
-            str2.LuaString = "4"
-            user_entry[1]:SetText(str2)
-            user_entry[2]:SetInteger(4)
-            str2.LuaString = "0"
-            for i = 3, 11, 2 do -- clear all other edit boxes
-                user_entry[i]:SetText(str2)
-                user_entry[i + 1]:SetInteger(0)
+    dialog:CreateCheckbox(x[3], y_middle + 85, "spacing"):SetText("Respace notes on completion")
+        :SetCheck(config.note_spacing and 1 or 0):SetWidth(170)
+    local clear_button = dialog:CreateButton(x[5], 0):SetWidth(80):SetText("Clear All")
+    clear_button:AddHandleCommand(function()
+            box[1]:SetText("4")
+            box[4]:SetInteger(4)
+            for _, i in ipairs({2, 3, 7, 8, 9}) do -- "clear" the other edit boxes
+                box[i]:SetText("0")
+                box[i + 3]:SetInteger(0)
             end
-            user_entry[1]:SetFocus()
+            box[1]:SetFocus()
         end
     )
     dialog:CreateOkButton()
     dialog:CreateCancelButton()
-    local ok = dialog:ExecuteModal(nil)  -- run the dialog
-
-    for i = 1, #meters do  -- collate user input
-        if i % 2 == 1 then    -- string for TOP
-            user_entry[i]:GetText(str)
-            meters[i] = str.LuaString
-        else              -- integer for BOTTOM
-            meters[i] = user_entry[i]:GetInteger()
+    local choices = {} -- convert edit box values to 12-element table
+    dialog:RegisterInitWindow(function() box[1]:SetKeyboardFocus() end)
+    -- "TOP" values are strings, "BOTTOMS" are integers
+    dialog:RegisterHandleOkButtonPressed(function(self)
+        for count = 0, 6, 6 do -- "main" then "display" t_sig values
+            for group = 1, 3 do
+                local id = count + group
+                choices[id] = self:GetControl(tostring(id)):GetText() or "0"
+                choices[id + 3] = math.abs(self:GetControl(tostring(id + 3)):GetInteger()) or 0
+            end
         end
-    end
-    return ok
+        config.note_spacing = (self:GetControl("spacing"):GetCheck() == 1)
+        dialog_save_position(self) -- save window position and config choices
+    end)
+    dialog_set_position(dialog)
+    local ok = dialog:ExecuteModal(nil)  -- run the dialog
+    return ok, choices
 end
 
-function encode_existing_meter(time_sig, meters, index_offset)
-    -- convert existing meter to our { meters } filing method
+function encode_current_meter(time_sig, sub_meter)
+    local function numerators_treble(top_table)
+        for j = 1, #top_table do
+            top_table[j] = top_table[j] * 3
+        end
+    end
+
     if time_sig.CompositeTop then
         local comp_top = time_sig:CreateCompositeTop()
         local group_count = comp_top:GetGroupCount()
-        if group_count > 3 then 
-            group_count = 3 -- three composites max
-        end
-        for i = 0, group_count - 1 do -- add elements of each group
-            local top_string = ""  -- empty string to index_offset
-            for element_count = 0, comp_top:GetGroupElementCount(i) - 1 do
-                if element_count > 0 then -- plus sign after first number
-                    top_string = top_string .. "+"
-                end
-                top_string = top_string .. comp_top:GetGroupElementBeats(i, element_count)
+        if group_count > 3 then group_count = 3 end -- 3 groups max
+        for i = 1, group_count do -- add each group
+            sub_meter.top[i] = {}
+            for element = 1, comp_top:GetGroupElementCount(i - 1) do
+                sub_meter.top[i][element] = comp_top:GetGroupElementBeats(i - 1, element - 1)
             end
-            meters[(i * 2) + index_offset] = top_string -- save the string result
         end
-    else    -- non-composite TOP, simple number string
-        meters[index_offset] = "" .. time_sig.Beats
+    else    -- non-composite TOP
+        sub_meter.top[1] = { time_sig.Beats }
     end
 
     if time_sig.CompositeBottom then
         local comp_bottom = time_sig:CreateCompositeBottom()
         local group_count = comp_bottom:GetGroupCount()
-        if group_count > 3 then
-            group_count = 3 -- 3 composites max
-        end
-        for i = 0, group_count - 1 do
-            -- assume one element for each composite bottom
-            local beat_duration = comp_bottom:GetGroupElementBeatDuration(i, 0)
-            local bottom_offset = (i * 2) + index_offset -- offset for individual composites
-            if beat_duration % 3 == 0 and not string.find(meters[bottom_offset], "+") then 
-                meters[bottom_offset] = "" .. ( meters[bottom_offset] * 3 ) -- create compound meter
+        if group_count > 3 then group_count = 3 end -- 3 groups max
+        for i = 1, group_count do
+            local beat_duration = comp_bottom:GetGroupElementBeatDuration(i - 1, 0)
+            if beat_duration % 3 == 0 then
                 beat_duration = beat_duration / 3
+                numerators_treble(sub_meter.top[i])
             end
-            meters[bottom_offset + 1] = math.floor(4096 / beat_duration) -- round to integer in case
+            sub_meter.bottom[i] = math.floor(4096 / beat_duration) -- round to integer in case
         end
     else    -- non-composite BOTTOM
         local beat_duration = time_sig.BeatDuration
-        if beat_duration % 3 == 0 and not string.find(meters[index_offset], "+") then
-            meters[index_offset] = "" .. ( meters[index_offset] * 3 ) -- create compound meter
+        if beat_duration % 3 == 0 then
             beat_duration = beat_duration / 3
+            numerators_treble(sub_meter.top[1])
         end
-        meters[index_offset + 1] = math.floor(4096 / beat_duration) -- round to integer in case
+        sub_meter.bottom[1] = math.floor(4096 / beat_duration)
     end
 end
 
-function copy_meters_from_score(meters, measure_number)
+function copy_meter_from_score(measure_number)
     local measure = finale.FCMeasure()
     measure:Load(measure_number)
-    encode_existing_meter(measure:GetTimeSignature(), meters, 1)  -- encode primary meter - offset to meters[1]
-    if measure.UseTimeSigForDisplay then    -- encode DISPLAY meter - offset to meters[7]
-        encode_existing_meter(measure.TimeSignatureForDisplay, meters, 7)
+    local meter = blank_meter()
+    encode_current_meter(measure:GetTimeSignature(), meter.main)
+    if measure.UseTimeSigForDisplay then
+        encode_current_meter(measure.TimeSignatureForDisplay, meter.display)
     end
-end
-
-function is_positive_integer(x)
-    return x ~= nil and x > 0 and x % 1 == 0
+    return meter
 end
 
 function is_power_of_two(num)
@@ -190,108 +230,73 @@ function is_power_of_two(num)
     return current == num
 end
 
-function convert_meter_pairs_to_numbers(top_index, meters)
-    -- 'TOP' indexed meter is a string of numbers, possibly joined by "+" signs
-    -- convert to a table of simple integers
-    if meters[top_index] == "0" or meters[top_index] == "" then
-        meters[top_index] = { 0 } -- zero array for numerators
-        if top_index == 1 then
-            return "Primary time signature can not be zero"
-        else
-            return "" -- nil result ... BOTTOM (denominator) is irrelevant
-        end
+function convert_choices_to_meter(choices, meter)
+    if choices[1] == "0" or choices[4] == 0 then
+        return "Primary time signature cannot be zero"
     end
-    if string.find(meters[top_index], "[+ -/]") then -- TOP number string contains "+" or other divider
-        -- COMPLEX string numerator: split into integers
-        local string_copy = meters[top_index] -- copy the string
-        meters[top_index] = {} -- start over with empty table of integers
-        for split_number in string.gmatch(string_copy, "[0-9]+") do -- split numbers
-        	local as_number = tonumber(split_number)
-            if not is_positive_integer(as_number) then -- positive integer resultor?
-                return "All numbers must be positive integers\n(not " .. as_number .. ")"
+    for jump = 0, 6, 6 do -- 'main' meter then 'display' meter
+        local data = (jump == 0) and meter.main or meter.display
+        for count = 1, 3 do
+            -- 'TOP' NUMBERS
+            local c_count = count + jump
+            local value = choices[c_count]
+            if value == "0" or choices[c_count + 3] == 0 then
+                break -- no valid meter values
             end
-            table.insert(meters[top_index], as_number)    -- else add integer to table
-        end
-    else -- simple integer, re-store as single-element table
-        local as_number = tonumber(meters[top_index])
-        if not is_positive_integer(as_number) then
-            return "All numbers must be positive integers\n(not " .. as_number .. ")"
-        end
-        meters[top_index] = { as_number }    -- save single integer table
-    end
+            if string.find(value, "^%d") then -- string contains non-numeric characters
+                data.top[count] = {}
+                for split in string.gmatch(value, "%d+") do
+                    table.insert(data.top[count], tonumber(split))
+                end
+            else
+                data.top[count] = { tonumber(choices[c_count]) } -- single integer value
+            end
+            -- 'BOTTOM' NUMBERS
+            local bottom = choices[c_count + 3]
+            if bottom <= 64 and bottom > 0 then -- must be a NOTE VALUE (64th note or smaller) not EDU
+                if not is_power_of_two(bottom) then
+                    return "DENOMINATORS must be powers of 2\n(not " .. bottom .. ")"
+                end
+                bottom = 4096 / bottom  -- convert to EDU
 
-    -- 'BOTTOM' numeric DENOMINATOR (top_index + 1)
-    -- must be simple integer, power of 2 ... convert NOTE NUMBER to EDU value, with compounding
-    local bottom_index = top_index + 1
-    local denominator = meters[bottom_index]
-    if denominator == 0 then  -- no meter here!
-        return ""
-    end
-    if not is_positive_integer(denominator) then
-        return "All numbers must be positive integers\n(not " .. denominator .. ")"
-    end
-    if denominator <= 64 then -- must be a NOTE VALUE (64th note or smaller) not EDU
-        if not is_power_of_two(denominator) then
-            return "Denominators must be powers of 2\n(not " .. denominator .. ")"
-        end
-        denominator = 4096 / denominator  -- convert to EDU
-        -- check for COMPOUND meter
-        if #meters[top_index] == 1 then -- single number, simple numerator
-            local numerator = meters[top_index][1]
-            -- convert to COMPOUND METER if not a display meter (top_index >= 7)
-            if top_index < 7 and numerator % 3 == 0 and denominator < 1024 then -- (8th notes or smaller)
-                meters[top_index][1] = numerator / 3 -- numerator divide by 3
-                denominator = denominator * 3   -- denominator multiply by 3
+                if #data.top[count] == 1 then -- not composite so check for compound
+                    local n = data.top[count][1]
+                    if n % 3 == 0 and jump == 0 and bottom < 1024 then -- (8th notes or smaller)
+                        data.top[count][1] = n / 3 -- COMPOUND METER: so numerator divide by 3
+                        bottom = bottom * 3   -- and denominator multiply by 3
+                    end
+                end
             end
+            data.bottom[count] = bottom
         end
-        meters[bottom_index] = denominator
     end
-    return ""   -- no errors
+    return "" -- no error
 end
 
-function new_composite_top(numerator_valuesA, numerator_valuesB, numerator_valuesC)
-    -- each numerator_values is a table of one or more integers to be composite meter numerators
+function new_composite_top(sub_meter)
     local composite_top = finale.FCCompositeTimeSigTop()
-    local group = composite_top:AddGroup(#numerator_valuesA)
-    for i = 1, #numerator_valuesA do
-        composite_top:SetGroupElementBeats(group, i - 1, numerator_valuesA[i])
-    end
-
-    if numerator_valuesB[1] ~= 0 then    -- secondary numerator is required
-        group = composite_top:AddGroup(#numerator_valuesB)
-        for i = 1, #numerator_valuesB do
-            composite_top:SetGroupElementBeats(group, i - 1, numerator_valuesB[i])
-        end
-        -- only add numerator_valuesC if numerator_valuesB is non-nil
-        if numerator_valuesC[1] ~= 0 then    -- non-nul tertiary
-            group = composite_top:AddGroup(#numerator_valuesC)
-            for i = 1, #numerator_valuesC do
-                composite_top:SetGroupElementBeats(group, i - 1, numerator_valuesC[i])
-            end
+    for count = 1, 3 do
+        if not sub_meter[count] or sub_meter[count][1] == 0 then break end
+        local group = composite_top:AddGroup(#sub_meter[count])
+        for i = 1, #sub_meter[count] do
+            composite_top:SetGroupElementBeats(group, i - 1, sub_meter[count][i])
         end
     end
     composite_top:SaveAll()
     return composite_top
 end
 
-function new_composite_bottom(denominatorA, denominatorB, denominatorC)
-    -- each number is an EDU value for meter denominator (bottom number)
+function new_composite_bottom(sub_meter)
     local composite_bottom = finale.FCCompositeTimeSigBottom()
-    local new_group = composite_bottom:AddGroup(1)
-    composite_bottom:SetGroupElementBeatDuration(new_group, 0, denominatorA)
-
-    if denominatorB > 0 then
-        new_group = composite_bottom:AddGroup(1)
-        composite_bottom:SetGroupElementBeatDuration(new_group, 0, denominatorB)
-        -- only consider denominatorC if denominatorB is non-zero
-        if denominatorC > 0 then
-            new_group = composite_bottom:AddGroup(1)
-            composite_bottom:SetGroupElementBeatDuration(new_group, 0, denominatorC)
-        end
+    for count = 1, 3 do
+        if not sub_meter[count] or sub_meter[count] == 0 then break end
+        local group = composite_bottom:AddGroup(1)
+        composite_bottom:SetGroupElementBeatDuration(group, 0, sub_meter[count])
     end
     composite_bottom:SaveAll()
     return composite_bottom
 end
+
 
 function fix_new_top(composite_top, time_sig, numerator)
     if composite_top ~= nil then    -- COMPOSITE top
@@ -318,63 +323,55 @@ function fix_new_bottom(composite_bottom, time_sig, denominator)
 end
 
 function create_new_meter()
-    local region = finenv.Region()
-    -- preset "all zero" basic meters - 6 sets of top/bottom pairs
-    --  "real" meter   1   +      2   +   3  | display meter 1    +     2    +   3   
-    local meters = { "4", 4,   "0", 0,   "0", 0,           "0", 0,   "0", 0,   "0", 0,  }
+    local region = mixin.FCMMusicRegion()
+    region:SetRegion(finenv.Region()):SetStartMeasurePosLeft():SetEndMeasurePosRight()
 
-    copy_meters_from_score(meters, region.StartMeasure) -- examine and encode original meter from start of selection
-    local ok = user_chooses_meter(meters, region) -- user choices stored in meters { }
+    local meter = copy_meter_from_score(region.StartMeasure)
+    local ok, choices = user_chooses_meter(meter, region) -- save user choices as 12-element table
 	if ok ~= finale.EXECMODAL_OK then return end -- user cancelled
 
-    for index_pairs = 1, 11, 2 do -- check 6 top/bottom pairs
-        local msg = convert_meter_pairs_to_numbers(index_pairs, meters)
-        if msg ~= "" then
-            finenv.UI():AlertInfo(msg, plugindef())
-            return
-        end
-    end
-    --  -----------
-    -- NOTE that "meters" table now equals
-    -- TOPS (1,3,5 / 7,9,11) = arrays of integers, BOTTOMS (2,4,6 / 8,10,12) = simple integers
-    --  -----------
-    -- new COMPOSITE METERS TABLE to hold FOUR combined composite Time Signatures:
-    -- "REAL" = 1 (top) / 2 (bottom) | "DISPLAY" = 3 (top) / 4 (bottom)
-    local composites = { nil, nil, nil, nil }
-    for i = 0, 1 do  -- PRIMARY meters then DISPLAY meters
-        local step = i * 6 -- 6 steps between "real" and "display" meter numbers in { meters }
-        if #meters[step + 1] > 1 or meters[step + 3][1] ~= 0 then -- composite TOP
-            composites[(i * 2) + 1] = new_composite_top(meters[step + 1], meters[step + 3], meters[step + 5])
-        end
-        -- composite BOTTOM?
-        if composites[(i * 2) + 1] ~= nil and meters[step + 3][1] ~= 0 then
-            composites[(i * 2) + 2] = new_composite_bottom(meters[step + 2], meters[step + 4], meters[step + 6])
+    meter = blank_meter() -- start over with an empty meter
+    local msg = convert_choices_to_meter(choices, meter)
+    if msg ~= "" then finenv.UI():AlertInfo(msg, plugindef()) return end -- entry error
+
+    local composites = {
+        main = { top = nil, bottom = nil},
+        display = { top = nil, bottom = nil}
+    }
+    for _, kind in ipairs({"main", "display"}) do
+        if meter[kind].top[1] and (#meter[kind].top > 1 or #meter[kind].top[1] > 1) then
+            composites[kind].top = new_composite_top(meter[kind].top)
+            if #meter[kind].bottom > 1 then
+                composites[kind].bottom = new_composite_bottom(meter[kind].bottom)
+            end
         end
     end
 
-    --  -----------
-    region.StartMeasurePos = 0    -- set to whole stack (in case it is safer)
-    region:SetEndMeasurePosRight()
-    region:SetFullMeasureStack()
     local measures = finale.FCMeasures()
     measures:LoadRegion(region)
-
     for measure in each(measures) do
         local time_sig = measure:GetTimeSignature()
-        fix_new_top(composites[1], time_sig, meters[1][1])
-        fix_new_bottom(composites[2], time_sig, meters[2])
+        fix_new_top(composites.main.top, time_sig, meter.main.top[1][1])
+        fix_new_bottom(composites.main.bottom, time_sig, meter.main.bottom[1])
 
-        if meters[7][1] ~= 0 then -- new, unique Display meter
+        if #meter.display.top > 0 then -- new DISPLAY meter
             measure.UseTimeSigForDisplay = true
             local display_sig = measure.TimeSignatureForDisplay
             if display_sig then
-                fix_new_top(composites[3], display_sig, meters[7][1])
-                fix_new_bottom(composites[4], display_sig, meters[8])
+                fix_new_top(composites.display.top, display_sig, meter.display.top[1][1])
+                fix_new_bottom(composites.display.bottom, display_sig, meter.display.bottom[1])
             end
-        else   -- suppress display time_sig
-            measure.UseTimeSigForDisplay = false
+        else
+            measure.UseTimeSigForDisplay = false -- suppress display time_sig
         end
         measure:Save()
+    end
+    if config.note_spacing then
+        local space_rgn = mixin.FCMMusicRegion()
+        space_rgn:SetRegion(region):SetFullMeasureStack()
+        space_rgn:SetInDocument()
+        finenv.UI():MenuCommand(finale.MENUCMD_NOTESPACING)
+        region:SetInDocument()
     end
 end
 


### PR DESCRIPTION
I'm sure this script used to automate note-spacing after change if `Automatic Note Spacing` was selected, but not any more. So added **Note Spacing** option to dialog. Also ground-up re-write of the `time_sig` data structure so it is at last intelligible. Also added keyboard focus to first data entry in dialog on InitWIndow().