### PR TITLE
Update lyrics_baseline_spacing.lua

### DIFF
--- a/src/lyrics_baseline_spacing.lua
+++ b/src/lyrics_baseline_spacing.lua
@@ -58,7 +58,7 @@ function lyrics_spacing(title)
 --
 
     function add_ctrl(dialog, ctrl_type, text, x, y, h, w, min, max)
-        str.LuaString = text
+        str.LuaString = tostring(text)
         local ctrl = ""
         if ctrl_type == "checkbox" then
             ctrl = dialog:CreateCheckbox(x, y)


### PR DESCRIPTION
Added tostring() function to avoid data type mismatch error under Lua 5.4.