### PR TITLE
mixin fix to prevent button creep in macOS dialogs

### DIFF
--- a/src/mixin/FCMControl.lua
+++ b/src/mixin/FCMControl.lua
@@ -342,10 +342,10 @@ function methods:StoreState()
     private[self].Text = temp_str.LuaString
     private[self].Enable = self:GetEnable__()
     private[self].Visible = self:GetVisible__()
-    private[self].Left = self:GetLeft__()
-    private[self].Top = self:GetTop__()
     private[self].Height = self:GetHeight__()
     private[self].Width = self:GetWidth__()
+    private[self].Left = self:GetLeft__()
+    private[self].Top = self:GetTop__()
 end
 
 --[[

--- a/src/mixin/FCMControl.lua
+++ b/src/mixin/FCMControl.lua
@@ -362,10 +362,10 @@ Restores the control's stored state.
 function methods:RestoreState()
     self:SetEnable__(private[self].Enable)
     self:SetVisible__(private[self].Visible)
-    self:SetLeft__(private[self].Left)
-    self:SetTop__(private[self].Top)
     self:SetHeight__(private[self].Height)
     self:SetWidth__(private[self].Width)
+    self:SetLeft__(private[self].Left)
+    self:SetTop__(private[self].Top) -- keep SetTop after SetHeight to work around height bug in macOS buttons
 
     -- Call SetText last to work around the Mac text box issue described above
     temp_str.LuaString = private[self].Text

--- a/src/mixin/FCMCustomLuaWindow.lua
+++ b/src/mixin/FCMCustomLuaWindow.lua
@@ -44,17 +44,10 @@ local function flush_custom_queue(self)
 end
 
 local function restore_position(self)
-    if private[self].HasBeenShown then
-        if private[self].EnableAutoRestorePosition and self.StorePosition then
-            self:StorePosition(false)
-            self:SetRestorePositionOnlyData__(private[self].StoredX, private[self].StoredY)
-            self:RestorePosition()
-        end
-        if private[self].RestoreControlState then
-            for control in each(self) do
-                control:RestoreState()
-            end
-        end
+    if private[self].HasBeenShown and private[self].EnableAutoRestorePosition and self.StorePosition then
+        self:StorePosition(false)
+        self:SetRestorePositionOnlyData__(private[self].StoredX, private[self].StoredY)
+        self:RestorePosition()
     end
 end
 
@@ -163,6 +156,12 @@ function class:Init()
 
         if event == "InitWindow" then
             self["Register" .. event .. "__"](self, function(...)
+                if private[self].HasBeenShown and private[self].RestoreControlState then
+                    for control in each(self) do
+                        control:RestoreState()
+                    end
+                end
+
                 dispatch_event_handlers(self, event, self, ...)
             end)
         elseif event == "CloseWindow" then

--- a/src/mixin/FCMCustomLuaWindow.lua
+++ b/src/mixin/FCMCustomLuaWindow.lua
@@ -44,10 +44,17 @@ local function flush_custom_queue(self)
 end
 
 local function restore_position(self)
-    if private[self].HasBeenShown and private[self].EnableAutoRestorePosition and self.StorePosition then
-        self:StorePosition(false)
-        self:SetRestorePositionOnlyData__(private[self].StoredX, private[self].StoredY)
-        self:RestorePosition()
+    if private[self].HasBeenShown then
+        if private[self].EnableAutoRestorePosition and self.StorePosition then
+            self:StorePosition(false)
+            self:SetRestorePositionOnlyData__(private[self].StoredX, private[self].StoredY)
+            self:RestorePosition()
+        end
+        if private[self].RestoreControlState then
+            for control in each(self) do
+                control:RestoreState()
+            end
+        end
     end
 end
 
@@ -156,12 +163,6 @@ function class:Init()
 
         if event == "InitWindow" then
             self["Register" .. event .. "__"](self, function(...)
-                if private[self].HasBeenShown and private[self].RestoreControlState then
-                    for control in each(self) do
-                        control:RestoreState()
-                    end
-                end
-
                 dispatch_event_handlers(self, event, self, ...)
             end)
         elseif event == "CloseWindow" then


### PR DESCRIPTION
This PR fixes #588.

I am proposing this change to mixin control restore handling to place it before the window starts running. The PDK Framework has a bug on the macOS side that calling `FCControl::SetHeight` after the window is running causes `NSButton` controls to meander up the window each time the same instance of `FCCustomLuaWindow` is used open a window. Addressing the issue in `mixin` is the preferred solution because:

- It allows an immediate fix to all supported versions of Lua on Finale.
- This particular code in the PDK Framework is complicated and modifications are likely to introduce new issues. I don't think a fix in the Framework is worth the risk of breaking something else.

What say you, @ThistleSifter ?
