### PR TITLE
replace hyphen string with N-dash string.

### DIFF
--- a/src/smufl_multisegment_curves.lua
+++ b/src/smufl_multisegment_curves.lua
@@ -118,7 +118,7 @@ local function create_dialog_box()
         x_off = right_side and text_width/2 + 40 or 0
         dlg:CreateStatic(x_off, y_off)
             :SetWidth(250)
-            :SetText("-----------" .. label_text .. "-----------")
+            :SetText("–––––––––––" .. label_text .. "–––––––––––")
         y_off = y_off + button_height
         for utf8char = utf8_first, utf8_last do
             add_button(utf8char, fontsize)


### PR DESCRIPTION
The deployment script thinks a double hyphen inside a string is a comment delimiter, which was trashing the dist version of the script. I changed the hyphens to n-dashes.