### PR TITLE
Rgp refactor transposition library

### DIFF
--- a/src/accidental_simplify.lua
+++ b/src/accidental_simplify.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "August 22, 2021"
+    finaleplugin.Version = "1.1"
+    finaleplugin.Date = "January 9, 2024"
     finaleplugin.CategoryTags = "Accidental"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     return "Simplify accidentals", "Simplify accidentals", "Removes all double sharps and flats by respelling them"
@@ -17,7 +17,7 @@ function accidentals_simplify()
         local staff_number = entry.Staff
         local cell = finale.FCCell(measure_number, staff_number)
         local key_signature = cell:GetKeySignature()
-
+        
         for note in transposition.each_to_transpose(entry) do
             if note.RaiseLower ~= 0 then
                 -- Use note_string rather than note.RaiseLower because

--- a/src/accidental_simplify.lua
+++ b/src/accidental_simplify.lua
@@ -13,37 +13,30 @@ local transposition = require("library.transposition")
 
 function accidentals_simplify()
     for entry in eachentrysaved(finenv.Region()) do
-        if not entry:IsNote() then
-            goto continue_entry_loop
-        end
         local measure_number = entry.Measure
         local staff_number = entry.Staff
         local cell = finale.FCCell(measure_number, staff_number)
         local key_signature = cell:GetKeySignature()
 
-        for note in each(entry) do
-            if note.RaiseLower == 0 then
-                goto continue_note_loop
+        for note in transposition.each_to_transpose(entry) do
+            if note.RaiseLower ~= 0 then
+                -- Use note_string rather than note.RaiseLower because
+                -- with key signatures, note.RaiseLower returns the alteration
+                -- from the key signature, not the actual accidental.
+                -- For instance, in the key of A, a Gb has a RaiseLower of -2
+                -- even though Gb is not a double flat.
+
+                local fs_note_string = finale.FCString()
+                note:GetString(fs_note_string, key_signature, false, false)
+                local note_string = fs_note_string:GetLuaString()
+
+                -- checking for 'bb' and '##' will also match triple sharps and flats
+                if string.match(note_string, "bb") or string.match(note_string, "##") then
+                    transposition.enharmonic_transpose(note, note.RaiseLower)
+                    transposition.simplify_spelling(note)
+                end
             end
-
-            -- Use note_string rather than note.RaiseLower because
-            -- with key signatures, note.RaiseLower returns the alteration
-            -- from the key signature, not the actual accidental.
-            -- For instance, in the key of A, a Gb has a RaiseLower of -2
-            -- even though Gb is not a double flat.
-
-            local fs_note_string = finale.FCString()
-            note:GetString(fs_note_string, key_signature, false, false)
-            local note_string = fs_note_string:GetLuaString()
-
-            -- checking for 'bb' and '##' will also match triple sharps and flats
-            if string.match(note_string, "bb") or string.match(note_string, "##") then
-                transposition.enharmonic_transpose(note, note.RaiseLower)
-                transposition.chromatic_transpose(note, 0, 0, true)
-            end
-            ::continue_note_loop::
         end
-        ::continue_entry_loop::
     end
 end
 

--- a/src/library/client.lua
+++ b/src/library/client.lua
@@ -124,7 +124,7 @@ For a list of valid features, see the [`features` table in the codebase](https:/
 : (boolean)
 ]]
 function client.supports(feature)
-    if features[feature].test == nil then
+    if features[feature] == nil then
         error("a test does not exist for feature " .. feature, 2)
     end
     return features[feature].test

--- a/src/pitch_entry_double_at_interval.lua
+++ b/src/pitch_entry_double_at_interval.lua
@@ -43,22 +43,10 @@ function plugindef()
 end
 
 local transposition = require("library.transposition")
-local note_entry = require("library.note_entry")
 
 function pitch_entry_double_at_interval(interval)
     for entry in eachentrysaved(finenv.Region()) do
-        local note_count = entry.Count
-        local note_index = 0
-        for note in each(entry) do
-            note_index = note_index + 1
-            if note_index > note_count then
-                break
-            end
-            local new_note = note_entry.duplicate_note(note)
-            if new_note then
-                transposition.diatonic_transpose(new_note, interval)
-            end
-        end
+        transposition.entry_diatonic_transpose(entry, interval, true) -- true: preserve originals
     end
 end
 

--- a/src/pitch_entry_double_at_interval.lua
+++ b/src/pitch_entry_double_at_interval.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "2.0"
-    finaleplugin.Date = "May 5, 2022"
+    finaleplugin.Version = "2.1"
+    finaleplugin.Date = "January 9, 2024"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     finaleplugin.MinJWLuaVersion = 0.62

--- a/src/transpose_by_step.lua
+++ b/src/transpose_by_step.lua
@@ -42,13 +42,6 @@ end
 local transposition = require("library.transposition")
 local mixin = require("library.mixin")
 
-local function do_stepwise(note, number_of_steps)
-    if not note.GetTransposer then -- if our plugin verison does not have FCTransposer
-        return transposition.stepwise_transpose(note, number_of_steps)
-    end
-    return note:GetTransposer():EDOStepTranspose(number_of_steps)
-end
-
 function do_transpose_by_step(global_number_of_steps_edit)
     if finenv.Region():IsEmpty() then
         return
@@ -60,10 +53,8 @@ function do_transpose_by_step(global_number_of_steps_edit)
     local success = true
     finenv.StartNewUndoBlock(undostr, false) -- this works on both JW Lua and RGP Lua
     for entry in eachentrysaved(finenv.Region()) do
-        for note in each(entry) do
-            if not do_stepwise(note, global_number_of_steps_edit) then
-                success = false
-            end
+        if not transposition.entry_stepwise_transpose(entry, global_number_of_steps_edit) then
+            success = false
         end
     end
     if finenv.EndUndoBlock then -- EndUndoBlock only exists on RGP Lua 0.56 and higher

--- a/src/transpose_by_step.lua
+++ b/src/transpose_by_step.lua
@@ -3,8 +3,8 @@ function plugindef()
     finaleplugin.HandlesUndo = true -- not recognized by JW Lua or RGP Lua v0.55
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.1"
-    finaleplugin.Date = "January 20, 2022"
+    finaleplugin.Version = "1.2"
+    finaleplugin.Date = "January 9, 2024"
     finaleplugin.CategoryTags = "Note"
     finaleplugin.Notes = [[
         This script allows you to specify a number of chromatic steps by which to transpose and the script

--- a/src/transpose_enharmonic_down.lua
+++ b/src/transpose_enharmonic_down.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "March 25, 2021"
+    finaleplugin.Version = "1.1"
+    finaleplugin.Date = "January 9, 2024"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.Notes = [[
         In normal 12-note music, enharmonically transposing is the same as transposing by a diminished 2nd.
@@ -35,10 +35,8 @@ local transposition = require("library.transposition")
 function transpose_enharmonic_down()
     local success = true
     for entry in eachentrysaved(finenv.Region()) do
-        for note in each(entry) do
-            if not transposition.enharmonic_transpose(note, -1) then
-                success = false
-            end
+        if not transposition.entry_enharmonic_transpose(entry, -1) then
+            success = false
         end
     end
     if not success then

--- a/src/transpose_enharmonic_up.lua
+++ b/src/transpose_enharmonic_up.lua
@@ -2,8 +2,8 @@ function plugindef()
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0"
-    finaleplugin.Date = "March 25, 2021"
+    finaleplugin.Version = "1.1"
+    finaleplugin.Date = "January 9, 2024"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.Notes = [[
         In normal 12-note music, enharmonically transposing is the same as transposing by a diminished 2nd.
@@ -35,10 +35,8 @@ local transposition = require("library.transposition")
 function transpose_enharmonic_up()
     local success = true
     for entry in eachentrysaved(finenv.Region()) do
-        for note in each(entry) do
-            if not transposition.enharmonic_transpose(note, 1) then
-                success = false
-            end
+        if not transposition.entry_enharmonic_transpose(entry, 1) then
+            success = false
         end
     end
     if not success then


### PR DESCRIPTION
- refactor transposition library to encapsulate best practices.
- call `FCTransposer` functions when possible.
- ignore rests
- modify all existing callers to use new functions as appropriate
