### PR TITLE
Mixin Refinements

### DIFF
--- a/samples/modeless_dialog.lua
+++ b/samples/modeless_dialog.lua
@@ -1,5 +1,6 @@
 function plugindef()
     finaleplugin.RequireDocument = false
+    finaleplugin.MinJWLuaVersion = 0.68
     finaleplugin.Notes = [[
         This script illustrates how to set up a modeless dialog box.
     ]]
@@ -10,138 +11,141 @@ if not finenv.ConsoleIsAvailable then
     require('mobdebug').start()
 end
 
+local mixin = require("library.mixin")
+
 local strings = {"Option 1", "Option 2", "Option 3"}
 local strings2 = {"Long Suboption 1", "Long Suboption 2"}
 
-local dlg = finale.FCCustomLuaWindow()
+local function create_dialog()
+    local dlg = mixin.FCXCustomLuaWindow()
+    dlg:SetTitle(finale.FCString("RGP Lua Modeless Test"))
 
-local str = finale.FCString()
-str.LuaString = "RGP Lua Modeless Test"
-dlg:SetTitle(str)
+    local do_something = dlg:CreateButton(0, 0, "do")
+    do_something:SetText(finale.FCString("Do Something"))
+    do_something:SetWidth(150)
 
-local do_something = dlg:CreateButton(0, 0)
-str.LuaString = "Do Something"
-do_something:SetText(str)
-do_something:SetWidth(150)
+    local radio_button_values = {} -- key: button group, value: last seen selected item
 
-local radio_button_values = {} -- key: button group, value: last seen selected item
-
-local button_group1 = dlg:CreateRadioButtonGroup(0, 30, 3)
-local v1 = -1
-local strs = finale.FCStrings()
-strs:CopyFromStringTable(strings)
-button_group1:SetText(strs)
-radio_button_values[button_group1.GroupID] = button_group1:GetSelectedItem()
+    local button_group1 = dlg:CreateRadioButtonGroup(0, 30, 3, "radio1")
+    local strs = finale.FCStrings()
+    strs:CopyFromStringTable(strings)
+    button_group1:SetText(strs)
+    radio_button_values[button_group1.GroupID] = button_group1:GetSelectedItem()
 
 
-local button_group2 = dlg:CreateRadioButtonGroup(0, 100, 2)
-strs:CopyFromStringTable(strings2)
-button_group2:SetText(strs)
-button_group2:SetWidth(150)
-radio_button_values[button_group2.GroupID] = button_group2:GetSelectedItem()
+    local button_group2 = dlg:CreateRadioButtonGroup(0, 100, 2, "radio2")
+    strs:CopyFromStringTable(strings2)
+    button_group2:SetText(strs)
+    button_group2:SetWidth(150)
+    radio_button_values[button_group2.GroupID] = button_group2:GetSelectedItem()
 
-dlg:RegisterInitWindow(function()
-        button_group1:MoveAllRelative(20, 10)
-    end)
+    dlg:RegisterInitWindow(function()
+            button_group1:MoveAllRelative(20, 10)
+        end)
 
-dlg:RegisterHandleActivate(function(activated)
-        if activated then
-            print("Activated")
-        else
-            print("Deactivated")
-        end
-    end)
-
-dlg:RegisterHandleCommand(function(control)
-        if control:ClassName() == "FCCtrlRadioButton" then
-            local button_group = control.RadioButtonGroup
-            if button_group:GetSelectedItem() == radio_button_values[button_group.GroupID] then
-                control:SetCheck(false)
+    dlg:RegisterHandleActivate(function(activated)
+            if activated then
+                print("Activated")
+            else
+                print("Deactivated")
             end
-            radio_button_values[button_group.GroupID] = button_group:GetSelectedItem()
-            local str = finale.FCString()
-            control:GetText(str)
-            print(str.LuaString..":", button_group:GetSelectedItem(), button_group:GetSelectedButton() and button_group:GetSelectedButton():GetControlID() or -1)
-        end
-    end)
+        end)
 
-dlg:RegisterHandleControlEvent(do_something,
-    function(control)
-        finenv.StartNewUndoBlock("Playback Region", false)
-        finenv.Region():Playback()
-        finenv.EndUndoBlock(false)
-        -- the following commented blocks are all other options for what the "Do Something" button could do.
-        --[[
-        local mresult = finale.FCListenToMidiResult()
-        finenv.UI():DisplayListenToMidiDialog(mresult)
-        dlg:CreateChildUI():DisplayListenToMidiDialog(mresult)
-        ]]
-        --[[
-        local radio_button = button_group1:GetSelectedButton()
-        if radio_button then
-            local str = finale.FCString()
-            radio_button:GetText(str)
-            finenv.UI():AlertInfo(str.LuaString, "")
-        else
-            finenv.UI():AlertInfo("nothing selected", "")
-        end
-        ]]
-        --[[
-        local fpath = finale.FCString()
-        fpath:SetRunningLuaFolderPath()
-        local fname = finale.FCString()
-        fname:SetRunningLuaFilePath()
-        finenv.UI():AlertInfo(fname.LuaString, fpath.LuaString)
-        ]]
-        --[[
-        local function fcstr(s)
-            local str = finale.FCString()
-            str.LuaString = s
-            return str
-        end
-        local function file_name()
+    dlg:RegisterHandleCommand(function(control)
+            if control:ClassName() == "FCCtrlRadioButton" then
+                local button_group = control.RadioButtonGroup
+                if button_group:GetSelectedItem() == radio_button_values[button_group.GroupID] then
+                    control:SetCheck(false)
+                end
+                radio_button_values[button_group.GroupID] = button_group:GetSelectedItem()
+                local str = finale.FCString()
+                control:GetText(str)
+                print(str.LuaString..":", button_group:GetSelectedItem(), button_group:GetSelectedButton() and button_group:GetSelectedButton():GetControlID() or -1)
+            end
+        end)
+
+    dlg:RegisterHandleControlEvent(do_something,
+        function(control)
+            local grp1 = global_dialog:GetControl("radio1")
+            print("radio group 1 selected item: " .. grp1:GetSelectedItem())
+            local grp2 = global_dialog:GetControl("radio2")
+            print("radio group 1 selected item: " .. grp2:GetSelectedItem())
+            --[[
+            finenv.StartNewUndoBlock("Playback Region", false)
+            finenv.Region():Playback()
+            finenv.EndUndoBlock(false)
+            ]]
+            -- the following commented blocks are all other options for what the "Do Something" button could do.
+            --[[
+            local mresult = finale.FCListenToMidiResult()
+            finenv.UI():DisplayListenToMidiDialog(mresult)
+            dlg:CreateChildUI():DisplayListenToMidiDialog(mresult)
+            ]]
+            --[[
+            local radio_button = button_group1:GetSelectedButton()
+            if radio_button then
+                local str = finale.FCString()
+                radio_button:GetText(str)
+                finenv.UI():AlertInfo(str.LuaString, "")
+            else
+                finenv.UI():AlertInfo("nothing selected", "")
+            end
+            ]]
+            --[[
             local fpath = finale.FCString()
-            fpath.LuaString = finenv.RunningLuaFilePath()
+            fpath:SetRunningLuaFolderPath()
             local fname = finale.FCString()
-            fpath:SplitToPathAndFile(nil, fname)
-            return fname.LuaString
-        end
-        local docs = finale.FCDocuments()
-        docs:LoadAll()
-        for doc in each(docs) do
-            doc:SwitchTo(fcstr(file_name().." "..doc.ID), false)
-            local region = finale.FCMusicRegion()
-            region:SetFullDocument()
-            for entry in eachentrysaved(region) do
-                entry.ManualPosition = entry.ManualPosition + 144
+            fname:SetRunningLuaFilePath()
+            finenv.UI():AlertInfo(fname.LuaString, fpath.LuaString)
+            ]]
+            --[[
+            local function fcstr(s)
+                local str = finale.FCString()
+                str.LuaString = s
+                return str
             end
-            region:Redraw()
-            doc:SwitchBack(true)
+            local function file_name()
+                local fpath = finale.FCString()
+                fpath.LuaString = finenv.RunningLuaFilePath()
+                local fname = finale.FCString()
+                fpath:SplitToPathAndFile(nil, fname)
+                return fname.LuaString
+            end
+            local docs = finale.FCDocuments()
+            docs:LoadAll()
+            for doc in each(docs) do
+                doc:SwitchTo(fcstr(file_name().." "..doc.ID), false)
+                local region = finale.FCMusicRegion()
+                region:SetFullDocument()
+                for entry in eachentrysaved(region) do
+                    entry.ManualPosition = entry.ManualPosition + 144
+                end
+                region:Redraw()
+                doc:SwitchBack(true)
+            end
+            ]]
         end
-        ]]
-    end
-)
+    )
 
-dlg:RegisterOSMenuCommandExecuted(function(menucmd, cmdtype)
-        local cmdstr = ""
-        if finenv.UI():IsOnMac() then
-            cmdstr = string.char(
-                        bit32.extract(menucmd, 24, 8),
-                        bit32.extract(menucmd, 16, 8),
-                        bit32.extract(menucmd, 8, 8),
-                        bit32.extract(menucmd, 0, 8)
-                    )
-        else
-            cmdstr = string.format(string.format("0x%x", menucmd))
-        end
-        print(cmdstr, cmdtype)
-    end)
+    dlg:RegisterOSMenuCommandExecuted(function(menucmd, cmdtype)
+            local cmdstr = ""
+            if finenv.UI():IsOnMac() then
+                cmdstr = string.char(
+                            bit32.extract(menucmd, 24, 8),
+                            bit32.extract(menucmd, 16, 8),
+                            bit32.extract(menucmd, 8, 8),
+                            bit32.extract(menucmd, 0, 8)
+                        )
+            else
+                cmdstr = string.format(string.format("0x%x", menucmd))
+            end
+            print(cmdstr, cmdtype)
+        end)
 
-dlg:CreateOkButton()
-dlg:CreateCancelButton()
+    dlg:CreateOkButton()
+    dlg:CreateCancelButton()
+    return dlg
+end
 
-finenv.RegisterModelessDialog(dlg)
-dlg:ShowModelessWithGrabbyFocus()
---dlg:ShowModeless()
---dlg:ExecuteModal(nil)
-
+global_dialog = global_dialog or create_dialog()
+global_dialog:RunModeless()

--- a/src/harp_pedal_wizard.lua
+++ b/src/harp_pedal_wizard.lua
@@ -1018,10 +1018,11 @@ or a chord from the drop down lists.]])
                 local f_stg_sharp = dialog:CreateCheckbox(col_x + (col * col_width) - nudge_rt_ped, sharp_y)
                 format_ctrl(f_stg_sharp, 16, 13, str.LuaString)
                 f_stg_sharp:SetText(blank)
-                
-                local reset_button_x = col * col_width - 16
+
+--                local reset_button_x = col * col_width - 16
+                local reset_button_x = 0
                 local reset_button_y = sharp_y + row_h
-                
+
                 col = col + 1
                 --  
                 str.LuaString = "G"
@@ -1052,7 +1053,7 @@ or a chord from the drop down lists.]])
                 a_stg_sharp:SetText(blank)
 
                 reset_button = dialog:CreateButton(reset_button_x, reset_button_y)
-                format_ctrl(reset_button, 14, 50, "Reset")
+                format_ctrl(reset_button, 14, 80, "Set to 'Last'")
 
 
 

--- a/src/harp_pedal_wizard.lua
+++ b/src/harp_pedal_wizard.lua
@@ -495,8 +495,10 @@ function harp_pedal_wizard()
                 local result = ui:AlertYesNo("There seems to be a problem with your harp diagram. \n Would you like to try again?", nil)
 --                if result == 2 then harp_dialog() end
             end -- error
+
             if is_dialog_assigned then
                 ui:AlertInfo("There is already a harp diagram assigned to this region.", nil)
+                is_dialog_assigned = false
             end
         end -- function add_pedals
 
@@ -1016,6 +1018,10 @@ or a chord from the drop down lists.]])
                 local f_stg_sharp = dialog:CreateCheckbox(col_x + (col * col_width) - nudge_rt_ped, sharp_y)
                 format_ctrl(f_stg_sharp, 16, 13, str.LuaString)
                 f_stg_sharp:SetText(blank)
+                
+                local reset_button_x = col * col_width - 16
+                local reset_button_y = sharp_y + row_h
+                
                 col = col + 1
                 --  
                 str.LuaString = "G"
@@ -1044,9 +1050,15 @@ or a chord from the drop down lists.]])
                 local a_stg_sharp = dialog:CreateCheckbox(col_x + (col * col_width) - nudge_rt_ped, sharp_y)
                 format_ctrl(a_stg_sharp, 16, 13, str.LuaString)
                 a_stg_sharp:SetText(blank)
+
+                reset_button = dialog:CreateButton(reset_button_x, reset_button_y)
+                format_ctrl(reset_button, 14, 50, "Reset")
+
+
+
                 col = col + 1
                 --
-                local tracker_v_line = dialog:CreateVerticalLine(col_x + (col * col_width) - 8, row_y, row_h * 4)
+                local tracker_v_line = dialog:CreateVerticalLine(col_x + (col * col_width) - 8, row_y, row_h * 5)
                 col = col + 1
                 --
                 local last_static = dialog:CreateStatic(col_x + (col * col_width) - 19, row_y)
@@ -1057,6 +1069,7 @@ or a chord from the drop down lists.]])
                 local lastnotes_static = dialog:CreateStatic(col_x + (col * col_width) + 11, row_y)
                 format_ctrl(lastnotes_static, 20, 150, config.last_notes)
 --                    lastnotes_static:SetVisible(false)        
+
 --
                 changes_static = dialog:CreateStatic(col_x + (col * col_width) - 19, row_y + 18)
                 format_ctrl(changes_static, 20, 166, changes_str.LuaString)
@@ -1191,7 +1204,7 @@ or a chord from the drop down lists.]])
                         lanes_checkbox:SetEnable(false)
                     end
                     changes_update()
-                end
+                end -- pedals_update()
 
                 function pedal_buttons()
                     scale_check:SetCheck(0)
@@ -1202,6 +1215,66 @@ or a chord from the drop down lists.]])
                     sel_chord:SetEnable(false)
                     pedals_update()
                 end
+
+                local function get_pedals()
+                    if d_stg_flat:GetCheck() == 1 then
+                        harpstrings[1] = "Db"
+                    elseif d_stg_nat:GetCheck() == 1 then
+                        harpstrings[1] = "D"
+                    elseif d_stg_sharp:GetCheck() == 1 then
+                        harpstrings[1] = "D#"
+                    end
+                    if c_stg_flat:GetCheck() == 1 then
+                        harpstrings[2] = "Cb"
+                    elseif  c_stg_nat:GetCheck() == 1 then
+                        harpstrings[2] = "C"
+                    elseif  c_stg_sharp:GetCheck() == 1 then
+                        harpstrings[2] = "C#"
+                    end
+                    if b_stg_flat:GetCheck() == 1 then
+                        harpstrings[3] = "Bb"
+                    elseif  b_stg_nat:GetCheck() == 1 then
+                        harpstrings[3] = "B"
+                    elseif b_stg_sharp:GetCheck() == 1 then
+                        harpstrings[3] = "B#"
+                    end
+                    if e_stg_flat:GetCheck() == 1 then
+                        harpstrings[4] = "Eb"
+                    elseif  e_stg_nat:GetCheck() == 1 then
+                        harpstrings[4] = "E"
+                    elseif  e_stg_sharp:GetCheck() == 1 then
+                        harpstrings[4] = "E#"
+                    end
+                    if  f_stg_flat:GetCheck() == 1 then
+                        harpstrings[5] = "Fb"
+                    elseif f_stg_nat:GetCheck() == 1 then
+                        harpstrings[5] = "F"
+                    elseif  f_stg_sharp:GetCheck() == 1 then
+                        harpstrings[5] = "F#"
+                    end
+                    if g_stg_flat:GetCheck() == 1 then
+                        harpstrings[6] = "Gb"
+                    elseif g_stg_nat:GetCheck() == 1 then
+                        harpstrings[6] = "G"
+                    elseif g_stg_sharp:GetCheck() == 1 then
+                        harpstrings[6] = "G#"
+                    end
+                    if a_stg_flat:GetCheck() == 1 then
+                        harpstrings[7] = "Ab"
+                    elseif a_stg_nat:GetCheck() == 1 then
+                        harpstrings[7] = "A"
+                    elseif a_stg_sharp:GetCheck() == 1 then
+                        harpstrings[7] = "A#"
+                    end
+                    pedal_buttons()
+                end -- get_pedals()
+
+                local function update_lastnotes()
+                    str.LuaString = harpstrings[1] .. ", " .. harpstrings[2] .. ", " .. harpstrings[3] .. ", " .. harpstrings[4] .. ", " .. harpstrings[5] .. ", " .. harpstrings[6] .. ", " .. harpstrings[7]
+                    config.last_notes = str.LuaString
+                    lastnotes_static:SetText(str)
+                end
+
 
                 function config_update()
                     config.root = sel_root:GetSelectedItem()
@@ -1384,6 +1457,11 @@ or a chord from the drop down lists.]])
                         harpstrings[7] = "A#"
                         pedal_buttons()                              
                     end
+
+                    if ctrl:GetControlID() == reset_button:GetControlID() then
+                        get_pedals()
+                        update_lastnotes()
+                    end
                     --
                     pedals_update()
                     update_variables()
@@ -1410,8 +1488,6 @@ or a chord from the drop down lists.]])
                 end
 
                 function scale_update()
-                    --local config = harp_config_load()
-
                     local use_chord = false
                     if chord_check:GetCheck() == 1 then use_chord = true end
                     local return_string = finale.FCString()
@@ -1484,8 +1560,7 @@ or a chord from the drop down lists.]])
                     str.LuaString = ""
                     harp_notes:SetText(str)
                     changes_static:SetText(str)
-                    str.LuaString = harpstrings[1] .. ", " .. harpstrings[2] .. ", " .. harpstrings[3] .. ", " .. harpstrings[4] .. ", " .. harpstrings[5] .. ", " .. harpstrings[6] .. ", " .. harpstrings[7]
-                    config.last_notes = str.LuaString
+                    update_lastnotes()
                     configuration.save_user_settings(script_name, config)
                     finenv.Region():Redraw()
                     direct = false
@@ -1497,6 +1572,7 @@ or a chord from the drop down lists.]])
                 dialog:RegisterHandleCommand(callback)
                 dialog:RegisterHandleOkButtonPressed(callback_ok)
                 dialog:RegisterHandleDataListSelect(callback_update)
+
                 if dialog.RegisterCloseWindow then
                     dialog:RegisterCloseWindow(on_close)
                 end

--- a/src/harp_pedal_wizard.lua
+++ b/src/harp_pedal_wizard.lua
@@ -8,7 +8,7 @@ function plugindef()
     finaleplugin.Date = "2022-07-17"
     finaleplugin.HandlesUndo = true
     finaleplugin.MinJWLuaVersion = 0.63 -- https://robertgpatterson.com/-fininfo/-rgplua/rgplua.html
-    return "Harp Pedal Wizard", "Harp Pedal Wizard", "Creates Harp Diagrams and Pedal Changes"
+    return "Harp Pedal Wizard...", "Harp Pedal Wizard", "Creates Harp Diagrams and Pedal Changes"
 end
 
 local library = require("library.general_library")
@@ -35,10 +35,10 @@ function harp_pedal_wizard()
     local pedal_lanes = true
     local direct = false
     local override = false
-    local context =
+    context = context or -- keep context as global so that it survives across calls
     {
-        window_pos_x = window_pos_x or nil,
-        window_pos_y = window_pos_y or nil
+        window_pos_x = nil,
+        window_pos_y = nil
     }
 
     local SMuFL = library.is_font_smufl_font(nil)
@@ -148,7 +148,7 @@ function harp_pedal_wizard()
             if harpstrings[i] == compare_notes[i] then
                 new_pedals[i] = 0
             else
-                new_pedals[i] = harpstrings[i]
+                new_pedals[i] = tonumber(harpstrings[i]) or 0
                 if changes_str.LuaString == "" then
                     changes_str.LuaString = "New: "
                 end
@@ -270,7 +270,7 @@ function harp_pedal_wizard()
                 if harpstrings[i] == compare_notes[i] then
                     new_pedals[i] = 0
                 else
-                    new_pedals[i] = harpstrings[i]
+                    new_pedals[i] = tonumber(harpstrings[i]) or 0
                     changes = true
                 end
             end
@@ -783,8 +783,10 @@ function harp_pedal_wizard()
             function format_ctrl(ctrl, h, w, st)
                 ctrl:SetHeight(h)
                 ctrl:SetWidth(w)
-                str.LuaString = st
-                ctrl:SetText(str)
+                if ctrl:ClassName() ~= "FCCtrlPopup" then
+                    str.LuaString = st
+                    ctrl:SetText(str)
+                end
             end -- function format_ctrl
 --
             local dialog = finale.FCCustomLuaWindow()

--- a/src/harp_pedal_wizard.lua
+++ b/src/harp_pedal_wizard.lua
@@ -4,8 +4,8 @@ function plugindef()
     finaleplugin.RequireSelection = false
     finaleplugin.Author = "Jacob Winkler"
     finaleplugin.Copyright = "2022"
-    finaleplugin.Version = "2.0"
-    finaleplugin.Date = "2022-07-17"
+    finaleplugin.Version = "2.0.1"
+    finaleplugin.Date = "2024-01-15"
     finaleplugin.HandlesUndo = true
     finaleplugin.MinJWLuaVersion = 0.63 -- https://robertgpatterson.com/-fininfo/-rgplua/rgplua.html
     return "Harp Pedal Wizard...", "Harp Pedal Wizard", "Creates Harp Diagrams and Pedal Changes"

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -342,19 +342,19 @@ for num_args, ctrl_types in pairs({
     [3] = {"HorizontalLine", "VerticalLine", "RadioButtonGroup"},
 }) do
     for _, control_type in pairs(ctrl_types) do
-        local got1 = false
+        local type_exists = false
         if finenv.IsRGPLua then
-            got1 = finale.FCCustomWindow.__class["Create" .. control_type]      
+            type_exists = finale.FCCustomWindow.__class["Create" .. control_type]      
         else
             -- JW Lua crashes if we index the __class table with an invalid key, so instead search it
             for k, _ in pairs(finale.FCCustomWindow.__class) do
                 if tostring(k) == "Create" .. control_type then
-                    got1 = true
+                    type_exists = true
                     break
                 end
             end
         end
-        if not got1 then
+        if not type_exists then
             goto continue
         end
 

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -16,9 +16,20 @@ local methods = class.Methods
 local private = setmetatable({}, {__mode = "k"})
 
 local function create_control(self, func, num_args, ...)
-    local control = self["Create" .. func .. "__"](self, ...)
-    private[self].Controls[control:GetControlID()] = control
-    control:RegisterParent(self)
+    local result = self["Create" .. func .. "__"](self, ...)
+
+    local function add_control(control)
+        private[self].Controls[control:GetControlID()] = control
+        control:RegisterParent(self)
+    end
+
+    if func == "RadioButtonGroup" then
+        for control in each(result) do
+            add_control(control)
+        end
+    else
+        add_control(result)
+    end
 
     local control_name = select(num_args + 1, ...)
     if control_name then
@@ -28,10 +39,10 @@ local function create_control(self, func, num_args, ...)
             error("A control is already registered with the name '" .. control_name .. "'", 2)
         end
 
-        private[self].NamedControls[control_name] = control
+        private[self].NamedControls[control_name] = result
     end
 
-    return control
+    return result
 end
 
 --[[
@@ -328,7 +339,7 @@ for num_args, ctrl_types in pairs({
     [2] = {"Button", "Checkbox", "CloseButton", "DataList", "Edit", "TextEditor",
         "ListBox", "Popup", "Slider", "Static", "Switcher", "Tree", "UpDown", "ComboBox",
     },
-    [3] = {"HorizontalLine", "VerticalLine",},
+    [3] = {"HorizontalLine", "VerticalLine", "RadioButtonGroup"},
 }) do
     for _, control_type in pairs(ctrl_types) do
         if not finale.FCCustomWindow.__class["Create" .. control_type] then

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -342,7 +342,19 @@ for num_args, ctrl_types in pairs({
     [3] = {"HorizontalLine", "VerticalLine", "RadioButtonGroup"},
 }) do
     for _, control_type in pairs(ctrl_types) do
-        if not finale.FCCustomWindow.__class["Create" .. control_type] then
+        local got1 = false
+        if finenv.IsRGPLua then
+            got1 = finale.FCCustomWindow.__class["Create" .. control_type]      
+        else
+            -- JW Lua crashes if we index the __class table with an invalid key, so instead search it
+            for k, _ in pairs(finale.FCCustomWindow.__class) do
+                if tostring(k) == "Create" .. control_type then
+                    got1 = true
+                    break
+                end
+            end
+        end
+        if not got1 then
             goto continue
         end
 

--- a/src/mixin/FCMCustomWindow.lua
+++ b/src/mixin/FCMCustomWindow.lua
@@ -326,7 +326,7 @@ Override Changes:
 for num_args, ctrl_types in pairs({
     [0] = {"CancelButton", "OkButton",},
     [2] = {"Button", "Checkbox", "CloseButton", "DataList", "Edit", "TextEditor",
-        "ListBox", "Popup", "Slider", "Static", "Switcher", "Tree", "UpDown",
+        "ListBox", "Popup", "Slider", "Static", "Switcher", "Tree", "UpDown", "ComboBox",
     },
     [3] = {"HorizontalLine", "VerticalLine",},
 }) do

--- a/src/mixin/FCXCtrlUpDown.lua
+++ b/src/mixin/FCXCtrlUpDown.lua
@@ -113,7 +113,7 @@ function class:Init()
         -- Align to closest step if needed
         if private[self].AlignWhenMoving then
             -- Casting back and forth works around floating point issues, such as 0.3/0.1 not being equal to 3 (even though 3 is displayed)
-            local num_steps = tonumber(tostring(value / step_def.value))
+            local num_steps = tonumber(tostring(value / step_def.value)) or 0
 
             if num_steps ~= math.floor(num_steps) then
                 if delta > 0 then

--- a/src/playback_selected_staves.lua
+++ b/src/playback_selected_staves.lua
@@ -54,6 +54,8 @@ local config = {
 }
 configuration.get_parameters("playback_selected_region.config.txt", config)
 
+mute_staves = mute_staves or false
+
 function set_layer_playback_data(layer_playback_data, region, staff_number)
     layer_playback_data.Play = not region:IsStaffIncluded(staff_number) or not mute_staves
     layer_playback_data.Solo = region:IsStaffIncluded(staff_number) and not mute_staves


### PR DESCRIPTION
- delint repo (including a couple minor mixin issues)
- add minimal support for `FCCtrlComboBox`.
- add support for `FCCtrlRadioButtonGroup`.
- fix issue causing JW Lua crash.

The JW Lua crash was due to adding controls that did not exist in JW Lua. It seems that indexing the `__class` table of a class with an invalid index crashes JW Lua. This code uses a sequential search of the table instead (when it is for JW Lua). I searched the repo, but I could not find other examples of indexing `__class` when there is the potential of indexing with an invalid index. A similar risk probably exists for `__static`, `__propget`, and `__propset` as well.

In addition to @ThistleSifter, I am adding @jwink75 as a reviewer as well. I made delinting changes to `harp_pedal_wizard.lua` and I would like JWink75 to review them. They are minimal, but the script appears to be working correctly. One of the issues revealed a problem in my current dev branch of RGP Lua, so I am grateful to it.

Resolves #638
Resolves #636 
Resolves #631 

