### PR TITLE
`FCMCtrlCheckBox` store check state

### DIFF
--- a/src/mixin/FCMCtrlCheckbox.lua
+++ b/src/mixin/FCMCtrlCheckbox.lua
@@ -11,9 +11,27 @@ local mixin_helper = require("library.mixin_helper")
 
 local class = {Methods = {}}
 local methods = class.Methods
+local private = setmetatable({}, {__mode = "k"})
 
 local trigger_check_change
 local each_last_check_change
+
+--[[
+% Init
+
+**[Internal]**
+
+@ self (FCMCtrlCheckbox)
+]]
+function class:Init()
+    if private[self] then
+        return
+    end
+
+    private[self] = {
+        Check = 0,
+    }
+end
 
 --[[
 % SetCheck
@@ -77,5 +95,39 @@ methods.AddHandleCheckChange, methods.RemoveHandleCheckChange, trigger_check_cha
         initial = 0,
     }
 )
+
+--[[
+% StoreState
+
+**[Fluid] [Internal] [Override]**
+
+Override Changes:
+- Stores `FCMCtrlCheckbox`-specific properties.
+
+*Do not disable this method. Override as needed but call the parent first.*
+
+@ self (FCMCtrlCheckbox)
+]]
+function methods:StoreState()
+    mixin.FCMControl.StoreState(self)
+    private[self].Check = self:GetCheck__()
+end
+
+--[[
+% RestoreState
+
+**[Fluid] [Internal] [Override]**
+
+Override Changes:
+- Restores `FCMCtrlCheckbox`-specific properties.
+
+*Do not disable this method. Override as needed but call the parent first.*
+
+@ self (FCMCtrlCheckbox)
+]]
+function methods:RestoreState()
+    mixin.FCMControl.RestoreState(self)
+    self:SetCheck__(private[self].Check)
+end
 
 return class

--- a/src/mixin/FCMCtrlCheckbox.lua
+++ b/src/mixin/FCMCtrlCheckbox.lua
@@ -34,6 +34,25 @@ function class:Init()
 end
 
 --[[
+% GetCheck
+
+**[Override]**
+
+Override Changes:
+- Hooks into control state preservation.
+
+@ self (FCMCtrlCheckbox)
+: (number)
+]]
+function methods:GetCheck()
+    if mixin.FCMControl.UseStoredState(self) then
+        return private[self].Check
+    end
+
+    return self:GetCheck__()
+end
+
+--[[
 % SetCheck
 
 **[Fluid] [Override]**
@@ -47,7 +66,11 @@ Override Changes:
 function methods:SetCheck(checked)
     mixin_helper.assert_argument_type(2, checked, "number")
 
-    self:SetCheck__(checked)
+    if mixin.FCMControl.UseStoredState(self) then
+        private[self].Check = checked
+    else
+        self:SetCheck__(checked)
+    end
 
     trigger_check_change(self)
 end


### PR DESCRIPTION
`FCMCtrlCheckBox.lua` was not storing its `Check` state. This meant that the dialog boxes would not remember checkbox state unless the script explicitly called `SetCheck` before the dialog was created the first time.

This PR adds `StoreState` and `RestoreState` overrides to `FCMCtrlCheckBox.lua`. I have tested with both 2-state and 3-state checkboxes.

