### PR TITLE
lint fixes and build broken

### DIFF
--- a/docs/rgp-lua.md
+++ b/docs/rgp-lua.md
@@ -103,6 +103,13 @@ _RGP Lua_ (starting in version 0.67) pre-loads the lua-cjson 2.1.0 library, whic
 local cjson = require('cjson')
 ```
 
+If you are writing a script to be deployed at the [Finale Lua](https://finalelua.com) website, you must wrap the call to `require` as follows:
+
+```lua
+local utils = require('library.utils')
+local cjson = utils.require_embedded('cjson')
+```
+
 The json strings formatted by cjson are flat, containing no line feeds. If you wish to format them in human-readable format, you can use the built-in function [`prettyformatjson`](#prettyformatjson).
 
 More information on how to use the cjson library is available here:  
@@ -136,6 +143,13 @@ _RGP Lua_ (starting in version 0.68) pre-loads the luafilesystem library ('lfs')
 local lfs = require('lfs')
 ```
 
+If you are writing a script to be deployed at the [Finale Lua](https://finalelua.com) website, you must wrap the call to `require` as follows:
+
+```lua
+local utils = require('library.utils')
+local lfs = utils.require_embedded('lfs')
+```
+
 More information on how to use the lfs libray is available here:  
 [https://lunarmodules.github.io/luafilesystem/](https://lunarmodules.github.io/luafilesystem/)
 
@@ -147,6 +161,13 @@ _RGP Lua_ does not load the library into a global namespace, however. You must e
 
 ```lua
 local osutils = require('luaosutils')
+```
+
+If you are writing a script to be deployed at the [Finale Lua](https://finalelua.com) website, you must wrap the call to `require` as follows:
+
+```lua
+local utils = require('library.utils')
+local osutils = utils.require_embedded('luaosutils')
 ```
 
 The advantage to this approach is that you do not need to change the body of your script if you wish to use an external version of `luaosutils` instead of the version embedded in _RGP Lua_. Simply disable the `LoadLuaOSUtils` option in [`plugindef`](#connect-to-finalelua) and the script will pick up the external version instead, provided it is in your `cpath` list. (_RGP Lua_ automatically adds the script’s running folder path to the `cpath` list.)

--- a/src/ostinato_maker.lua
+++ b/src/ostinato_maker.lua
@@ -58,7 +58,6 @@ info_notes = info_notes:gsub("\n%s*", " "):gsub("*", "\n"):gsub("@t", "\t")
     .. "\n(" .. finaleplugin.Version .. ")"
 
 global_timer_id = 1
-global_info = global_info or nil -- static text "INFO" listing
 
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
@@ -358,7 +357,7 @@ local function create_dialog_box()
             save_rpt = s
         end
     end
-    global_info = dialog:CreateStatic(0, y)
+    dialog:CreateStatic(0, y, "info")
         :SetText("Selection " .. selection_id() .. "\n" .. staff_id())
         :SetWidth(edit_x * 2):SetHeight(30)
     y = y + 35

--- a/src/ostinato_maker.lua
+++ b/src/ostinato_maker.lua
@@ -316,7 +316,8 @@ local function on_timer()
     end
     if changed then
         global_selection = copy_region_bounds()
-        global_info:SetText("Selection " .. selection_id() .. "\n" .. staff_id())
+        global_dialog:GetControl("info")
+            :SetText("Selection " .. selection_id() .. "\n" .. staff_id())
     end
 end
 

--- a/src/pitch_singles_changer.lua
+++ b/src/pitch_singles_changer.lua
@@ -28,8 +28,12 @@ end
 
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
-local cjson = require("cjson")
-local script_name = "pitch_singles_changer"
+local utils = require("library.utils")
+local library = require("libary.general_library")
+
+local cjson = utils.require_embedded("cjson")
+
+local script_name = library.calc_script_name()
 
 local config = {
     pitch_set = '[["C4","C5"]]', -- JSON encoded pitch replacement set

--- a/src/pitch_singles_changer.lua
+++ b/src/pitch_singles_changer.lua
@@ -29,7 +29,7 @@ end
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
 local utils = require("library.utils")
-local library = require("libary.general_library")
+local library = require("library.general_library")
 
 local cjson = utils.require_embedded("cjson")
 
@@ -78,7 +78,7 @@ end
 local function user_selects_pitches(pitches)
     local y, yd, x = 0, 25, { 83, 126, 150 }
     local answer = {}
-    local dialog = mixin.FCXCustomLuaWindow():SetTitle(plugindef())
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle(plugindef():gsub("%.%.%.", ""))
         local function cstat(dx, dy, txt, wid)
             local y_off = finenv.UI():IsOnMac() and 3 or 0
             return dialog:CreateStatic(dx, dy + y_off):SetText(txt):SetWidth(wid)


### PR DESCRIPTION
`page_singles_changer.lua` broke the build because of the raw call to `require` for the embedded `cjson` c-library. Recall that the build parses the source files for dependencies by looking for `require` statements. Therefore, in this repo we have to wrap those require statements for embedded utilities with a call to `util.require_embedded`.

While I was at it, I fixed a couple of lint errors and changed the code to use `library.calc_script_name` instead of hard-coding the script name.

Please test these changes. If you would rather hard-code the script name, that's fine. I just like to avoid hard-coding when possible.
