### PR TITLE
mobdebug breaks build!!

### DIFF
--- a/src/page_format_wizard.lua
+++ b/src/page_format_wizard.lua
@@ -1858,7 +1858,6 @@ local function format_wizard()
   bold_control(score_ctrls.staff_settings)
   bold_control(parts_ctrls.staff_settings)
   bold_control(special_ctrls.staff_settings)
---    require('mobdebug').start()
 --  finale.FCFileSaveAsDialog(finenv.UI()):GetFileName(str)
 end
 


### PR DESCRIPTION
A reminder to @jwink75 that `require('mobdebug').start()` breaks the build, *even if it is commented out!*.

A question for @asherber: would it be possible to modify the build script to ignore comments. At least single-line comments that start with `--`?
