### PR TITLE
Add utility function for displaying script notes

### DIFF
--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -292,4 +292,72 @@ function utils.rethrow_placeholder()
     return "'" .. rethrow_placeholder .. "'"
 end
 
+--[[
+% show_notes_dialog
+
+Displays a modal dialog with the contents of finaleplugin.RFTNotes (if present) or finaleplugin.Notes. If neither one is present, no dialog is shown.
+
+@ caption (string) The caption for the dialog. Defaults to plugin name and version.
+@ width (number) The width in pixels of the edit control. Defaults to 500.
+@ height (number) The height inpixels of the edit control. Defaults to 350.
+]]
+function utils.show_notes_dialog(caption, width, height)
+    if not finaleplugin.RTFNotes and not finaleplugin.Notes then
+        return
+    end
+    
+    width = width or 500
+    height = height or 350
+    
+    if not caption then
+        caption = plugindef()
+        if finaleplugin.Version then
+            local version = finaleplugin.Version
+            if string.sub(version, 1, 1) ~= "v" then
+                version = "v" .. version
+            end
+            caption = string.format("%s %s", caption, version)
+        end
+    end
+
+    local dlg = finale.FCCustomLuaWindow()
+    dlg:SetTitle(finale.FCString(caption))
+    local edit_text = dlg:CreateTextEditor(10, 10)
+    edit_text:SetWidth(width)
+    edit_text:SetHeight(height)
+    edit_text:SetUseRichText(finaleplugin.RTFNotes)
+    edit_text:SetReadOnly(true)
+    edit_text:SetWordWrap(true)
+
+    local ok = dlg:CreateOkButton()
+
+    local function dedent(input)
+        local first_line_indent = input:match("^(%s*)")
+        local pattern = "\n" .. string.rep(" ", #first_line_indent)
+        local result = input:gsub(pattern, "\n")
+
+        result = result:gsub("^%s+", "")
+
+        return result
+    end
+
+    dlg:RegisterInitWindow(
+        function()
+            local notes = dedent(finaleplugin.RTFNotes or dedent(finaleplugin.Notes))
+            local notes_str = finale.FCString(notes)
+            if edit_text:GetUseRichText() then
+                edit_text:SetRTFString(notes_str)
+            else
+                local edit_font = finale.FCFontInfo()
+                edit_font.Name = "Arial"
+                edit_font.Size = 10
+                edit_text:SetFont(edit_font)
+                edit_text:SetText(notes_str)
+            end
+            edit_text:ResetColors()
+            ok:SetKeyboardFocus()
+        end)
+    dlg:ExecuteModal(nil)
+end
+
 return utils


### PR DESCRIPTION
It would be better to merge this after #665, in case there are any changes needed here (and so that the repo actually has RTFNotes to display).

The modal dialog will display RTFNotes in a (readonly) text edit control, falling back to Notes. If neither one exists, then no dialog is shown. The caller can specify the dialog caption, height, and width; sensible defaults are provided. 

@cv-on-hub Please see if this meets your needs as a replacement for the custom code you've got behind your `?` buttons. Note that after the other PR is merged all scripts with Notes will automatically get RTFNotes during the build process.