### PR TITLE
Teach utils.show_notes_dialog() to use mac/win sizes

### DIFF
--- a/.github/actions/bundle/dist/custom_template.rtf
+++ b/.github/actions/bundle/dist/custom_template.rtf
@@ -2,8 +2,8 @@
         {\rtf1\ansi\deff0{\fonttbl{\f0 \fswiss Helvetica;}{\f1 \fmodern Courier New;}}
         {\colortbl;\red255\green0\blue0;\red0\green0\blue255;}
         \widowctrl\hyphauto
-        \f0\fs20
-        \f1\fs20
+        \$basefont$
+        {\info{\comment $fontsizes$}}
         $body$
         }
     

--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -6987,14 +6987,39 @@ const getRTFNotes = (input) => {
     const notesRegex = /(?<=finaleplugin.Notes = \[\[).*(?=\]\])/ius;
     const match = input.match(notesRegex);
     if (match) {
-        const notes = (0, dedent_js_1.default)(match[0]);
+        let notes = (0, dedent_js_1.default)(match[0]);
+        notes = notes.replace(/^#{4,}/gm, '###');
         const templateFile = path_1.default.join(__dirname, "custom_template.rtf");
-        const args = ['-f', 'markdown', '-t', 'rtf', '-s', `--template=${templateFile}`];
+        /**
+         * Default font sizes are:
+         *         p   h1  h2  h3
+         * pandoc  24  36  32  28
+         * win     18  26  23  20
+         * mac     24  32  29  26
+         *
+         * The win p size is injected as a variable into the call to pandoc, and the
+         * other win sizes are replaced below. The mac sizes are injected, as a JSON
+         * fragment, into the RTF comment field; utils.show_notes_dialog() can use
+         * this to perform replacements.
+         */
+        const args = `
+            -f markdown 
+            -t rtf 
+            --standalone 
+            --template=${templateFile}
+            -V basefont=fs18
+            -V fontsizes="os":"mac","fs18":"fs24","fs26":"fs32","fs23":"fs29","fs20":"fs26"
+        `.trim().split(/\s+/);
         const pandocResult = (0, child_process_1.spawnSync)('pandoc', args, { input: notes, encoding: 'utf-8' });
         if (!pandocResult.error) {
-            result = pandocResult.stdout.replace(/fs28/g, 'fs24')
-                .replace(/fs32/g, 'fs28')
-                .replace(/fs36/g, 'fs32');
+            result = pandocResult.stdout.replace(/(?<=\\)fs\d\d/g, function (match) {
+                switch (match) {
+                    case 'fs36': return 'fs26';
+                    case 'fs32': return 'fs23';
+                    case 'fs28': return 'fs20';
+                    default: return match;
+                }
+            });
             result = `    finaleplugin.RTFNotes = [[${result}]]`;
         }
     }

--- a/.github/actions/bundle/src/custom_template.rtf
+++ b/.github/actions/bundle/src/custom_template.rtf
@@ -2,8 +2,8 @@
         {\rtf1\ansi\deff0{\fonttbl{\f0 \fswiss Helvetica;}{\f1 \fmodern Courier New;}}
         {\colortbl;\red255\green0\blue0;\red0\green0\blue255;}
         \widowctrl\hyphauto
-        \f0\fs20
-        \f1\fs20
+        \$basefont$
+        {\info{\comment $fontsizes$}}
         $body$
         }
     


### PR DESCRIPTION
### tl;dr

The `RTFNotes` generated by the build process now allows for different font sizes on Win and Mac. You can use [this standalone script](https://gist.github.com/asherber/85cfe0fb44a650fe316cb162f1de9697) to test the functionality.

### explanation

While the build process will continue to embed in `RTFNotes` the default font sizes for Windows, it will also add to the RTF a comment string containing a JSON fragment with substitutions to make for Mac. At display time, the `show_notes_dialog()` determines whether to make these substitutions based on the current OS.

The hope is that we can agree on default sizes for each OS that work reasonably for everyone, so that `RTFNotes` works transparently without additional effort. (Current defaults are 9pt for Win and 12pt for Mac.) Individual script authors can still choose to include their own RTF with their scripts. If developers are working on Mac, they can also leave those font sizes embedded and change the comment string to provide the substitutions for Win by setting the `os` element to `win`.

This is intended to supersede #674 