### PR TITLE
Don't take dependent actions in forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
           path: "./lua"
       - run: "rm -f ./lua/dist/*"
       - name: Checkout docs website repository
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository_owner == 'finale-lua'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -65,7 +65,7 @@ jobs:
       - run: "rm -rf website/docs"
       - run: "cp -R lua/docs website/docs"
       - name: Commit & Push docs to website
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository_owner == 'finale-lua'
         uses: finale-lua/commit-and-push@1.4.1
         with:
           github_token: ${{ secrets.NICK_PERSONAL_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
           branch: main
           repository: finale-lua/jw-lua-scripts-docs
       - name: Commit & Push docs to this repo
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository_owner == 'finale-lua'
         uses: finale-lua/commit-and-push@1.4.1
         with:
           github_token: ${{ secrets.NICK_PERSONAL_TOKEN }}


### PR DESCRIPTION
This fixes an issue that seems to have been going on for a while, unrelated to recent changes made to the GH actions for this repo.

The actions in the `deploy.yml` file are set to run on any push to `master` -- but the ones that require the secret token from this repo (checkout docs, commit to this repo, commit to docs) fail on forks because they don't have the token. This PR changes `deploy.yml` so that these actions only run when pushing to `master` _in this repo_, not in a fork. The build actions that don't require a token will still run in forks.

cc: @jwink75 