### PR TITLE
RTF fix 

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -6984,7 +6984,7 @@ const getHashURL = (name) => {
 };
 const getRTFNotes = (input) => {
     let result = '';
-    const notesRegex = /(?<=finaleplugin.Notes = \[\[).*(?=\]\])/ius;
+    const notesRegex = /(?<=finaleplugin.Notes = \[\[).*?(?=\]\])/ius;
     const match = input.match(notesRegex);
     if (match) {
         let notes = (0, dedent_js_1.default)(match[0]);

--- a/.github/actions/bundle/src/inject-extras.test.ts
+++ b/.github/actions/bundle/src/inject-extras.test.ts
@@ -57,6 +57,60 @@ return true
         expect(result).toEqual(expected);
     });
 
+    it('should inject HashURL and RTFNotes into the contents (with items after)', () => {
+        const name = 'test.lua';
+        const contents = `
+function plugindef()
+    -- plugin definition goes here
+    finaleplugin.Notes = [[
+        # Header 1
+    ]]
+    finaleplugin.AdditionalMenuOptions = [[
+        Unbeam Selected Region
+    ]]
+    return "1", "2", "3"
+end
+
+function testFunction()
+    -- function definition goes here
+end
+
+return true
+`;
+        const expected = `
+function plugindef()
+    -- plugin definition goes here
+    finaleplugin.Notes = [[
+        # Header 1
+    ]]
+    finaleplugin.AdditionalMenuOptions = [[
+        Unbeam Selected Region
+    ]]
+    finaleplugin.RTFNotes = [[
+        {\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 \\fswiss Helvetica;}{\\f1 \\fmodern Courier New;}}
+        {\\colortbl;\\red255\\green0\\blue0;\\red0\\green0\\blue255;}
+        \\widowctrl\\hyphauto
+        \\fs18
+        {\\info{\\comment "os":"mac","fs18":"fs24","fs26":"fs32","fs23":"fs29","fs20":"fs26"}}
+        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs26 Header 1\\par}
+        }
+    ]]
+    finaleplugin.HashURL = "https://raw.githubusercontent.com/finale-lua/lua-scripts/master/hash/test.hash"
+    return "1", "2", "3"
+end
+
+function testFunction()
+    -- function definition goes here
+end
+
+return true
+`;
+
+        const result = injectExtras(name, contents);
+
+        expect(result).toEqual(expected);
+    });
+
     it('should inject only HashURL into the contents (with return)', () => {
         const name = 'test.lua';
         const contents = `

--- a/.github/actions/bundle/src/inject-extras.test.ts
+++ b/.github/actions/bundle/src/inject-extras.test.ts
@@ -36,9 +36,9 @@ function plugindef()
         {\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 \\fswiss Helvetica;}{\\f1 \\fmodern Courier New;}}
         {\\colortbl;\\red255\\green0\\blue0;\\red0\\green0\\blue255;}
         \\widowctrl\\hyphauto
-        \\f0\\fs20
-        \\f1\\fs20
-        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs32 Header 1\\par}
+        \\fs18
+        {\\info{\\comment "os":"mac","fs18":"fs24","fs26":"fs32","fs23":"fs29","fs20":"fs26"}}
+        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs26 Header 1\\par}
         }
     ]]
     finaleplugin.HashURL = "https://raw.githubusercontent.com/finale-lua/lua-scripts/master/hash/test.hash"
@@ -116,9 +116,9 @@ function plugindef()
         {\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 \\fswiss Helvetica;}{\\f1 \\fmodern Courier New;}}
         {\\colortbl;\\red255\\green0\\blue0;\\red0\\green0\\blue255;}
         \\widowctrl\\hyphauto
-        \\f0\\fs20
-        \\f1\\fs20
-        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs32 Header 1\\par}
+        \\fs18
+        {\\info{\\comment "os":"mac","fs18":"fs24","fs26":"fs32","fs23":"fs29","fs20":"fs26"}}
+        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs26 Header 1\\par}
         }
     ]]
     finaleplugin.HashURL = "https://raw.githubusercontent.com/finale-lua/lua-scripts/master/hash/test.hash"
@@ -165,8 +165,8 @@ function plugindef()
         {\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 \\fswiss Helvetica;}{\\f1 \\fmodern Courier New;}}
         {\\colortbl;\\red255\\green0\\blue0;\\red0\\green0\\blue255;}
         \\widowctrl\\hyphauto
-        \\f0\\fs20
-        \\f1\\fs20
+        \\fs18
+        {\\info{\\comment "os":"mac","fs18":"fs24","fs26":"fs32","fs23":"fs29","fs20":"fs26"}}
         {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 This is a description of the plugin.\\par}
         }
     ]]
@@ -259,11 +259,11 @@ function plugindef()
         {\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 \\fswiss Helvetica;}{\\f1 \\fmodern Courier New;}}
         {\\colortbl;\\red255\\green0\\blue0;\\red0\\green0\\blue255;}
         \\widowctrl\\hyphauto
-        \\f0\\fs20
-        \\f1\\fs20
-        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs32 Heading one\\par}
-        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs28 Heading two\\par}
-        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs24 Heading three\\par}
+        \\fs18
+        {\\info{\\comment "os":"mac","fs18":"fs24","fs26":"fs32","fs23":"fs29","fs20":"fs26"}}
+        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs26 Heading one\\par}
+        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs23 Heading two\\par}
+        {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 \\b \\fs20 Heading three\\par}
         {\\pard \\ql \\f0 \\sa180 \\li0 \\fi0 This is a regular paragraph with {\\b Bold} and {\\i Italic}.\\par}
         {\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab Bullet 1\\par}
         {\\pard \\ql \\f0 \\sa0 \\li360 \\fi-360 \\bullet \\tx360\\tab Bullet 2\\par}

--- a/.github/actions/bundle/src/inject-extras.ts
+++ b/.github/actions/bundle/src/inject-extras.ts
@@ -41,7 +41,7 @@ const getHashURL = (name: string): string => {
 const getRTFNotes = (input: string): string => {    
     let result = '';
 
-    const notesRegex = /(?<=finaleplugin.Notes = \[\[).*(?=\]\])/ius;
+    const notesRegex = /(?<=finaleplugin.Notes = \[\[).*?(?=\]\])/ius;
     const match = input.match(notesRegex);
 
     if (match) {


### PR DESCRIPTION
Fixes #686 

I had a greedy regex where a non-greedy one was wanted, and I didn't have a test case to cover this situation. When I committed the initial code, I verified visually that the only changes in dist were that `RTFNotes` got added -- but I didn't look closely enough to see that the field contained more than it should have. All better now.