### PR TITLE
Don't strip plugindef comments

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -6834,7 +6834,7 @@ const bundleFile = (name, sourcePath, mixins) => {
     const bundled = (0, exports.bundleFileBase)(name, exports.files, mixins, localizations, (fileName) => fs_1.default.readFileSync(path_1.default.join(sourcePath, fileName)).toString());
     const parts = (0, helpers_1.getFileParts)(bundled);
     return (0, remove_comments_1.removeComments)(parts.prolog, true)
-        + (0, remove_comments_1.removeComments)(parts.plugindef, false)
+        + parts.plugindef
         + (0, remove_comments_1.removeComments)(parts.epilog, true);
 };
 exports.bundleFile = bundleFile;

--- a/.github/actions/bundle/src/bundle.ts
+++ b/.github/actions/bundle/src/bundle.ts
@@ -83,6 +83,6 @@ export const bundleFile = (name: string, sourcePath: string, mixins: string[]): 
     const parts = getFileParts(bundled);
 
     return removeComments(parts.prolog, true) 
-        + removeComments(parts.plugindef, false) 
+        + parts.plugindef
         + removeComments(parts.epilog, true);
 }

--- a/src/beam_selected_region.lua
+++ b/src/beam_selected_region.lua
@@ -1,6 +1,4 @@
-function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
+function plugindef()    
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"

--- a/src/clef_change.lua
+++ b/src/clef_change.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Jacob Winkler"
     finaleplugin.Copyright = "2022"
     finaleplugin.Version = "1.0.1"

--- a/src/dynamics_move_above_staff.lua
+++ b/src/dynamics_move_above_staff.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
    finaleplugin.RequireScore = false
    finaleplugin.RequireSelection = true
    finaleplugin.Author = "Jacob Winkler"

--- a/src/expression_add_opaque_background.lua
+++ b/src/expression_add_opaque_background.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"

--- a/src/expression_find_orphaned_definitions.lua
+++ b/src/expression_find_orphaned_definitions.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"

--- a/src/expression_remove_enclosure.lua
+++ b/src/expression_remove_enclosure.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"

--- a/src/expression_score_parts_assignment.lua
+++ b/src/expression_score_parts_assignment.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
     finaleplugin.RequireSelection = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"

--- a/src/finale_lua_menu_organizer.lua
+++ b/src/finale_lua_menu_organizer.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.RequireDocument = false
     finaleplugin.RequireSelection = false
     finaleplugin.NoStore = true

--- a/src/harp_pedal_wizard.lua
+++ b/src/harp_pedal_wizard.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.RequireSelection = false
     finaleplugin.Author = "Jacob Winkler"
     finaleplugin.Copyright = "2022"

--- a/src/layers_create_whole_rests_1_2.lua
+++ b/src/layers_create_whole_rests_1_2.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Jacob Winkler"
     finaleplugin.Copyright = "2022"
     finaleplugin.Version = "1.0.2"

--- a/src/measure_force_full_names.lua
+++ b/src/measure_force_full_names.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
    finaleplugin.RequireSelection = true
    finaleplugin.Author = "Robert Patterson"
    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"

--- a/src/mmrest_widen_to_tempo_mark.lua
+++ b/src/mmrest_widen_to_tempo_mark.lua
@@ -1,6 +1,4 @@
 function plugindef()
-   -- This function and the 'finaleplugin' namespace
-   -- are both reserved for the plug-in definition.
     finaleplugin.RequireSelection = false
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"

--- a/src/page_title_remove_inserts.lua
+++ b/src/page_title_remove_inserts.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0.1"

--- a/src/prefs_reset_group_abbreviated_name_fonts.lua
+++ b/src/prefs_reset_group_abbreviated_name_fonts.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0.2"

--- a/src/prefs_reset_group_full_name_fonts.lua
+++ b/src/prefs_reset_group_full_name_fonts.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0.1"

--- a/src/prefs_reset_lyrics_fonts.lua
+++ b/src/prefs_reset_lyrics_fonts.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0.1"

--- a/src/prefs_reset_staff_abbreviated_name_fonts.lua
+++ b/src/prefs_reset_staff_abbreviated_name_fonts.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0.2"

--- a/src/prefs_reset_staff_full_name_fonts.lua
+++ b/src/prefs_reset_staff_full_name_fonts.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0.2"

--- a/src/region_multimeasure_rest_tacet.lua
+++ b/src/region_multimeasure_rest_tacet.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.RequireSelection = false
     finaleplugin.Author = "The JWs: Jacob Winkler & Jari Williamsson"
     finaleplugin.Version = "3.0"

--- a/src/smufl_bravura_larger_noteheads.lua
+++ b/src/smufl_bravura_larger_noteheads.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Jacob Winkler"
     finaleplugin.Copyright = "2022"
     finaleplugin.Version = "1.0"

--- a/src/smufl_maestro_wide_noteheads.lua
+++ b/src/smufl_maestro_wide_noteheads.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Jacob Winkler"
     finaleplugin.Copyright = "2022"
     finaleplugin.Version = "1.0"

--- a/src/staff_groups_copy_score_to_part.lua
+++ b/src/staff_groups_copy_score_to_part.lua
@@ -1,6 +1,4 @@
 function plugindef()
-    -- This function and the 'finaleplugin' namespace
-    -- are both reserved for the plug-in definition.
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
     finaleplugin.Version = "1.0"

--- a/src/staff_rename.lua
+++ b/src/staff_rename.lua
@@ -1,6 +1,4 @@
 function plugindef()
-  -- This function and the 'finaleplugin' namespace
-  -- are both reserved for the plug-in definition.
   finaleplugin.Author = "Jacob Winkler"
   finaleplugin.Copyright = "2022"
   finaleplugin.Version = "3.0"

--- a/src/ties_remove_dangling.lua
+++ b/src/ties_remove_dangling.lua
@@ -1,6 +1,4 @@
 function plugindef()
-  -- This function and the 'finaleplugin' namespace
-  -- are both reserved for the plug-in definition.
   finaleplugin.Author = "Jacob Winkler"
   finaleplugin.Copyright = "2024"
   finaleplugin.Version = "1.2"


### PR DESCRIPTION
Related to #692 

I also added a commit that removes "boilerplate" comments from existing scripts. I can put these back if you want, though they seem unnecessary to me.

@rpatters1 You'll need to add the new lines to your localized scripts, either in this PR or one after it.