### PR TITLE
Allow pre-0.71 to find `plugindef`

### DIFF
--- a/src/baseline_move_reset.lua
+++ b/src/baseline_move_reset.lua
@@ -1,4 +1,8 @@
 function plugindef(locale)
+--[[
+-- This comment allows RGP Lua pre-0.71 to find the plugindef function
+function plugindef()
+--]]
     local loc = {}
     loc.en = {
         addl_menus = [[

--- a/src/transpose_by_step.lua
+++ b/src/transpose_by_step.lua
@@ -1,4 +1,8 @@
 function plugindef(locale)
+--[[
+-- This comment allows RGP Lua pre-0.71 to find the plugindef function
+function plugindef()
+--]]
     local loc = {}
     loc.en = {
         menu = "Transpose By Steps",

--- a/src/transpose_chromatic.lua
+++ b/src/transpose_chromatic.lua
@@ -1,4 +1,8 @@
 function plugindef(locale)
+--[[
+-- This comment allows RGP Lua pre-0.71 to find the plugindef function
+function plugindef()
+--]]
     local loc = {}
     loc.en = {
         menu = "Transpose Chromatic",

--- a/src/transpose_enharmonic_down.lua
+++ b/src/transpose_enharmonic_down.lua
@@ -1,4 +1,8 @@
 function plugindef(locale)
+--[[
+-- This comment allows RGP Lua pre-0.71 to find the plugindef function
+function plugindef()
+--]]
     local loc = {}
     loc.en = {
         menu = "Enharmonic Transpose Down",

--- a/src/transpose_enharmonic_up.lua
+++ b/src/transpose_enharmonic_up.lua
@@ -1,4 +1,8 @@
 function plugindef(locale)
+--[[
+-- This comment allows RGP Lua pre-0.71 to find the plugindef function
+function plugindef()
+--]]
     local loc = {}
     loc.en = {
         menu = "Enharmonic Transpose Up",


### PR DESCRIPTION
These changes allow RGP Lua pre-0.71 to find localized plugindef functions. The approach is to exploit accidental features of Lua and pre-0.71 RGP Lua. Instead of

```lua
function plugindef(locale)
.
.
.
end
```

we now have

```lua
function plugindef(locale)
--[[
function plugindef()
--]]
.
.
.
end
```

Versions of RGP Lua before 0.71 find the definition inside the multiline comment and treat it as the beginning of the function. RGP Lua 0.71+ (as well as JW Lua) finds the actual start of the function and ignores the one inside the multiline comment because it's a comment.

This approach is only possible because the character sequence `--]]` functions equally well in Lua as the terminator of a multiline comment and a stand-alone single-line comment.

@asherber please confirm this will pass through the bundler.