### PR TITLE
Add `assert_table_argument_type` to `library.mixin_helper`

### DIFF
--- a/src/library/mixin_helper.lua
+++ b/src/library/mixin_helper.lua
@@ -175,7 +175,7 @@ local function assert_table_argument_type(argument_number, table_value, ...)
     end
 
     for k, v in pairsbykeys(table_value) do
-        if k ~= "n" or type(k) ~= "number" do
+        if k ~= "n" or type(k) ~= "number" then
             assert_argument_type(5, tostring(argument_number) .. to_key_string(k), v, ...)
         end
     end


### PR DESCRIPTION
I need table argument validation for something I'm working on, so I split it out from the multi string proxy function into its own function. Also took the opportunity to fix up some old indenting horrors from the autoformatter.

I'd appreciate it if someone could test this by making sure any multi string proxy method still works and throws errors as expected.