### PR TITLE
2 Pitch-entry scripts: modeless option

### DIFF
--- a/src/pitch_entry_diatonic_double.lua
+++ b/src/pitch_entry_diatonic_double.lua
@@ -160,7 +160,7 @@ local function run_the_dialog()
     local dialog = mixin.FCXCustomLuaWindow():SetTitle(finaleplugin.ScriptGroupName)
         -- local functions
         local function show_info()
-            utils.show_notes_dialog(dialog, "About " .. finaleplugin.ScriptGroupName, 400, 290)
+            utils.show_notes_dialog(dialog, "About " .. finaleplugin.ScriptGroupName, 400, 315)
             refocus_document = true
         end
         local function dy(diff) y = diff and (y + diff) or (y + y_inc) end

--- a/src/pitch_entry_diatonic_double.lua
+++ b/src/pitch_entry_diatonic_double.lua
@@ -1,10 +1,11 @@
 function plugindef()
-    finaleplugin.RequireSelection = true
+    finaleplugin.RequireSelection = false
+    finaleplugin.HandlesUndo = true
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "v0.10"
-    finaleplugin.Date = "2024/01/10"
+    finaleplugin.Version = "0.14" -- STREAMLINED MODELESS
+    finaleplugin.Date = "2024/02/25"
     finaleplugin.AdditionalMenuOptions = [[
         Double Diatonic Repeat
     ]]
@@ -17,16 +18,34 @@ function plugindef()
     finaleplugin.AdditionalPrefixes = [[
         no_dialog = true
     ]]
-    finaleplugin.MinJWLuaVersion = 0.62
+    finaleplugin.MinJWLuaVersion = 0.70
     finaleplugin.CategoryTags = "Pitch, Transposition"
     finaleplugin.ScriptGroupName = "Double Diatonic"
     finaleplugin.ScriptGroupDescription = "Double notes and chords up or down by a chosen diatonic interval"
     finaleplugin.Notes = [[
-        Notes and chords in the current music selection are doubled 
-        either up or down by the chosen diatonic interval. 
-        Act on one layer or all four. 
+        Notes and chords in the current music selection are __doubled__ 
+        (duplicated) either up or down by the chosen diatonic interval. 
+        Affect all layers or just one. 
         To repeat the last action without a confirmation dialog use 
-        the "Repeat" menu or hold down [shift] when starting the script.
+        the _Repeat_ menu or hold down [Shift] when starting the script. 
+
+        Select __Modeless__ if you prefer the dialog window to 
+        "float" above your score and you can change the score selection 
+        while it floats. In this mode click __Apply__ 
+        [Return/Enter] to double pitches and __Cancel__ [Escape] 
+        to close the window. 
+        Cancelling __Modeless__ will apply the _next_ 
+        time you use the script.
+
+        > These key commands are available  
+        > if a "numeric" field is highlighted: 
+
+        > - __z__: toggle up/down
+        > - __1-8__: interval (unison, 2nd, 3rd, .. 8ve) 
+        > - __0-8__: extra octave 
+        > - __0-4__: layer number (__0__ = all layers) 
+        > - __q__: show this script information 
+        > - (delete key not needed in numeric fields) 
 	]]
    return "Double Diatonic...", "Double Diatonic",
         "Double notes and chords up or down by a chosen diatonic interval"
@@ -34,37 +53,27 @@ end
 
 no_dialog = no_dialog or false
 
-local info_notes = [[
-Notes and chords in the current music selection are doubled
-either up or down by the chosen diatonic interval.
-Act on one layer or all four.
-To repeat the last action without a confirmation dialog use
-the "Repeat" menu or hold down [shift] when starting the script.
-**
-If the "layer number" field is highlighted
-*these key commands are available:
-**[0]-[4] layer number (delete key not needed)
-*[+]/[a]  interval up
-*[-]/[z]  interval down
-*[q] @t show this script information
-*[w] @t up an octave
-*[s] @t zero
-*[x] @t down an octave
-*[e] @t + extra octave
-*[d] @t - extra octave
-*[c] @t reverse up/down intervals
-]]
-info_notes = info_notes:gsub("\n%s*", " "):gsub("*", "\n"):gsub("@t", "\t")
-
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
 local transposition = require("library.transposition")
-local script_name = "diatonic_doubler"
+local utils = require("library.utils")
+local library = require("library.general_library")
+local script_name = library.calc_script_name()
+local refocus_document = false
+local selection
+local saved_bounds = {}
+local bounds = { -- primary region selection boundaries
+    "StartStaff", "StartMeasure", "StartMeasurePos",
+    "EndStaff",   "EndMeasure",   "EndMeasurePos",
+}
 
 local config = {
-    layer_num = 0,
-    interval = 0,
-    octave = 0,
+    layer     = 0,
+    interval  = 1,  -- 1 = unison
+    octave    = 0,
+    direction = 0,  -- 0 = up / 1 = down (popup item no)
+    timer_id  = 1,
+    modeless  = false, -- false = modal / true = modeless
     window_pos_x = false,
     window_pos_y = false,
 }
@@ -84,107 +93,204 @@ local function dialog_save_position(dialog)
     configuration.save_user_settings(script_name, config)
 end
 
-local function user_chooses()
-    local offset = finenv.UI():IsOnMac() and 3 or 0
-    local y
-    local box_wide = 60
-    local box_high = (15 * 17) + 4 -- 15-row list
-    local function show_info()
-        finenv.UI():AlertInfo(info_notes, "About " .. finaleplugin.ScriptGroupName)
-    end
-    local dialog = mixin.FCXCustomLuaWindow():SetTitle(plugindef())
-    dialog:CreateStatic(0, 5):SetText("Diatonic Interval:"):SetWidth(box_wide + 40)
-    local interval_list = dialog:CreateListBox(0, 22):SetWidth(box_wide):SetHeight(box_high)
-    local interval_names = { "2nd", "3rd", "4th", "5th", "6th", "7th", "8ve" }
-    for i = 7, -7, -1 do
-        local prefix = i > 0 and "↑ " or "↓ "
-        if i == 0 then
-            interval_list:AddString("- - -")
-        else
-            interval_list:AddString(prefix .. interval_names[math.abs(i)])
-        end
-    end
-    interval_list:SetSelectedItem(7 - config.interval)
-    local function list_increment(add)
-        local sel = interval_list:GetSelectedItem()
-        if (add > 0 and sel < 14) or (add < 0 and sel > 0) then
-            interval_list:SetSelectedItem(sel + add)
-        end
-    end
+local function measure_duration(measure_number)
+    local m = finale.FCMeasure()
+    return m:Load(measure_number) and m:GetDuration() or 0
+end
 
-    local x_off = box_wide + 10
-    dialog:CreateStatic(x_off + 5, 60):SetText("Extra\nOctaves:"):SetWidth(box_wide):SetHeight(30)
-    local octave_list = dialog:CreateListBox(x_off + 15, 90):SetWidth(25):SetHeight(4 * 17 + 4)
-    for i = 3, 0, -1 do
-        octave_list:AddString(i)
+local function get_staff_name(staff_num)
+    local staff = finale.FCStaff()
+    staff:Load(staff_num)
+    local str = staff:CreateDisplayFullNameString().LuaString
+    if not str or str == "" then
+        str = "Staff " .. staff_num
     end
-    octave_list:SetSelectedItem(3 - config.octave)
-    local function octave_increment(add)
-        local sel = octave_list:GetSelectedItem()
-        if (add > 0 and sel < 3) or (add < 0 and sel > 0) then
-            octave_list:SetSelectedItem(sel + add)
+    return str
+end
+
+local function initialise_parameters()
+    -- set_saved_bounds
+    local rgn = finenv.Region()
+    for _, prop in ipairs(bounds) do
+        saved_bounds[prop] = rgn[prop]
+    end
+    -- update_selection_id
+    selection = { staff = "no staff", region = "no selection"} -- default
+    if not rgn:IsEmpty() then
+        -- measures
+        local r1 = rgn.StartMeasure + (rgn.StartMeasurePos / measure_duration(rgn.StartMeasure))
+        local m = measure_duration(rgn.EndMeasure)
+        local r2 = rgn.EndMeasure + (math.min(rgn.EndMeasurePos, m) / m)
+        selection.region = string.format("m%.2f-m%.2f", r1, r2)
+        -- staves
+        selection.staff = get_staff_name(rgn.StartStaff)
+        if rgn.EndStaff ~= rgn.StartStaff then
+            selection.staff = selection.staff .. " → " .. get_staff_name(rgn.EndStaff)
         end
     end
-    y = 180
+end
+
+local function do_double_diatonic()
+    if config.modeless then
+        finenv.StartNewUndoBlock(finaleplugin.ScriptGroupName .. " " .. selection.region, false)
+    end
+    local direction = (config.direction * -2) + 1
+    local shift = ((config.octave * 7) + config.interval - 1) * direction
+    if shift ~= 0 then
+        for entry in eachentrysaved(finenv.Region(), config.layer) do
+            transposition.entry_diatonic_transpose(entry, shift, true)
+        end
+    end
+    if config.modeless then
+        finenv.EndUndoBlock(true)
+        finenv.Region():Redraw()
+    end
+end
+
+local function run_the_dialog()
+    local offset = finenv.UI():IsOnMac() and 3 or 0
     local max = finale.FCLayerPrefs.GetMaxLayers and finale.FCLayerPrefs.GetMaxLayers() or 4
-    dialog:CreateStatic(x_off, y):SetText("Layer 1-" .. max .. ":"):SetWidth(box_wide)
-    y = y + 20
-    local save_layer = config.layer_num
-    local layer_num = dialog:CreateEdit(x_off + 20, y - offset):SetWidth(20):SetText(save_layer)
-        :AddHandleCommand(function(self) -- key command replacements
-            local val = self:GetText():lower()
-            if val:find("[^0-" .. max .. "]") then
-                if val:find("[+=a]") then list_increment(-1) -- note up
-                elseif val:find("[-_z]") then list_increment(1) -- note down
-                elseif val:find("w") then interval_list:SetSelectedItem(0)
-                elseif val:find("s") then interval_list:SetSelectedItem(7)
-                elseif val:find("x") then interval_list:SetSelectedItem(14)
-                elseif val:find("[e%[]") then octave_increment(-1) -- octave up
-                elseif val:find("[d%]]") then octave_increment(1) -- octave down
-                elseif val:find("c") then -- invert interval polarity
-                    interval_list:SetSelectedItem(14 - interval_list:GetSelectedItem())
-                elseif val:find("[?q]") then show_info()
+    local y, y_inc = 0, 21
+    local pop_wide, box_wide = 55, 105
+    local interval_names = { "unis.", "2nd", "3rd", "4th", "5th", "6th", "7th", "8ve"}
+    local options = {"layer", "interval", "octave", "direction"}
+    local save, answer = {}, {}
+    for _, v in ipairs(options) do save[v] = config[v] end
+
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle(finaleplugin.ScriptGroupName)
+        -- local functions
+        local function show_info()
+            utils.show_notes_dialog(dialog, "About " .. finaleplugin.ScriptGroupName, 400, 290)
+            refocus_document = true
+        end
+        local function dy(diff) y = diff and (y + diff) or (y + y_inc) end
+        local function cs(cx, cy, ctext, cwide)
+            return dialog:CreateStatic(cx, cy):SetText(ctext):SetWidth(cwide)
+        end
+        local function key_command(id) -- key command replacements
+            local ctl = answer[id]
+            local val = ctl:GetText():lower()
+            if     val:find("[^0-8]")
+                or (id == "layer" and val:find("[" .. (max + 1) .. "-9]"))
+                or (id == "interval" and val:find("0"))
+                    then
+                if val:find("z") then -- flip direction
+                    local n = answer.direction:GetSelectedItem()
+                    answer.direction:SetSelectedItem((n + 1) % 2)
+                elseif val:find("m") then -- toggle modeless
+                    local m = answer.modeless:GetCheck()
+                    answer.modeless:SetCheck((m + 1) % 2)
+                elseif val:find("[?q]") then
+                    show_info()
                 end
-                self:SetText(save_layer):SetKeyboardFocus()
             elseif val ~= "" then
-                val = val:sub(-1)
-                self:SetText(val)
-                save_layer = val
+                save[id] = val:sub(-1)
+                if id == "interval" then
+                    local n = tonumber(save[id]) or 1
+                    answer.msg:SetText(interval_names[n])
+                end
             end
-        end)
-    y = y + 20
-    dialog:CreateStatic(x_off + 7, y):SetWidth(50):SetText("(0 = all)")
-    local q = dialog:CreateButton(x_off + 20, box_high + 3):SetText("?"):SetWidth(20)
+            ctl:SetText(save[id])
+            ctl:SetKeyboardFocus()
+        end
+        local function on_timer() -- look for changes in selected region
+            for k, v in pairs(saved_bounds) do
+                if finenv.Region()[k] ~= v then -- selection changed
+                    initialise_parameters() -- update selection tracker
+                    answer.info1:SetText(selection.staff)
+                    answer.info2:SetText(selection.region)
+                    break -- all done
+                end
+            end
+        end
+
+    answer.a = cs(0, y, "Direction:", 60)
+    cs(60, y, "(z)", 25)
+    answer.direction = dialog:CreatePopup(box_wide - 15, y - offset + 1)
+        :AddStrings("Up", "Down"):SetWidth(55)
+        :SetSelectedItem(save.direction)
+    dy()
+    answer.b = cs(0, y, "Diatonic Interval:", box_wide)
+    answer.interval = dialog:CreateEdit(box_wide, y - offset)
+        :SetText(save.interval):SetWidth(20)
+        :AddHandleCommand(function() key_command("interval") end)
+    answer.msg = cs(box_wide + 25, y, interval_names[save.interval], pop_wide - 20)
+    dy()
+    answer.c = cs(0, y, "Extra Octaves:", box_wide)
+    answer.octave = dialog:CreateEdit(box_wide, y - offset):SetText(save.octave):SetWidth(20)
+        :AddHandleCommand(function() key_command("octave") end)
+    dy()
+    answer.d = cs(0, y, "Layer Number:", box_wide)
+    answer.layer = dialog:CreateEdit(box_wide, y - offset):SetWidth(20):SetText(save.layer)
+        :AddHandleCommand(function() key_command("layer") end)
+    dy()
+    answer.modeless = dialog:CreateCheckbox(0, y):SetWidth(box_wide + 15)
+        :SetCheck(config.modeless and 1 or 0):SetText("\"Modeless\" Dialog")
+    answer.q = dialog:CreateButton(box_wide + pop_wide - 37, y - 1):SetText("?"):SetWidth(20)
         :AddHandleCommand(function() show_info() end)
-    dialog:CreateOkButton():SetText("Select")
+    -- modeless selection info
+    if config.modeless then
+        dy(15)
+        answer.info1 = cs(0, y, selection.staff, box_wide + pop_wide)
+        dy(15)
+        answer.info2 = cs(0, y, selection.region, box_wide + pop_wide)
+    end
+    dialog:CreateOkButton():SetText(config.modeless and "Apply" or "OK")
     dialog:CreateCancelButton()
     dialog_set_position(dialog)
-    dialog:RegisterInitWindow(function()
-        q:SetFont(q:CreateFontInfo():SetBold(true))
-        layer_num:SetKeyboardFocus()
+    if config.modeless then dialog:RegisterHandleTimer(on_timer) end
+    dialog:RegisterInitWindow(function(self)
+        if config.modeless then self:SetTimer(config.timer_id, 125) end
+        local bold = answer.a:CreateFontInfo():SetBold(true)
+        for _, v in ipairs{"a", "b", "c", "d", "q", "msg"} do
+            answer[v]:SetFont(bold)
+        end
+        answer.interval:SetKeyboardFocus()
     end)
+    local change_mode = false
+    dialog:SetOkButtonCanClose(not config.modeless)
     dialog:RegisterHandleOkButtonPressed(function()
-        config.interval = 7 - interval_list:GetSelectedItem()
-        config.octave = 3 - octave_list:GetSelectedItem()
-        config.layer_num = layer_num:GetInteger()
+        config.interval = tonumber(save.interval) -- 1-8 ("shift" interval value PLUS 1)
+        config.octave = answer.octave:GetInteger()
+        config.layer = answer.layer:GetInteger()
+        config.direction = answer.direction:GetSelectedItem()
+        do_double_diatonic()
     end)
-    dialog:RegisterCloseWindow(function(self) dialog_save_position(self) end)
-    return (dialog:ExecuteModal() == finale.EXECMODAL_OK)
+    dialog:RegisterCloseWindow(function(self)
+        if config.modeless then self:StopTimer(config.timer_id) end
+        local mode = (answer.modeless:GetCheck() == 1)
+        change_mode = (config.modeless ~= mode) -- new mode!
+        config.modeless = mode
+        dialog_save_position(self)
+    end)
+    if config.modeless then   -- "modeless"
+        dialog:RunModeless()
+    else
+        dialog:ExecuteModal() -- "modal"
+        if refocus_document then finenv.UI():ActivateDocumentWindow() end
+    end
+    return change_mode
 end
 
 function interval_doubler()
     configuration.get_user_settings(script_name, config, true)
+    if not config.modeless and finenv.Region():IsEmpty() then
+        finenv.UI():AlertError(
+            "Please select some music before\nrunning this script.",
+            finaleplugin.ScriptGroupName
+        )
+        return
+    end
     local qim = finenv.QueryInvokedModifierKeys
     local mod_key = qim and (qim(finale.CMDMODKEY_ALT) or qim(finale.CMDMODKEY_SHIFT))
+    local mode_change = true
 
-    if no_dialog or mod_key or user_chooses() then
-        local shift = config.interval
-        if shift < 0 then config.octave = -config.octave end
-        shift = shift + (config.octave * 7)
-        if shift ~= 0 then
-            for entry in eachentrysaved(finenv.Region(), config.layer_num) do
-                transposition.entry_diatonic_transpose(entry, shift, true)
-            end
+    initialise_parameters()
+    if no_dialog or mod_key then
+        do_double_diatonic()
+    else
+        while mode_change do
+            mode_change = run_the_dialog()
         end
     end
 end

--- a/src/pitch_entry_diatonic_double.lua
+++ b/src/pitch_entry_diatonic_double.lua
@@ -4,8 +4,8 @@ function plugindef()
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "0.14" -- STREAMLINED MODELESS
-    finaleplugin.Date = "2024/02/25"
+    finaleplugin.Version = "0.15" -- MODELESS/MODAL
+    finaleplugin.Date = "2024/03/01"
     finaleplugin.AdditionalMenuOptions = [[
         Double Diatonic Repeat
     ]]
@@ -131,9 +131,7 @@ local function initialise_parameters()
 end
 
 local function do_double_diatonic()
-    if config.modeless then
-        finenv.StartNewUndoBlock(finaleplugin.ScriptGroupName .. " " .. selection.region, false)
-    end
+    finenv.StartNewUndoBlock(finaleplugin.ScriptGroupName .. " " .. selection.region, false)
     local direction = (config.direction * -2) + 1
     local shift = ((config.octave * 7) + config.interval - 1) * direction
     if shift ~= 0 then
@@ -141,10 +139,8 @@ local function do_double_diatonic()
             transposition.entry_diatonic_transpose(entry, shift, true)
         end
     end
-    if config.modeless then
-        finenv.EndUndoBlock(true)
-        finenv.Region():Redraw()
-    end
+    finenv.EndUndoBlock(true)
+    finenv.Region():Redraw()
 end
 
 local function run_the_dialog()
@@ -275,7 +271,7 @@ function interval_doubler()
     configuration.get_user_settings(script_name, config, true)
     if not config.modeless and finenv.Region():IsEmpty() then
         finenv.UI():AlertError(
-            "Please select some music before\nrunning this script.",
+            "Please select some music\nbefore running this script.",
             finaleplugin.ScriptGroupName
         )
         return

--- a/src/pitch_entry_keep_delete.lua
+++ b/src/pitch_entry_keep_delete.lua
@@ -4,8 +4,8 @@ function plugindef()
     finaleplugin.Author = "Jacob Winkler, Nick Mazuk & Carl Vine"
     finaleplugin.AuthorEmail = "jacob.winkler@mac.com"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.33"
-    finaleplugin.Date = "2024-02-26"
+    finaleplugin.Version = "1.34"
+    finaleplugin.Date = "2024-03-01"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.Notes = [[
         Select a note within each chord to either keep or delete, 
@@ -35,6 +35,8 @@ function plugindef()
         To repeat the last action without a confirmation dialog 
         hold down [Shift] when starting the script. 
     ]]
+    finaleplugin.MinJWLuaVersion = 0.70
+    finaleplugin.CategoryTags = "Pitch, Transposition"
     return "Pitch: Chord Notes Keep-Delete...",
         "Pitch: Chord Notes Keep-Delete",
         "Keep or Delete selected notes from chords"
@@ -119,9 +121,7 @@ local function initialise_parameters()
 end
 
 local function make_changes()
-    if config.modeless then
-        finenv.StartNewUndoBlock(script_name:sub(13) .. " " .. selection.region, false)
-    end
+    finenv.StartNewUndoBlock("Keep-Delete " .. selection.region, false)
     for entry in eachentrysaved(finenv.Region(), config.layer) do
         if (entry.Count >= 2) then
             local n = config.number
@@ -136,10 +136,8 @@ local function make_changes()
             end
         end
     end
-    if config.modeless then
-        finenv.EndUndoBlock(true)
-        finenv.Region():Redraw()
-    end
+    finenv.EndUndoBlock(true)
+    finenv.Region():Redraw()
 end
 
 local function run_the_dialog()
@@ -267,7 +265,7 @@ local function keep_delete()
     configuration.get_user_settings(script_name, config, true)
     if not config.modeless and finenv.Region():IsEmpty() then
         finenv.UI():AlertError(
-            "Please select some music before\nrunning this script.",
+            "Please select some music\nbefore running this script.",
             finaleplugin.ScriptGroupName
         )
         return

--- a/src/pitch_entry_keep_delete.lua
+++ b/src/pitch_entry_keep_delete.lua
@@ -1,5 +1,6 @@
 function plugindef()
-    finaleplugin.RequireSelection = true
+    finaleplugin.RequireSelection = false
+    finaleplugin.HandlesUndo = true
     finaleplugin.Author = "Jacob Winkler, Nick Mazuk & Carl Vine"
     finaleplugin.AuthorEmail = "jacob.winkler@mac.com"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
@@ -12,7 +13,7 @@ function plugindef()
 
         - __1__ deletes (or keeps) the top (or bottom) note 
         - __2__ deletes (or keeps) the 2nd note from the top (or bottom) 
-        - etc. 
+        - etc. ...
 
         > If __Note Number__ or __Layer__ are highlighted  
         > then these __Key Commands__ are available:
@@ -27,13 +28,15 @@ function plugindef()
 
         Select __Modeless__ if you prefer the dialog window to 
         "float" above your score and you can change the score selection 
-        while it floats. In this mode click __Apply__ [Return/Enter] 
+        while it's active. In this mode, click __Apply__ [Return/Enter] 
         to make changes and __Cancel__ [Escape] to close the window. 
         Cancelling __Modeless__ will apply the _next_ time you use the script.
 
         To repeat the last action without a confirmation dialog 
         hold down [Shift] when starting the script. 
     ]]
+    finaleplugin.MinJWLuaVersion = 0.70
+    finaleplugin.CategoryTags = "Pitch, Transposition"
     return "Pitch: Chord Notes Keep-Delete...",
         "Pitch: Chord Notes Keep-Delete",
         "Keep or Delete selected notes from chords"
@@ -249,7 +252,7 @@ local function run_the_dialog()
     dialog:RegisterCloseWindow(function(self)
         if config.modeless then self:StopTimer(config.timer_id) end
         local mode = (answer.modeless:GetCheck() == 1)
-        change_mode = (config.modeless ~= mode) -- new mode!
+        change_mode = (mode and not config.modeless) -- modal -> modeless?
         config.modeless = mode
         dialog_save_position(self)
     end)

--- a/src/pitch_entry_keep_delete.lua
+++ b/src/pitch_entry_keep_delete.lua
@@ -35,8 +35,6 @@ function plugindef()
         To repeat the last action without a confirmation dialog 
         hold down [Shift] when starting the script. 
     ]]
-    finaleplugin.MinJWLuaVersion = 0.70
-    finaleplugin.CategoryTags = "Pitch, Transposition"
     return "Pitch: Chord Notes Keep-Delete...",
         "Pitch: Chord Notes Keep-Delete",
         "Keep or Delete selected notes from chords"
@@ -156,7 +154,7 @@ local function run_the_dialog()
             return dialog:CreateStatic(dx, dy):SetText(title):SetWidth(width)
         end
         local function show_info()
-            utils.show_notes_dialog(dialog, "About " .. name, 400, 330)
+            utils.show_notes_dialog(dialog, "About " .. name, 400, 375)
             refocus_document = true
         end
         local function flip_radio(id)

--- a/src/pitch_entry_keep_delete.lua
+++ b/src/pitch_entry_keep_delete.lua
@@ -3,33 +3,40 @@ function plugindef()
     finaleplugin.Author = "Jacob Winkler, Nick Mazuk & Carl Vine"
     finaleplugin.AuthorEmail = "jacob.winkler@mac.com"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.2"
-    finaleplugin.Date = "2024-02-19"
+    finaleplugin.Version = "1.33"
+    finaleplugin.Date = "2024-02-26"
     finaleplugin.CategoryTags = "Pitch"
     finaleplugin.Notes = [[
-        Using __Pitch Entry Keep-Delete__
-
         Select a note within each chord to either keep or delete, 
         numbered from either the top or bottom of each chord. 
 
         - __1__ deletes (or keeps) the top (or bottom) note 
-        - __2__ deletes (or keeps) the 2nd note from top (or bottom) 
+        - __2__ deletes (or keeps) the 2nd note from the top (or bottom) 
         - etc. 
 
-        >__Key Commands:__ 
+        > If __Note Number__ or __Layer__ are highlighted  
+        > then these __Key Commands__ are available:
 
-        > - __a__ - keep 
-        > - __z__ - delete 
-        > - __s__ - from the top 
-        > - __x__ - from the bottom 
-        > - – 
-        > - __q__ - toggle keep/delete 
-        > - __w__ - toggle top/bottom 
-        > - __e__ - show these notes 
-        > - __1-9__ - enter note count (delete key not needed) 
+        > - __z__: toggle keep/delete 
+        > - __x__: toggle top/bottom 
+        > - __m__: toggle "Modeless"
+        > - __q__: show these notes 
+        > - __1-9__: note number 
+        > - __0-4__: layer number 
+        > - (delete key not needed for number entry) 
+
+        Select __Modeless__ if you prefer the dialog window to 
+        "float" above your score and you can change the score selection 
+        while it floats. In this mode click __Apply__ [Return/Enter] 
+        to make changes and __Cancel__ [Escape] to close the window. 
+        Cancelling __Modeless__ will apply the _next_ time you use the script.
+
+        To repeat the last action without a confirmation dialog 
+        hold down [Shift] when starting the script. 
     ]]
-    return "Pitch: Chord Notes Keep-Delete...", "Pitch: Chord Notes Keep-Delete",
-    "Keep or Delete selected notes from chords"
+    return "Pitch: Chord Notes Keep-Delete...",
+        "Pitch: Chord Notes Keep-Delete",
+        "Keep or Delete selected notes from chords"
 end
 
 local configuration = require("library.configuration")
@@ -38,11 +45,22 @@ local mixin = require("library.mixin")
 local utils = require("library.utils")
 local library = require("library.general_library")
 local script_name = library.calc_script_name()
+local refocus_document = false
+local selection
+local saved_bounds = {}
+local bounds = { -- primary region selection boundaries
+    "StartStaff", "StartMeasure", "StartMeasurePos",
+    "EndStaff",   "EndMeasure",   "EndMeasurePos",
+}
+
 
 local config = { -- retained and over-written by the user's "settings" file
-    number       = 1, -- which note to work on
-    direction    = 0, -- 0 == from top / 1 == from bottom
-    keep_delete  = 0, -- 0 == keep / 1 == delete
+    number      = 1, -- which note to work on
+    direction   = 0, -- 0 == from top / 1 == from bottom
+    keep_delete = 0, -- 0 == keep / 1 == delete
+    layer       = 0,
+    timer_id    = 1,
+    modeless    = false, -- false = modal / true = modeless
     window_pos_x = false,
     window_pos_y = false,
 }
@@ -62,93 +80,209 @@ local function dialog_save_position(dialog)
     configuration.save_user_settings(script_name, config)
 end
 
-local function user_chooses()
-    local x, y, y_diff = 85, 3, 24
+local function measure_duration(measure_number)
+    local m = finale.FCMeasure()
+    return m:Load(measure_number) and m:GetDuration() or 0
+end
+
+local function get_staff_name(staff_num)
+    local staff = finale.FCStaff()
+    staff:Load(staff_num)
+    local str = staff:CreateDisplayFullNameString().LuaString
+    if not str or str == "" then
+        str = "Staff " .. staff_num
+    end
+    return str
+end
+
+local function initialise_parameters()
+    -- set_saved_bounds
+    local rgn = finenv.Region()
+    for _, property in ipairs(bounds) do
+        saved_bounds[property] = rgn[property]
+    end
+    -- update_selection_id
+    selection = { staff = "no staff", region = "no selection"} -- default
+    if not rgn:IsEmpty() then
+        -- measures
+        local r1 = rgn.StartMeasure + (rgn.StartMeasurePos / measure_duration(rgn.StartMeasure))
+        local m = measure_duration(rgn.EndMeasure)
+        local r2 = rgn.EndMeasure + (math.min(rgn.EndMeasurePos, m) / m)
+        selection.region = string.format("m%.2f-m%.2f", r1, r2)
+        -- staves
+        selection.staff = get_staff_name(rgn.StartStaff)
+        if rgn.EndStaff ~= rgn.StartStaff then
+            selection.staff = selection.staff .. " → " .. get_staff_name(rgn.EndStaff)
+        end
+    end
+end
+
+local function make_changes()
+    if config.modeless then
+        finenv.StartNewUndoBlock(script_name:sub(13) .. " " .. selection.region, false)
+    end
+    for entry in eachentrysaved(finenv.Region(), config.layer) do
+        if (entry.Count >= 2) then
+            local n = config.number
+            local target = (config.direction == 0) and (n - 1) or (entry.Count - n)
+            local i = 0
+            for note in eachbackwards(entry) do -- scan pitches top to bottom
+                if      (i == target and config.keep_delete == 1)
+                    or  (i ~= target and config.keep_delete == 0) then
+                    note_entry.delete_note(note)
+                end
+                i = i + 1
+            end
+        end
+    end
+    if config.modeless then
+        finenv.EndUndoBlock(true)
+        finenv.Region():Redraw()
+    end
+end
+
+local function run_the_dialog()
+    local x, y, tag_wide = 84, 3, 23
     local y_offset = finenv.UI():IsOnMac() and 3 or 0
     local answer = {}
-    local saved = config.number
+    local saved = { number = config.number, layer = config.layer }
     local name = plugindef():gsub("%.%.%.", "")
     local dialog = mixin.FCXCustomLuaWindow():SetTitle(name)
         -- local functions
+        local function cs(dx, dy, title, width)
+            return dialog:CreateStatic(dx, dy):SetText(title):SetWidth(width)
+        end
         local function show_info()
-            utils.show_notes_dialog(dialog, "About " .. name, 500, 280)
+            utils.show_notes_dialog(dialog, "About " .. name, 400, 330)
+            refocus_document = true
         end
         local function flip_radio(id)
             local n = answer[id]:GetSelectedItem()
             answer[id]:SetSelectedItem((n + 1) % 2)
         end
-        local function key_check(ctl)
+        local function key_check(id)
+            local ctl = answer[id]
             local s = ctl:GetText():lower()
-            if  s:find("[^1-9]") then
-                if     s:find("a") then answer.keep_delete:SetSelectedItem(0)
-                elseif s:find("z") then answer.keep_delete:SetSelectedItem(1)
-                elseif s:find("q") then flip_radio("keep_delete")
-                elseif s:find("s") then answer.direction:SetSelectedItem(0)
-                elseif s:find("x") then answer.direction:SetSelectedItem(1)
-                elseif s:find("w") then flip_radio("direction")
-                elseif s:find("e") then show_info()
+            if     (id == "number" and s:find("[^1-9]") )
+                or (id == "layer" and s:find("[^0-4]"))
+                    then
+                if     s:find("z") then flip_radio("keep_delete")
+                elseif s:find("x") then flip_radio("direction")
+                elseif s:find("q") then show_info()
+                elseif s:find("m") then -- toggle modeless
+                    local m = answer.modeless:GetCheck()
+                    answer.modeless:SetCheck((m + 1) % 2)
                 end
-                ctl:SetText(saved):SetKeyboardFocus()
             elseif s ~= "" then
-                s = s:sub(-1) -- 1-digit note number
-                ctl:SetText(s)
-                saved = s
+                saved[id] = s:sub(-1) -- most recent digit only
+            end
+            ctl:SetText(saved[id]):SetKeyboardFocus()
+        end
+        local function on_timer() -- look for changes in selected region
+            for k, v in pairs(saved_bounds) do
+                if finenv.Region()[k] ~= v then -- selection changed
+                    initialise_parameters() -- update selection tracker
+                    answer.info1:SetText(selection.staff)
+                    answer.info2:SetText(selection.region)
+                    break -- all done
+                end
             end
         end
-        --
-    dialog:CreateStatic(0, y):SetText("Note Number:"):SetWidth(x)
-    answer.number = dialog:CreateEdit(x, y - y_offset):SetInteger(config.number)
-        :AddHandleCommand(function(self) key_check(self) end):SetWidth(25)
-    dialog:CreateButton(x + 105 - 20, 0):SetText("?"):SetWidth(20)
-        :AddHandleCommand(function() show_info() end)
-    y = y + y_diff
 
-    local titles = { {"Keep (a)", "Delete (z)"}, {"From Top (s)", "From Bottom (x)"}}
+    -- First Line
+    answer.a = cs(0, y, "Note Number:", x)
+    answer.number = dialog:CreateEdit(x, y - y_offset):SetInteger(config.number)
+        :AddHandleCommand(function() key_check("number") end):SetWidth(20)
+    answer.b = cs(x + 42, y, "Layer:", 40)
+    answer.layer = dialog:CreateEdit(x + 82, y - y_offset):SetInteger(config.layer)
+        :AddHandleCommand(function() key_check("layer") end):SetWidth(20)
+    y = y + 22
+
+    -- RadioButtonGroup
+    local titles = { {"Keep", "Delete"}, {"From Top", "From Bottom"}}
+    local tags   = {  "(z)",              "(x)"}
     local labels = finale.FCStrings()
     labels:CopyFromStringTable(titles[1])
     answer.keep_delete = dialog:CreateRadioButtonGroup(0, y, 2)
-        :SetText(labels):SetWidth(x - 10)
+        :SetText(labels):SetWidth(x - 25)
         :SetSelectedItem(config.keep_delete)
+    cs(x - 28, y + 5, tags[1], tag_wide)
     labels:CopyFromStringTable(titles[2])
     answer.direction = dialog:CreateRadioButtonGroup(x, y, 2)
-        :SetText(labels):SetWidth(105)
+        :SetText(labels):SetWidth(85)
         :SetSelectedItem(config.direction)
-    y = y + 31
-    dialog:CreateStatic(0 + 14, y):SetText("Toggle (q)")
-    dialog:CreateStatic(x + 14, y):SetText("Toggle (w)")
+    cs(x + 85, y + 5, tags[2], tag_wide)
+    y = y + 35
+    answer.modeless = dialog:CreateCheckbox(0, y):SetWidth(x + 80)
+        :SetCheck(config.modeless and 1 or 0):SetText("\"Modeless\" Dialog")
+    answer.q = dialog:CreateButton(x + 82, y):SetText("?"):SetWidth(20)
+        :AddHandleCommand(function() show_info() end)
+    -- modeless selection info
+    if config.modeless then
+        y = y + 15
+        answer.info1 = cs(0, y, selection.staff, x + 105)
+        y = y + 15
+        answer.info2 = cs(0, y, selection.region, x + 105)
+    end
     -- wrap it up
-    dialog:CreateOkButton()
+    dialog:CreateOkButton():SetText(config.modeless and "Apply" or "OK")
     dialog:CreateCancelButton()
     dialog_set_position(dialog)
+    if config.modeless then dialog:RegisterHandleTimer(on_timer) end
+    dialog:RegisterInitWindow(function(self)
+        dialog:SetOkButtonCanClose(not config.modeless)
+        if config.modeless then self:SetTimer(config.timer_id, 125) end
+        local bold = answer.a:CreateFontInfo():SetBold(true)
+        answer.a:SetFont(bold)
+        answer.b:SetFont(bold)
+        answer.q:SetFont(bold)
+        answer.number:SetKeyboardFocus()
+    end)
+    local change_mode = false
     dialog:RegisterHandleOkButtonPressed(function()
         config.number = answer.number:GetInteger()
+        config.layer = answer.layer:GetInteger()
         config.direction = answer.direction:GetSelectedItem()
         config.keep_delete = answer.keep_delete:GetSelectedItem()
+        make_changes()
     end)
-    dialog:RegisterInitWindow(function() answer.number:SetKeyboardFocus() end)
-    dialog:RegisterCloseWindow(function(self) dialog_save_position(self) end)
-    return (dialog:ExecuteModal() == finale.EXECMODAL_OK)
+    dialog:RegisterCloseWindow(function(self)
+        if config.modeless then self:StopTimer(config.timer_id) end
+        local mode = (answer.modeless:GetCheck() == 1)
+        change_mode = (config.modeless ~= mode) -- new mode!
+        config.modeless = mode
+        dialog_save_position(self)
+    end)
+    if config.modeless then   -- "modeless"
+        dialog:RunModeless()
+    else
+        dialog:ExecuteModal() -- "modal"
+        if refocus_document then finenv.UI():ActivateDocumentWindow() end
+    end
+    return change_mode
 end
 
 local function keep_delete()
     configuration.get_user_settings(script_name, config, true)
-    if user_chooses() then
-        for entry in eachentrysaved(finenv.Region()) do
-            if (entry.Count >= 2) then
-                local n = config.number
-                local target = (config.direction == 0) and (n - 1) or (entry.Count - n)
-                local i = 0
-                for note in eachbackwards(entry) do -- scan pitches top to bottom
-                    if      (i == target and config.keep_delete == 1)
-                        or  (i ~= target and config.keep_delete == 0) then
-                        note_entry.delete_note(note)
-                    end
-                    i = i + 1
-                end
-            end
+    if not config.modeless and finenv.Region():IsEmpty() then
+        finenv.UI():AlertError(
+            "Please select some music before\nrunning this script.",
+            finaleplugin.ScriptGroupName
+        )
+        return
+    end
+    local qim = finenv.QueryInvokedModifierKeys
+    local mod_key = qim and (qim(finale.CMDMODKEY_ALT) or qim(finale.CMDMODKEY_SHIFT))
+    local mode_change = true
+
+    initialise_parameters()
+    if mod_key then
+        make_changes()
+    else
+        while mode_change do
+            mode_change = run_the_dialog()
         end
     end
-    finenv.UI():ActivateDocumentWindow()
 end
 
 keep_delete()


### PR DESCRIPTION
Two __pitch-entry__ scripts undergoing considerable graphic cleansing and added __optional modeless__ operation. __Keep-Delete__ still needs approval from @jwink75  as a partial collaborator. __Diatonic Double__ is a considerable departure from its predecessor, losing both _LIST_BOX_ control elements in favour of simple (“clamped”) numeric entry. So __less__ keyboard hacking but much cleaner user interaction (inspired by @rpatters1’s _Chromatic_ and _By Steps_ transposition scripts).

In both scripts, switching from Modal to Modeless is re-entrant, immediately triggering the Modeless variant. Can’t see any way to make the converse transition without first exiting the Modeless state.