### PR TITLE
Update ostinato_maker.lua

### DIFF
--- a/src/ostinato_maker.lua
+++ b/src/ostinato_maker.lua
@@ -4,8 +4,8 @@ function plugindef()
     finaleplugin.Author = "Carl Vine after Michael McClennan & Jacob Winkler"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "https://creativecommons.org/licenses/by/4.0/"
-    finaleplugin.Version = "0.28" -- MODAL/MODELESS optional
-    finaleplugin.Date = "2024/03/04"
+    finaleplugin.Version = "0.29" -- MODAL/MODELESS optional
+    finaleplugin.Date = "2024/03/05"
     finaleplugin.MinJWLuaVersion = 0.70
     finaleplugin.Notes = [[
         Copy the current selection and paste it consecutively 
@@ -256,15 +256,6 @@ local function region_erasures(rgn)
     end
 end
 
-local function shave_end_pos(rgn)
-    if rgn.EndMeasurePos > 1 then
-        rgn.EndMeasurePos = rgn.EndMeasurePos - 1
-    else
-        rgn.EndMeasure = rgn.EndMeasure - 1
-        rgn.EndMeasurePos = measure_duration(rgn.EndMeasure) - 1
-    end
-end
-
 local function paste_many_copies(region)
     if region:IsEmpty() or config.num_repeats < 1 then return end -- no duplication
     local rgn = mixin.FCMMusicRegion()
@@ -277,8 +268,8 @@ local function paste_many_copies(region)
     rgn.EndMeasurePos = math.min(rgn.EndMeasurePos, measure_duration(rgn.EndMeasure))
     local end_pos = rgn.EndMeasurePos
     local rounded_pos = round_measure_position(rgn.EndMeasure, end_pos)
-    if end_pos == rounded_pos then
-        shave_end_pos(rgn) -- don't run over to start of next beat
+    if end_pos >= rounded_pos and rounded_pos > 1 then
+        rgn.EndMeasurePos = rounded_pos - 1
     end
 
     rgn:CopyMusic() -- save a copy of the current selection

--- a/src/ostinato_maker.lua
+++ b/src/ostinato_maker.lua
@@ -4,91 +4,74 @@ function plugindef()
     finaleplugin.Author = "Carl Vine after Michael McClennan & Jacob Winkler"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "https://creativecommons.org/licenses/by/4.0/"
-    finaleplugin.Version = "v0.19"
-    finaleplugin.Date = "2024/01/31"
-    finaleplugin.MinJWLuaVersion = 0.62
+    finaleplugin.Version = "0.27" -- MODAL/MODELESS optional
+    finaleplugin.Date = "2024/03/04"
+    finaleplugin.MinJWLuaVersion = 0.70
     finaleplugin.Notes = [[
         Copy the current selection and paste it consecutively 
         to the right a nominated number of times. 
         The replicas can span barlines ignoring time signatures. 
-        The same effect can be achieved with Edit → Paste Multiple 
+        The same effect can be achieved with _Edit_ → _Paste Multiple_, 
         but this script is simpler to use and works intuitively 
         on the current music selection in a single step. 
 
-        To repeat the last action without confirmation 
-        dialog hold down [shift] when starting the script. 
-        Choose to independently include or remove articulations, 
+        To repeat the last action without a confirmation 
+        dialog hold down [Shift] when starting the script. 
+        Independently include or remove articulations, 
         expressions, smartshapes, lyrics or chords from the repeats. 
+        Your choice at _Finale_ → _Settings..._ → _Edit_ → _Automatic Music Spacing_ 
+        determines whether or not the music is _respaced_ on completion. 
 
-        This script grew from the "region_replicate_music.lua" script in 
-        the FinaleLua.com repository by Michael McClennan and Jacob Winkler.
+        Select __Modeless__ if you prefer the dialog window to 
+        "float" above your score so you can change the score selection 
+        while the script is active. In this mode, click __Apply__ [Return/Enter] 
+        to create an ostinato and __Cancel__ [Escape] to close the window. 
+        Cancelling __Modeless__ will apply the _next_ time you use the script.
+
+        > These __Key Commands__ are available when the __times__ field is highlighted: 
+
+        > - __q__: show these script notes 
+        > - __w__: flip [copy Articulations] 
+        > - __e__: flip [copy Expressions] 
+        > - __r__: flip [copy Slurs] 
+        > - __t__: flip [copy Other Smartshapes] 
+        > - __y__: flip [copy Lyrics] 
+        > - __u__: flip [copy Chords]  
+        > - __a__: copy all 
+        > - __z__: copy none 
+        > - __m__: flip [Modeless] 
     ]]
     return "Ostinato Maker...", "Ostinato Maker",
         "Copy the current selection and paste it consecutively to the right a number of times"
 end
 
-local info_notes = [[
-Copy the current selection and paste it consecutively
-to the right a nominated number of times.
-The replicas can span barlines ignoring time signatures.
-The same effect can be achieved with Edit → Paste Multiple
-but this script is simpler to use and works intuitively
-on the current music selection in a single step.
-**
-To repeat the last action without confirmation
-dialog hold down [shift] when starting the script.
-Choose to independently include or remove articulations,
-expressions, smartshapes, lyrics or chords from the repeats.
-**
-This script grew from the "region_replicate_music.lua" script in
-the FinaleLua.com repository by Michael McClennan and Jacob Winkler.
-**
-Key Commands:
-*• q @t show these script notes
-*• w @t flip [copy articulations]
-*• e @t flip [copy expressions]
-*• r @t flip [copy smartshapes]
-*• t @t flip [copy lyrics]
-*• y @t flip [copy chords]
-*– – –
-*• a @t copy all
-*• z @t copy none
-]]
-info_notes = info_notes:gsub("\n%s*", " "):gsub("*", "\n"):gsub("@t", "\t")
-    .. "\n(" .. finaleplugin.Version .. ")"
-
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
+local utils = require("library.utils")
 local library = require("library.general_library")
 local script_name = library.calc_script_name()
-local dialog, current_selection
-
-local config = {
-    num_repeats  = 1,
-    timer_id     = 1,
-    window_pos_x = false,
-    window_pos_y = false,
-}
-local dialog_options = { -- and populate config values (unchecked)
-    "copy_articulations", "copy_expressions", "copy_smartshapes",
-    "copy_lyrics", "copy_chords"
-}
-for _, v in ipairs(dialog_options) do config[v] = 0 end -- (default unchecked)
-
-local bounds = { -- primary region selection boundary properties
+local refocus_document = false -- set to true if utils.show_notes_dialog is used
+local selection
+local saved_bounds = {}
+local bounds = { -- primary region selection boundaries
     "StartStaff", "StartMeasure", "StartMeasurePos",
     "EndStaff",   "EndMeasure",   "EndMeasurePos",
 }
 
-local function copy_region_bounds()
-    local copy = {}
-    for _, v in ipairs(bounds) do
-        copy[v] = finenv.Region()[v]
-    end
-    return copy
-end
+local config = {
+    num_repeats  = 1,
+    timer_id    = 1,
+    modeless    = false, -- false = modal / true = modeless
+    window_pos_x = false,
+    window_pos_y = false,
+}
+local dialog_options = { -- and populate config values (unchecked)
+    "copy_articulations", "copy_expressions", "copy_slurs",
+     "copy_smartshapes",  "copy_lyrics",      "copy_chords"
+}
+for _, v in ipairs(dialog_options) do config[v] = 0 end -- (default unchecked)
 
-local function dialog_set_position()
+local function dialog_set_position(dialog)
     if config.window_pos_x and config.window_pos_y then
         dialog:StorePosition()
         dialog:SetRestorePositionOnlyData(config.window_pos_x, config.window_pos_y)
@@ -96,7 +79,7 @@ local function dialog_set_position()
     end
 end
 
-local function dialog_save_position()
+local function dialog_save_position(dialog)
     dialog:StorePosition()
     config.window_pos_x = dialog.StoredX
     config.window_pos_y = dialog.StoredY
@@ -108,38 +91,46 @@ local function measure_duration(measure_number)
     return m:Load(measure_number) and m:GetDuration() or 0
 end
 
-local function selection_id()
-    if finenv.Region():IsEmpty() then return " - no selection - " end
-    local rgn = finenv.Region()
-    local ratio = rgn.StartMeasure + (rgn.StartMeasurePos / measure_duration(rgn.StartMeasure))
-    local id = "m" .. string.format("%.2f", ratio) .. "-"
-    local m = measure_duration(rgn.EndMeasure)
-    ratio = rgn.EndMeasure + (math.min(rgn.EndMeasurePos, m) / m)
-    id = id .. "m" .. string.format("%.2f", ratio)
-    return id
+local function get_staff_name(staff_num)
+    local staff = finale.FCStaff()
+    staff:Load(staff_num)
+    local str = staff:CreateDisplayFullNameString().LuaString
+    if not str or str == "" then
+        str = "Staff " .. staff_num
+    end
+    return str
 end
 
-local function staff_id()
-    if finenv.Region():IsEmpty() then return "" end
-    local staff = finale.FCStaff()
-    staff:Load(finenv.Region().StartStaff)
-    local str = staff:CreateDisplayFullNameString()
-    local id = "Staff: " .. str.LuaString .. " → "
-    staff:Load(finenv.Region().EndStaff)
-    str = staff:CreateDisplayFullNameString()
-    return id .. str.LuaString
+local function initialise_parameters()
+    local rgn = finenv.Region()
+    selection = { staff = "no staff", region = "no selection"} -- default
+    -- saved_bounds
+    for _, property in ipairs(bounds) do
+        saved_bounds[property] = rgn:IsEmpty() and 0 or rgn[property]
+    end
+    -- selection_id
+    if not rgn:IsEmpty() then
+        -- measures
+        local r1 = rgn.StartMeasure + (rgn.StartMeasurePos / measure_duration(rgn.StartMeasure))
+        local m = measure_duration(rgn.EndMeasure)
+        local r2 = rgn.EndMeasure + (math.min(rgn.EndMeasurePos, m) / m)
+        selection.region = string.format("m%.2f-m%.2f", r1, r2)
+        -- staves
+        selection.staff = get_staff_name(rgn.StartStaff)
+        if rgn.EndStaff ~= rgn.StartStaff then
+            selection.staff = selection.staff .. " → " .. get_staff_name(rgn.EndStaff)
+        end
+    end
 end
 
 local function add_duration(measure_number, position, add_edu)
     local m_width = measure_duration(measure_number)
-    if m_width == 0 then -- measure didn't load
-        return 0, 0
-    end
+    if m_width == 0 then return 0, 0 end -- measure didn't load
     if position > m_width then
         position = m_width
     end
     local remaining_to_add = position + add_edu
-    while remaining_to_add > m_width do
+    while remaining_to_add >= m_width do
         remaining_to_add = remaining_to_add - m_width
         local next_width = measure_duration(measure_number + 1) -- another measure?
         if next_width == 0 then -- no more measures
@@ -154,10 +145,10 @@ end
 
 local function shift_region_by_EDU(rgn, add_edu)
     rgn.EndMeasure, rgn.EndMeasurePos =
-            add_duration(rgn.EndMeasure, rgn.EndMeasurePos, add_edu)
+        add_duration(rgn.EndMeasure, rgn.EndMeasurePos, add_edu)
     if rgn.EndMeasure == 0 then return false end
     rgn.StartMeasure, rgn.StartMeasurePos =
-            add_duration(rgn.StartMeasure, rgn.StartMeasurePos, add_edu)
+        add_duration(rgn.StartMeasure, rgn.StartMeasurePos, add_edu)
     if rgn.StartMeasure == 0 then return false end
     return true
 end
@@ -165,26 +156,22 @@ end
 local function round_measure_position(measure_num, pos)
     -- round off measure position to nearest reasonable sub-beat
     local measure = finale.FCMeasure()
-    local beat_edu = finale.NOTE_QUARTER -- default for composite T_Sig
     measure:Load(measure_num)
-    local time_sig = measure:GetTimeSignature()
+    local beat_edu = measure:GetTimeSignature():CalcLargestBeatDuration()
+    if (beat_edu % 3 == 0) then beat_edu = beat_edu / 3 end -- compound meter
 
-    if not time_sig.CompositeTop then -- simple T_Sig beat value
-        beat_edu = time_sig.BeatDuration
-        if (beat_edu % 3 == 0) then beat_edu = beat_edu / 3 end -- compound
-    end
-    local ok, count = false, 1
-    while not ok and count <= 3 do -- scan down to 1/8th sub-beat
+    local ok, count = false, 0
+    while not ok and count < 4 do -- scan down to 1/8th sub-beat
         local remainder = pos % beat_edu
         if remainder == 0 then
             ok = true -- found integer multiple
         else
             local ratio = remainder / beat_edu
             local num_beats = math.floor(pos / beat_edu)
-            if ratio >= 7/8 or ratio <= 1/8 then
-                if ratio >= 7/8 then num_beats = num_beats + 1 end
+            if ratio >= 15/16 or ratio <= 1/16 then
+                if ratio >= 15/16 then num_beats = num_beats + 1 end
                 pos = num_beats * beat_edu
-                ok = true -- within 1/8th of total beat
+                ok = true -- within 1/16th of total beat
             end
         end
         if not ok then
@@ -195,23 +182,21 @@ local function round_measure_position(measure_num, pos)
     return pos
 end
 
-local function region_duration(rgn)
-    local meas = {
+local function region_duration(rgn, rounded_end_pos)
+    local measure = {
         start = rgn.StartMeasure,
-        stop = rgn.EndMeasure
+        stop  = rgn.EndMeasure
     }
     local pos = {
-        start = round_measure_position(meas.start, rgn.StartMeasurePos),
-        stop = round_measure_position(meas.stop, rgn.EndMeasurePos)
+        start = rgn.StartMeasurePos,
+        stop  = rounded_end_pos
     }
-    local diff, duration
-    if meas.start == meas.stop then -- simple EDU offset
-        diff = pos.stop - pos.start
-    else
-        duration = -pos.start
-        while meas.start < meas.stop do
-            duration = duration + measure_duration(meas.start)
-            meas.start = meas.start + 1
+    local diff = pos.stop - pos.start -- simple EDU offset
+    if measure.start ~= measure.stop then
+        local duration = pos.start * -1
+        while measure.start < measure.stop do
+            duration = duration + measure_duration(measure.start)
+            measure.start = measure.start + 1
         end
         diff = duration + pos.stop
     end
@@ -220,14 +205,19 @@ end
 
 local function region_erasures(rgn)
     -- region-based markings
-    if config.copy_smartshapes == 0 then -- erase SMART SHAPES
+    if config.copy_smartshapes == 0 or config.copy_slurs == 0 then -- erase SMART SHAPES
         local sh_rgn = finale.FCMusicRegion()
         sh_rgn:SetRegion(rgn) -- extend erasure region for stray hairpins
         sh_rgn.EndMeasure, sh_rgn.EndMeasurePos =
-            add_duration(sh_rgn.EndMeasure, sh_rgn.EndMeasurePos, 256)
+            add_duration(sh_rgn.EndMeasure, sh_rgn.EndMeasurePos, finale.NOTE_8TH)
         for mark in loadallforregion(finale.FCSmartShapeMeasureMarks(), sh_rgn) do
             local shape = mark:CreateSmartShape()
-            if shape then shape:DeleteData() end
+            if shape and
+                (   (not shape:IsSlur() and config.copy_smartshapes == 0) or
+                    (shape:IsSlur() and config.copy_slurs == 0)
+                )   then
+                shape:DeleteData()
+            end
         end
     end
     if config.copy_expressions == 0 then -- erase EXPRESSIONS
@@ -247,13 +237,13 @@ local function region_erasures(rgn)
     -- then entry-based markings
     if config.copy_articulations == 0 or config.copy_lyrics == 0 then
         for entry in eachentrysaved(rgn) do
-            if entry.ArticulationFlag and config.copy_articulations == 0 then -- erase ARTICULATIONS
+            if config.copy_articulations == 0 and entry.ArticulationFlag then -- erase ARTICULATIONS
                 for articulation in eachbackwards(entry:CreateArticulations()) do
                     articulation:DeleteData()
                 end
                 entry:SetArticulationFlag(false)
             end
-            if entry.LyricFlag and config.copy_lyrics == 0 then -- erase LYRICS
+            if config.copy_lyrics == 0 and entry.LyricFlag then -- erase LYRICS
                 for _, v in ipairs{"FCChorusSyllable", "FCSectionSyllable", "FCVerseSyllable"} do
                     local lyric = finale[v]()
                     lyric:SetNoteEntry(entry)
@@ -266,146 +256,187 @@ local function region_erasures(rgn)
     end
 end
 
-local function paste_many_copies()
-    if finenv.Region():IsEmpty() then
-        finenv.UI():AlertError("Please select some music before\n"
-            .. "running this script.", plugindef() .. " Error" )
-        return
+local function shave_end_pos(rgn)
+    if rgn.EndMeasurePos > 1 then
+        rgn.EndMeasurePos = rgn.EndMeasurePos - 1
+    else
+        rgn.EndMeasure = rgn.EndMeasure - 1
+        rgn.EndMeasurePos = measure_duration(rgn.EndMeasure) - 1
     end
-    local rgn = finenv.Region()
-    local origin = copy_region_bounds() -- copy current bounds
-    local undo_str = "Ostinato Maker " .. selection_id()
-    finenv.StartNewUndoBlock(undo_str, false)
-    --  ---- DO THE WORK
-    local m_d = measure_duration(rgn.EndMeasure)
-    if rgn.EndMeasurePos >= m_d then
-        rgn.EndMeasurePos = m_d - 1
+end
+
+local function paste_many_copies(region)
+    if region:IsEmpty() or config.num_repeats < 1 then return end -- no duplication
+    local rgn = mixin.FCMMusicRegion()
+    rgn:SetRegion(region)
+    --
+    finenv.StartNewUndoBlock(
+        string.format("Ostinato %s x %d", selection.region, config.num_repeats),
+        false
+    )
+    rgn.EndMeasurePos = math.min(rgn.EndMeasurePos, measure_duration(rgn.EndMeasure))
+    local end_pos = rgn.EndMeasurePos
+    local rounded_pos = round_measure_position(rgn.EndMeasure, end_pos)
+    if end_pos == rounded_pos then
+        shave_end_pos(rgn) -- don't run over to start of next beat
     end
+
     rgn:CopyMusic() -- save a copy of the current selection
-    local duration = region_duration(rgn)
-    local first_rpt = nil -- save start position of first repeat
-    for _ = 1, config.num_repeats do
-        if not shift_region_by_EDU(rgn, duration) then break end
+    local duration = region_duration(rgn, rounded_pos) -- "full" duration of duplicate period
+    local first_step = { m = region.StartMeasure, pos = region.StartMeasurePos }
+    for i = 1, config.num_repeats do
+        if not shift_region_by_EDU(rgn, duration) then break end -- no more music
         rgn:PasteMusic()
-        if not first_rpt then -- only save the first repeat region
-            first_rpt = { measure = rgn.StartMeasure, pos = rgn.StartMeasurePos }
+        if i == 1 then -- save start of the first repeat region
+            first_step = { m = rgn.StartMeasure, pos = rgn.StartMeasurePos }
         end
     end
     rgn:ReleaseMusic()
     -- erase unwanted markings across whole ostinato passage
-    rgn.StartMeasure = first_rpt.measure
-    rgn.StartMeasurePos = first_rpt.pos
-    region_erasures(rgn)
-    -- reset to start of operation
-    for _, v in ipairs(bounds) do rgn[v] = origin[v] end
-    rgn:SetInDocument()
-    --  ----
-    if finenv.EndUndoBlock then
-        finenv.EndUndoBlock(true)
-        finenv.Region():Redraw()
-    else
-        finenv.StartNewUndoBlock(undo_str, true)
-    end
+    rgn.StartMeasure = first_step.m
+    rgn.StartMeasurePos = first_step.pos
+    region_erasures(rgn)  -- erase markings from full "duplicated" region
+    region:SetInDocument() -- restore original selection
+    finenv.EndUndoBlock(true)
+    region:Redraw()
 end
 
-local function on_timer()
-    local changed = false
-    for _, v in ipairs(bounds) do
-        if current_selection[v] ~= finenv.Region()[v] then
-            changed = true
-            break
-        end
-    end
-    if changed then
-        current_selection = copy_region_bounds()
-        dialog:GetControl("info")
-            :SetText("Selection " .. selection_id() .. "\n" .. staff_id())
-    end
-end
-
-local function create_dialog()
+local function run_user_dialog()
     local edit_x, e_wide, y_step = 110, 40, 18
     local y_offset = finenv.UI():IsOnMac() and 3 or 0
     local save_rpt = config.num_repeats
-    local name = plugindef():gsub("%.%.%.", "")
-    dialog = mixin.FCXCustomLuaWindow():SetTitle(name)
+    local name = plugindef():sub(1, -4)
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle(name)
     local y = 0
-    local function flip_check(id)
-        local ctl = dialog:GetControl(dialog_options[id])
-        ctl:SetCheck((ctl:GetCheck() + 1) % 2)
-    end
-    local function check_all_state(state)
-        for _, v in ipairs(dialog_options) do
-            dialog:GetControl(v):SetCheck(state)
+        -- local functions
+        local function flip_check(id)
+            local ctl = dialog:GetControl(dialog_options[id])
+            ctl:SetCheck((ctl:GetCheck() + 1) % 2)
         end
-    end
-    local function info_dialog()
-        finenv.UI():AlertInfo(info_notes, "About " .. name)
-    end
-    local function key_check(ctl) -- some stray key commands
-        local s = ctl:GetText():lower()
-        if s:find("[^0-9]") then
-            if s:find("q") then info_dialog()
-            elseif s:find("w") then flip_check(1)
-            elseif s:find("e") then flip_check(2)
-            elseif s:find("r") then flip_check(3)
-            elseif s:find("t") then flip_check(4)
-            elseif s:find("y") then flip_check(5)
-            elseif s:find("a") then check_all_state(1)
-            elseif s:find("z") then check_all_state(0)
+        local function check_all_state(state)
+            for _, v in ipairs(dialog_options) do
+                dialog:GetControl(v):SetCheck(state)
             end
-            ctl:SetText(save_rpt):SetKeyboardFocus()
-        else
-            s = s:sub(-3) -- 3-digit limit
-            ctl:SetText(s)
-            save_rpt = s
         end
-    end
-    dialog:CreateStatic(0, y, "info")
-        :SetText("Selection " .. selection_id() .. "\n" .. staff_id())
-        :SetWidth(edit_x * 2):SetHeight(30)
-    y = y + 35
+        local function info_dialog()
+            utils.show_notes_dialog(dialog, "About " .. name, 500, 420)
+            refocus_document = true
+        end
+        local function key_check(ctl) -- key commands
+            local s = ctl:GetText():lower()
+            if s:find("[^0-9]") then
+                if s:find("q") then info_dialog()
+                elseif s:find("w") then flip_check(1)
+                elseif s:find("e") then flip_check(2)
+                elseif s:find("r") then flip_check(3)
+                elseif s:find("t") then flip_check(4)
+                elseif s:find("y") then flip_check(5)
+                elseif s:find("u") then flip_check(6)
+                elseif s:find("m") then
+                    local mod = dialog:GetControl("modeless")
+                    mod:SetCheck((mod:GetCheck() + 1) % 2)
+                elseif s:find("a") then check_all_state(1)
+                elseif s:find("z") then check_all_state(0)
+                end
+                ctl:SetText(save_rpt):SetKeyboardFocus()
+            else
+                if #s > 2 then
+                    save_rpt = s:sub(-2)
+                    ctl:SetText(save_rpt)
+                end
+            end
+        end
+        local function on_timer() -- look for changes in selected region
+            for k, v in pairs(saved_bounds) do
+                if finenv.Region()[k] ~= v then -- selection changed
+                    initialise_parameters() -- update selection tracker
+                    dialog:GetControl("info1"):SetText(selection.staff)
+                    dialog:GetControl("info2"):SetText(selection.region)
+                    break -- all done
+                end
+            end
+        end
+    --
     dialog:CreateStatic(0, y):SetText("Repeat ostinato:"):SetWidth(edit_x)
     dialog:CreateStatic(edit_x, y):SetText("Include:"):SetWidth(90)
-    y = y + y_step
+    y = y + y_step + 2
     local num_repeats = dialog:CreateEdit(0, y + 2 - y_offset)
         :SetWidth(e_wide - 4):SetText(config.num_repeats)
         :AddHandleCommand(function(self) key_check(self) end)
     dialog:CreateStatic(e_wide, y + 2):SetText("times"):SetWidth(edit_x)
     for _, v in ipairs(dialog_options) do
+        local id = v:sub(6):gsub("^%l", string.upper)
+        if id:find("Smart") then id = "Other Smartshapes" end
         dialog:CreateCheckbox(edit_x, y, v):SetCheck(config[v])
-           :SetText(v:sub(6, -1):gsub("^%l", string.upper)):SetWidth(90)
+           :SetText(id):SetWidth(120)
         y = y + y_step
     end
-    local q = dialog:CreateButton(0, y - 19):SetText("?"):SetWidth(20)
+    dialog:CreateCheckbox(0, y, "modeless"):SetWidth(80)
+        :SetCheck(config.modeless and 1 or 0):SetText("\"Modeless\" Dialog")
+    local q = dialog:CreateButton(edit_x + 100, y):SetText("?"):SetWidth(20)
         :AddHandleCommand(function() info_dialog() end)
-    dialog:CreateOkButton()
+    -- modeless selection info
+    if config.modeless then
+        y = y + 17
+        dialog:CreateStatic(20, y, "info1"):SetText(selection.staff):SetWidth(edit_x + 70)
+        y = y + 15
+        dialog:CreateStatic(20, y, "info2"):SetText(selection.region):SetWidth(edit_x + 70)
+    end
+
+    dialog:CreateOkButton():SetText(config.modeless and "Apply" or "OK")
     dialog:CreateCancelButton()
-    dialog_set_position()
-    dialog:RegisterHandleTimer(on_timer)
-    dialog:RegisterInitWindow(function()
+    dialog_set_position(dialog)
+    if config.modeless then dialog:RegisterHandleTimer(on_timer) end
+    dialog:RegisterInitWindow(function(self)
+        dialog:SetOkButtonCanClose(not config.modeless)
+        if config.modeless then self:SetTimer(config.timer_id, 125) end
         q:SetFont(q:CreateFontInfo():SetBold(true))
         num_repeats:SetKeyboardFocus()
-        dialog:SetTimer(config.timer_id, 125)
     end)
-    dialog:RegisterCloseWindow(function()
-        dialog_save_position()
-        dialog:StopTimer(config.timer_id)
-    end)
+    local change_mode = false
     dialog:RegisterHandleOkButtonPressed(function()
         config.num_repeats = num_repeats:GetInteger()
         for _, v in ipairs(dialog_options) do
             config[v] = dialog:GetControl(v):GetCheck()
         end
-        paste_many_copies()
+        paste_many_copies(finenv.Region())
     end)
+    dialog:RegisterCloseWindow(function(self)
+        if config.modeless then self:StopTimer(config.timer_id) end
+        local mode = (dialog:GetControl("modeless"):GetCheck() == 1)
+        change_mode = (mode and not config.modeless) -- modal -> modeless?
+        config.modeless = mode
+        dialog_save_position(self)
+    end)
+    if config.modeless then   -- "modeless"
+        dialog:RunModeless()
+    else
+        dialog:ExecuteModal() -- "modal"
+        if refocus_document then finenv.UI():ActivateDocumentWindow() end
+    end
+    return change_mode
 end
 
 local function make_ostinato()
     configuration.get_user_settings(script_name, config, true)
-    current_selection = copy_region_bounds()
-    create_dialog()
-    dialog:RunModeless()
+    if not config.modeless and finenv.Region():IsEmpty() then
+        finenv.UI():AlertError(
+            "Please select some music\nbefore running this script", plugindef()
+        )
+        return
+    end
+
+    local qim = finenv.QueryInvokedModifierKeys
+    local mod_key = qim and (qim(finale.CMDMODKEY_ALT) or qim(finale.CMDMODKEY_SHIFT))
+    local mode_change = true
+    initialise_parameters()
+    if mod_key then
+        paste_many_copies(finenv.Region())
+    else
+        while mode_change do
+            mode_change = run_user_dialog()
+        end
+    end
 end
 
 make_ostinato()


### PR DESCRIPTION
Added __modal/modeless__ option; `info_notes` replaced by `utils.show_notes_dialog()`; correctly handle null selection in __Modeless__; allow for nil staff names; corrected `copy_lyrics` flag in erasures; check for nil repeats and empty region; isolate __Slurs__ from “other” shapes to copy; corrected long-standing (serious) error in calculation of ostinato boundaries; many minor fixes and improvements.