### PR TITLE
Update pitch_changer.lua

### DIFF
--- a/src/pitch_changer.lua
+++ b/src/pitch_changer.lua
@@ -1,10 +1,11 @@
 function plugindef()
-    finaleplugin.RequireSelection = true
+    finaleplugin.RequireSelection = false
+    finaleplugin.HandlesUndo = true
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "v0.19"
-    finaleplugin.Date = "2023/11/04"
+    finaleplugin.Version = "v0.32"
+    finaleplugin.Date = "2024/03/23"
     finaleplugin.AdditionalMenuOptions = [[
         Pitch Changer Repeat
     ]]
@@ -17,42 +18,57 @@ function plugindef()
     finaleplugin.AdditionalPrefixes = [[
         repeat_change = true
     ]]
-    finaleplugin.MinJWLuaVersion = 0.64
+    finaleplugin.MinJWLuaVersion = 0.70
     finaleplugin.ScriptGroupName = "Pitch Changer"
     finaleplugin.ScriptGroupDescription = "Change all notes of one pitch in the region to another pitch"
     finaleplugin.Notes = [[
-        This script was inspired by Jari Williamsson's "JW Change Pitches" 
-        plug-in (2017) revived to work on Macs with non-Intel processors.
+        This script revives Jari Williamsson's _JW Change Pitches_ 
+        2017 plug-in to work on Macs with non-Intel processors.
 
-        Identify "from" and "to" pitches by note name (a-g or A-G) 
-        followed by accidental (#-###, b-bbb) as required. 
+        Identify __from__ and __to__ pitches by note name (__a-g__ or __A-G__) 
+        followed by accidental (#-##-###, b-bb-bbb) as required. 
         Matching pitches will be changed in every octave. 
-        To repeat the last pitch change without a confirmation dialog use 
-        the "Pitch Changer Repeat" menu or hold down the SHIFT key at startup.
+        For transposing instruments on transposing scores select 
+        __Written Pitch__ to affect the pitch you see on screen. 
+        To repeat the last change without a confirmation dialog use 
+        the _Pitch Changer Repeat_ menu or hold down [Shift] when opening the script. 
 
-        KEY REPLACEMENTS:
+        Select __Modeless__ if you prefer the dialog window to 
+        "float" above your score so you can change the score selection 
+        while it remains active. In this mode, click __Apply__ [Return/Enter] 
+        to make changes and __Cancel__ [Escape] to close the window. 
+        Cancelling __Modeless__ will apply the _next_ time you use the script.
 
-        Type "z", "x" or "v" to change the DIRECTION to "Closest", 
-        "Up" or "Down" respectively. 
-        Type "s" as an alternative to "#". 
-        Type "w" to swap the values in the "From:" and "To:" fields. 
-        Type "q" to display this "Information" window. 
+        > __Key Commands:__ 
+
+        > - __a-g__ (__A-G__): Note Names
+        > - __0-4__: Layer number (delete key not needed)
+        > - __z__: Direction Closest 
+        > - __x__: Direction Up 
+        > - __v__: Direction Down  
+        > - __w__: Swap the __From:__ and __To:__ values 
+        > - __s__: Shortcut for __#__ 
+        > - __m__: Toggle the __Modeless__ setting 
+        > - __r__: Toggle the __Written Pitch__ setting 
+        > - __q__: Display these script notes 
 	]]
     return "Pitch Changer...", "Pitch Changer", "Change all notes of one pitch in the region to another pitch"
 end
 
 repeat_change = repeat_change or false
 
-local directions = { {"Closest", "z"}, {"Up", "x"}, {"Down", "v" } }
 local config = {
-    find_string = "F#",
-    find_pitch = "F",
-    find_offset = 1, -- raise/lower value (to find)
-    new_string = "eb",
-    new_pitch = "E",
-    new_offset = -1, -- raise/lower value (to replace)
-    direction = 1, -- one-based index of "directions" choice
+    find_string = "F#", -- find this note
+    find_pitch = "F", -- its pitch name
+    find_offset = 1, -- its raise/lower value
+    new_string = "Eb", -- replace with this note
+    new_pitch = "E", -- its pitch name
+    new_offset = -1, -- its raise/lower value
+    direction = 1, -- one-based index of "direction" name [Closest/Up/Down]
     layer_num = 0,
+    written_pitch = false,
+    timer_id    = 1,
+    modeless    = false, -- false = modal / true = modeless
     window_pos_x = false,
     window_pos_y = false,
 }
@@ -60,7 +76,17 @@ local config = {
 local configuration = require("library.configuration")
 local layer = require("library.layer")
 local mixin = require("library.mixin")
-local script_name = "pitch_changer"
+local utils = require("library.utils")
+local library = require("library.general_library")
+local script_name = library.calc_script_name()
+local refocus_document = false -- set to true if utils.show_notes_dialog is used
+local selection
+local saved_bounds = {}
+local bounds = { -- primary region selection boundaries
+    "StartStaff", "StartMeasure", "StartMeasurePos",
+    "EndStaff",   "EndMeasure",   "EndMeasurePos",
+}
+local directions = { "Closest (z)", "Up (x)", "Down (v)" } -- 1 / 2 / 3
 
 local function dialog_set_position(dialog)
     if config.window_pos_x and config.window_pos_y then
@@ -77,86 +103,190 @@ local function dialog_save_position(dialog)
     configuration.save_user_settings(script_name, config)
 end
 
-local function calc_pitch_string(note)
-    local pitch_string = finale.FCString()
-    local cell = finale.FCCell(note.Entry.Measure, note.Entry.Staff)
-    local key_signature = cell:GetKeySignature()
-    note:GetString(pitch_string, key_signature, false, false)
-    return pitch_string.LuaString
+local function measure_duration(measure_number)
+    local m = finale.FCMeasure()
+    return m:Load(measure_number) and m:GetDuration() or 0
+end
+
+local function get_staff_name(staff_num)
+    local staff = finale.FCStaff()
+    staff:Load(staff_num)
+    local str = staff:CreateDisplayFullNameString().LuaString
+    if not str or str == "" then
+        str = "Staff " .. staff_num
+    end
+    return str
+end
+
+local function track_selection()
+    -- set_saved_bounds
+    local rgn = finenv.Region()
+    for _, property in ipairs(bounds) do
+        saved_bounds[property] = rgn:IsEmpty() and 0 or rgn[property]
+    end
+    -- update_selection_id
+    selection = { staff = "no staff", region = "no selection"} -- default
+    if not rgn:IsEmpty() then
+        -- measures
+        local r1 = rgn.StartMeasure + (rgn.StartMeasurePos / measure_duration(rgn.StartMeasure))
+        local m = measure_duration(rgn.EndMeasure)
+        local r2 = rgn.EndMeasure + (math.min(rgn.EndMeasurePos, m) / m)
+        selection.region = string.format("m%.2f-m%.2f", r1, r2)
+        -- staves
+        selection.staff = get_staff_name(rgn.StartStaff)
+        if rgn.EndStaff ~= rgn.StartStaff then
+            selection.staff = selection.staff .. " → " .. get_staff_name(rgn.EndStaff)
+        end
+    end
 end
 
 local function decode_note_string(str)
-    local s = str:upper()
-    local pitch = s:sub(1, 1)
-    if s == "" or pitch < "A" or pitch > "G" then
-        return "", 0, 0
+    local pitch = str:upper():sub(1, 1)
+    local acci = str:sub(2):lower():gsub("s", "#")
+    if str == "" or pitch:find("[^A-G]") or
+        (acci:find("[^b#]") or (acci:find("b") and acci:find("#"))) then
+            return "", 0
     end
-    local octave = tonumber(s:sub(-1)) or 4
-    local raise_lower = 0
-    s = s:sub(2) -- move past first char
-    if s:find("[#B]") then
-        for _ in s:gmatch("#") do raise_lower = raise_lower + 1 end
-        for _ in s:gmatch("B") do raise_lower = raise_lower - 1 end
-    end
-    return pitch, raise_lower, octave
+    local raise_lower = 0 -- count flats and sharps
+    for _ in acci:gmatch("b") do raise_lower = raise_lower - 1 end
+    for _ in acci:gmatch("#") do raise_lower = raise_lower + 1 end
+    return pitch, raise_lower
 end
 
-local function user_selection()
+local function octave_direction()
+    local find = string.byte(config.find_pitch) - 67 -- "A" = -2, "C" = 0
+    local new = string.byte(config.new_pitch) - 67
+    local find_off, new_off = config.find_offset, config.new_offset
+    local oct = 0 -- octave change
+
+    if config.direction == 1 then -- "Closest"
+        if ((find - new) > 3 and (new_off < 0)) then
+            oct = 1
+        elseif ((new - find) > 3 and (find_off < 0)) then
+            oct = -1
+        end
+    elseif config.direction == 2 then -- "Up"
+        if  (find < 0 and new > 0) or -- octave jumps around C
+            (new < find and (find < 0 or new >= 0)) or
+            (new == find and new_off < find_off) then
+            oct = 1 -- shift up octave
+        end
+    else -- config.direction == 3 -- "Down"
+        if  (new < 0 and find > 0) or
+            (new > find and (find >= 0 or new < 0)) or
+            (new == find and new_off > find_off) then
+            oct = -1 -- shift down octave
+        end
+    end
+    return oct
+end
+
+local function change_the_pitches()
+    finenv.StartNewUndoBlock(
+        string.format("Pitch Change %s to %s %s",
+            config.find_string, config.new_string, selection.region)
+    )
+    local octave_change = octave_direction() -- get "direction" octave choice
+    local s = finale.FCString()
+
+    for entry in eachentrysaved(finenv.Region(), config.layer_num) do
+        local key_sig = finale.FCCell(entry.Measure, entry.Staff):GetKeySignature()
+        if entry:IsNote() then
+            for note in each(entry) do
+                note:GetString(s, key_sig, false, config.written_pitch)
+                local pitch_string = s.LuaString
+                local octave = pitch_string:sub(-1)
+                if config.find_string == pitch_string:sub(1, -2) then
+                    s.LuaString = config.new_string .. (octave + octave_change)
+                    note:SetString(s, key_sig, config.written_pitch)
+                end
+            end
+        end
+    end
+    finenv.EndUndoBlock(true)
+    finenv.Region():Redraw()
+end
+
+local function run_the_dialog()
     local max_layer = layer.max_layers()
     local x_pos = { 0, 47, 85, 130 }
     local m_offset = finenv.UI():IsOnMac() and 3 or 0
-    local notes = finaleplugin.Notes:gsub(" %s+", " "):gsub("\n ", "\n"):sub(2)
-        local function show_info()
-            finenv.UI():AlertInfo(notes, finaleplugin.ScriptGroupName .. " Information")
-        end
-    local pitch, save_text = {}, { find = config.find_string, new = config.new_string }
-    local dialog = mixin.FCXCustomLuaWindow():SetTitle(plugindef())
     local y = 0
-        local function cstat(horiz, vert, wide, str)
-            dialog:CreateStatic(horiz, vert):SetWidth(wide):SetText(str)
-        end
-    cstat(x_pos[1], y, 50, "From:")
-    cstat(x_pos[3], y, 50, "To:")
-    cstat(x_pos[4], y, 60, "Direction:")
+    local name = finaleplugin.ScriptGroupName
+    local pitch, ctl, errors = {}, {}, {}
+    local save_text = { find = config.find_string, new = config.new_string }
 
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle(name)
+        -- local functions
+        local function yd(diff) y = y + (diff or 25) end
+        local function show_info()
+            utils.show_notes_dialog(dialog, "About " .. name, 420, 430)
+            refocus_document = true
+        end
+        local function cstat(horiz, vert, wide, str) -- dialog static text
+            return dialog:CreateStatic(horiz, vert):SetWidth(wide):SetText(str)
+        end
         local function value_swap()
             pitch.new:SetText(save_text.find)
             pitch.find:SetText(save_text.new)
             save_text.find = save_text.new
             save_text.new = pitch.new:GetText()
         end
-
+        local function toggle_check(id)
+            ctl[id]:SetCheck((ctl[id]:GetCheck() + 1) % 2)
+        end
         local function key_substitutions(kind)
-            local t = pitch[kind]:GetText()
-            local s = t:upper()
+            local s = pitch[kind]:GetText():upper()
             if (kind == "layer" and s:find("[^0-4]"))
               or (kind ~= "layer" and s:find("[^A-G#]")) then
-                local sub = 0
-                -- substitutions:Closest| Up |Down |Info |SHARP| Swap
-                for i, v in ipairs ({"Z", "X", "V", "[?Q]", "S", "W"}) do
-                    if s:find(v) then sub = i break end
+                -- key substitutions:
+                if      s:find("Z") then pitch.popup:SetSelectedItem(0) -- closest
+                elseif  s:find("X") then pitch.popup:SetSelectedItem(1) -- up
+                elseif  s:find("V") then pitch.popup:SetSelectedItem(2) -- down
+                elseif  s:find("S") and kind ~= "layer" then
+                    save_text[kind] = s:gsub("S", "#") -- substitute "#"
+                elseif  s:find("W") then value_swap()
+                elseif  s:find("[?Q]") then show_info()
+                elseif s:find("M") then toggle_check("modeless")
+                elseif s:find("R") then toggle_check("written_pitch")
                 end
-                if sub > 0 then
-                    if     sub == 6 then value_swap()
-                    elseif sub == 5 and kind ~= "layer" then
-                        save_text[kind] = save_text[kind] .. "#"
-                    elseif sub == 4 then show_info()
-                    elseif sub <= 3 then pitch.popup:SetSelectedItem(sub - 1)
-                    end
-                end
-                if sub < 6 or kind == "layer" then
+                if kind == "layer" or not s:find("W") then
                     pitch[kind]:SetText(save_text[kind])
                 end
             else
-                if kind == "layer" then
-                    t = t:sub(-1)
-                    pitch[kind]:SetText(t)
-                end
-                save_text[kind] = t
+                s = (kind == "layer") and s:sub(-1) or (s:sub(1, 1) .. s:sub(2):lower())
+                save_text[kind] = s
+                pitch[kind]:SetText(s)
             end
         end
-
-    y = y + 20
+        local function encode_pitches(kind)
+            local s = pitch[kind]:GetText()
+            local note, raise_lower = decode_note_string(s)
+            if note == "" then -- pitch name error
+                table.insert(errors, s) -- add error to list
+                return false -- flag user input error
+            end
+            config[kind .. "_pitch"] = note
+            config[kind .. "_offset"] = raise_lower
+            config[kind .. "_string"] = s
+            pitch[kind]:SetText(s)
+            save_text[kind] = s
+            return true -- no errors
+        end
+        local function on_timer() -- track changes in selected region
+            for k, v in pairs(saved_bounds) do
+                if finenv.Region()[k] ~= v then -- selection changed
+                    track_selection() -- update selection tracker
+                    ctl.info1:SetText(selection.staff)
+                    ctl.info2:SetText(selection.region)
+                    break -- all done
+                end
+            end
+        end
+    ctl.from = cstat(x_pos[1], y, 50, "From:")
+    ctl.to = cstat(x_pos[3], y, 50, "To:")
+    ctl.direction = cstat(x_pos[4], y, 60, "Direction:")
+    yd(20)
     pitch.find = dialog:CreateEdit(x_pos[1], y - m_offset):SetWidth(40):SetText(config.find_string)
         :AddHandleCommand(function() key_substitutions("find") end)
     dialog:CreateButton(x_pos[2], y):SetText("←→"):SetWidth(30)
@@ -165,97 +295,96 @@ local function user_selection()
         :AddHandleCommand(function() key_substitutions("new") end)
     pitch.popup = dialog:CreatePopup(x_pos[4], y):SetWidth(80)
     for _, v in ipairs(directions) do
-        pitch.popup:AddString(v[1] .. " (" .. v[2] ..")")
+        pitch.popup:AddString(v)
     end
     pitch.popup:SetSelectedItem(config.direction - 1) -- 0-based index configure value
-
-    y = y + 25
-    dialog:CreateButton(x_pos[1], y):SetText("?"):SetWidth(20)
-        :AddHandleCommand(function() show_info() end)
-    cstat(x_pos[3] - 58, y, 60, "Layer 1-" .. max_layer .. ":")
+    yd()
+    cstat(0, y, 60, "Layer 0-" .. max_layer .. ":")
     save_text.layer = tostring(config.layer_num)
-    pitch.layer = dialog:CreateEdit(x_pos[3], y - m_offset):SetWidth(25):SetText(config.layer_num)
+    pitch.layer = dialog:CreateEdit(60, y - m_offset):SetWidth(20):SetText(config.layer_num)
         :AddHandleCommand(function() key_substitutions("layer") end)
-
-    cstat(x_pos[3] + 27, y, 90, "(0 = all layers)")
-    dialog:CreateOkButton():SetText("Change")
-    dialog:CreateCancelButton()
-    dialog:RegisterInitWindow(function() pitch.find:SetKeyboardFocus() end)
-    dialog:RegisterCloseWindow(function() dialog_save_position(dialog) end)
-    dialog_set_position(dialog)
-
-        local function encode_pitches(kind)
-            local s = pitch[kind]:GetText()
-            local p_pitch, raise_lower, _ = decode_note_string(s:upper())
-            if p_pitch == "" or s:upper():sub(2):find("[AC-G]") then
-                config.find_pitch = "" -- signal submission error
-                return false
-            end -- otherwise continue without error
-            config[kind .. "_pitch"] = p_pitch
-            config[kind .. "_offset"] = raise_lower
-            config[kind .. "_string"] = s
-            return true
-        end
-    dialog:RegisterHandleOkButtonPressed(function()
-            if encode_pitches("find") and encode_pitches("new") then
-                config.layer_num = pitch.layer:GetInteger()
-                config.direction = pitch.popup:GetSelectedItem() + 1 -- save as one-based index
-                configuration.save_user_settings(script_name, config)
-            end
-        end)
-    return (dialog:ExecuteModal(nil) == finale.EXECMODAL_OK)
-end
-
-local function displacement_direction(disp)
-    local direction = config.direction
-    if direction == 1 then -- "Closest"
-        if disp < -3 then disp = disp + 7
-        elseif disp > 3 then disp = disp - 7
-        end
-    elseif direction == 2 then -- "Up"
-        if disp < 0 or (disp == 0 and config.new_offset < config.find_offset) then
-            disp = disp + 7
-        end
-    elseif direction == 3 then -- "Down"
-        if disp > 0 or (disp == 0 and config.new_offset > config.find_offset) then
-            disp = disp - 7
-        end
+    ctl.written_pitch = dialog:CreateCheckbox(x_pos[3] + 12, y):SetWidth(85)
+        :SetCheck(config.written_pitch and 1 or 0):SetText("Written Pitch")
+    ctl.q = dialog:CreateButton(x_pos[4] + 60, y):SetText("?"):SetWidth(20)
+       :AddHandleCommand(function() show_info() end)
+    yd()
+    ctl.modeless = dialog:CreateCheckbox(0, y):SetWidth(x_pos[4] + 80)
+        :SetCheck(config.modeless and 1 or 0):SetText("\"Modeless\" Dialog")
+    -- modeless selection info
+    if config.modeless then
+        yd(14)
+        ctl.info1 = dialog:CreateStatic(16, y):SetText(selection.staff):SetWidth(x_pos[4] + 65)
+        yd(14)
+        ctl.info2 = dialog:CreateStatic(16, y):SetText(selection.region):SetWidth(x_pos[4] + 65)
     end
-    return disp
+    -- wrap it up
+    dialog:CreateOkButton():SetText(config.modeless and "Apply" or "Change")
+    dialog:CreateCancelButton()
+    dialog:RegisterInitWindow(function(self)
+        self:SetOkButtonCanClose(not config.modeless)
+        if config.modeless then self:SetTimer(config.timer_id, 125) end
+        local bold = ctl.from:CreateFontInfo():SetBold(true)
+        ctl.from:SetFont(bold)
+        ctl.to:SetFont(bold)
+        ctl.direction:SetFont(bold)
+        pitch.find:SetKeyboardFocus()
+    end)
+    local change_mode, user_error = false, false
+    dialog_set_position(dialog)
+    if config.modeless then dialog:RegisterHandleTimer(on_timer) end
+    dialog:RegisterHandleOkButtonPressed(function()
+        errors = {} -- empty error list
+        local good_name1, good_name2 = encode_pitches("find"), encode_pitches("new")
+        if good_name1 and good_name2 then -- no pitch name errors
+            config.layer_num = pitch.layer:GetInteger()
+            config.direction = pitch.popup:GetSelectedItem() + 1 -- one-based index
+            config.written_pitch = (ctl.written_pitch:GetCheck() == 1)
+            change_the_pitches()
+        else
+            dialog:CreateChildUI():AlertError( -- **ERROR!**
+                "Pitch names cannot be empty and must start with a single "
+                .. "note name (a-g or A-G) followed by accidentals "
+                .. "(#-###, b-bbb) as required.\n\n"
+                .. "These pitch names are invalid:\n"
+                .. table.concat(errors, "; "),
+                name .. " Error"
+            )
+            user_error = true
+        end
+    end)
+    dialog:RegisterCloseWindow(function(self)
+        if config.modeless then self:StopTimer(config.timer_id) end
+        local mode = (ctl.modeless:GetCheck() == 1)
+        change_mode = (mode and not config.modeless) -- modal -> modeless?
+        config.modeless = mode
+        dialog_save_position(self)
+    end)
+    if config.modeless then   -- "modeless"
+        dialog:RunModeless()
+    else
+        dialog:ExecuteModal()
+        if refocus_document then finenv.UI():ActivateDocumentWindow() end
+    end
+    return (change_mode or user_error) -- something still to change
 end
 
 local function change_pitch()
     configuration.get_user_settings(script_name, config, true)
-    local mod_key = finenv.QueryInvokedModifierKeys and
-        (finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_SHIFT)
-            or finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT)
+    if not config.modeless and finenv.Region():IsEmpty() then
+        finenv.UI():AlertError(
+            "Please select some music\nbefore running this script.",
+            finaleplugin.ScriptGroupName
         )
-    if not (repeat_change or mod_key) then
-        if not user_selection() then return end -- user cancelled
-        if config.find_pitch == "" then -- entry error
-            finenv.UI():AlertError(
-                "Pitch names cannot be empty and must start with a single " ..
-                "note name (a-g or A-G) followed by accidentals " ..
-                "(#-###, b-bbb) if required.", "Error"
-            )
-            return
-        end
+        return
     end
-    local displacement = string.byte(config.new_pitch) - string.byte(config.find_pitch)
-    displacement = displacement_direction(displacement) -- adjust for "direction" preference
+    local qim = finenv.QueryInvokedModifierKeys
+    local mod_key = qim and (qim(finale.CMDMODKEY_ALT) or qim(finale.CMDMODKEY_SHIFT))
 
-    -- change the pitches ...
-    for entry in eachentrysaved(finenv.Region(), config.layer_num) do
-        if entry:IsNote() then
-            for note in each(entry) do
-                local pitch_string = calc_pitch_string(note)
-                local pitch, raise_lower, _ = decode_note_string(pitch_string)
-                if pitch == config.find_pitch and raise_lower == config.find_offset then
-                    note.Displacement = note.Displacement + displacement
-                    note.RaiseLower = config.new_offset
-                end
-            end
-        end
+    track_selection() -- track current selected region
+    if mod_key or repeat_change then
+        change_the_pitches()
+    else
+        while run_the_dialog() do end
     end
 end
 


### PR DESCRIPTION
The last version of this script failed to correctly identify accidentals in all key signatures. The pitch-matching algorithm has been improved, but also a __Modeless__ option has been added. Also: `script_name` from `general_library` not literal; upgraded Notes for Markdown using `utils.show_notes_dialog`; sundry other improvements.