### PR TITLE
Update deletion_chooser.lua

### DIFF
--- a/src/deletion_chooser.lua
+++ b/src/deletion_chooser.lua
@@ -3,8 +3,8 @@ function plugindef()
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "https://carlvine.com/lua"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "0.92"
-    finaleplugin.Date = "2024/04/01"
+    finaleplugin.Version = "0.95"
+    finaleplugin.Date = "2024/04/22"
     finaleplugin.MinJWLuaVersion = 0.70
 	finaleplugin.Notes = [[ 
         This script presents an alphabetical list of 24 individual types 
@@ -18,10 +18,10 @@ function plugindef()
         > Custom Lines | Dynamics• | Expressions (Not Dynamics)•  
         > Expressions (All)• | Expressions (Measure-Attached) | Glissandos  
         > Hairpins | Lyrics• | MIDI Continuous Data | MIDI Note Data•  
-        > Note Position Offsets• | Notehead Modifications• | Secondary Beam Breaks•  
-        > Slurs | Smart Shapes (Note Attached)• | Smart Shapes (Beat Attached)  
-        > Smart Shapes (All) | Staff Styles | Tuplets• | User Selected...  
-        > (• = filter by layer)
+        > Note Position Offsets• | Notehead Modifications• | Notes•  
+        > Secondary Beam Breaks• | Slurs | Smart Shapes (Note Attached)•  
+        > Smart Shapes (Beat Attached) | Smart Shapes (All) | Staff Styles  
+        > Tuplets• | User Selected... | (• = filter by layer)
 
         To delete the same data as last time without a confirmation dialog 
         hold down [Shift] when starting the script. 
@@ -42,6 +42,7 @@ local mixin = require("library.mixin")
 local expression = require("library.expression")
 local layer = require("library.layer")
 local utils = require("library.utils")
+local note_entry = require("library.note_entry")
 local library = require("library.general_library")
 local script_name = library.calc_script_name()
 local refocus_document = false -- set to true if utils.show_notes_dialog is used
@@ -49,64 +50,44 @@ local refocus_document = false -- set to true if utils.show_notes_dialog is used
 -- Mac / Windows menu command value ...
 local clear_selected_items_menu = finenv.UI():IsOnMac() and 1296385394 or 16010
 
-local dialog_options = { -- key, text description (ordered)
-    { "entry_articulation", "Articulations •" },
-    { "rest_articulation", "Articulations on Rests •" },
-    { "chords", "Chords" },
-    { "cross_staff", "Cross Staff Entries •" },
-    { "shape_IsCustomLine", "Custom Lines" },
-    { "expression_dynamic", "Dynamics •" },
-    { "expression_not_dynamic", "Expressions (Not Dynamics) •" },
-    { "expression_all", "Expressions (All Note-Attached) •" },
-    { "measure_attached", "Expressions (Measure-Attached)" },
-    { "shape_IsGlissando", "Glissandos" },
-    { "shape_IsHairpin", "Hairpins" },
-    { "entry_lyrics", "Lyrics •" },
-    { "midi_continuous", "MIDI Continuous Data" },
-    { "midi_entry", "MIDI Note Data •" },
-    { "entry_position", "Note Position Offsets •" },
-    { "notehead_mods", "Notehead Modifications •" },
-    { "secondary_beam_breaks", "Secondary Beam Breaks •" }, 
-    { "shape_IsSlur", "Slurs" },
-    { "shape_IsEntryBased", "Smart Shapes (Note Attached) •" },
-    { "shape_GetBeatAttached", "Smart Shapes (Beat Attached)" },
-    { "shape_all", "Smart Shapes (All)" },
-    { "staff_styles", "Staff Styles (Current Score/Part)" },
-    { "entry_tuplets", "Tuplets •" },
-    { "user_selected", "User Selected Items ..."}
+local dialog_options = { -- name key, HOTKEY, text description (ordered)
+    { "entry_articulation",     "A", "Articulations •" },
+    { "rest_articulation",      "R", "Articulations on Rests •" },
+    { "chords",                 "W", "Chords" },
+    { "cross_staff",            "X", "Cross Staff Entries •" },
+    { "shape_IsCustomLine",     "C", "Custom Lines" },
+    { "expression_dynamic",     "D", "Dynamics •" },
+    { "expression_not_dynamic", "E", "Expressions (Not Dynamics) •" },
+    { "expression_all",         "F", "Expressions (All Note-Attached) •" },
+    { "measure_attached",       "M", "Expressions (Measure-Attached)" },
+    { "shape_IsGlissando",      "G", "Glissandos" },
+    { "shape_IsHairpin",        "H", "Hairpins" },
+    { "entry_lyrics",           "L", "Lyrics •" },
+    { "midi_continuous",        "O", "MIDI Continuous Data" },
+    { "midi_entry",             "I", "MIDI Note Data •" },
+    { "entry_position",         "Q", "Note Position Offsets •" },
+    { "notehead_mods",          "J", "Notehead Modifications •" },
+    { "notes",                  "N", "Notes •" },
+    { "secondary_beam_breaks",  "K", "Secondary Beam Breaks •" },
+    { "shape_IsSlur",           "S", "Slurs" },
+    { "shape_IsEntryBased",     "P", "Smart Shapes (Note Attached) •" },
+    { "shape_GetBeatAttached",  "B", "Smart Shapes (Beat Attached)" },
+    { "shape_all",              "V", "Smart Shapes (All)" },
+    { "staff_styles",           "Y", "Staff Styles (Current Score/Part)" },
+    { "entry_tuplets",          "T", "Tuplets •" },
+    { "user_selected",          "Z", "User Selected Items ..." },
 }
 
-local config = { -- keystroke assignments, layer number and window position
-    entry_articulation = "A",
-    rest_articulation = "R",
-    chords = "W",
-    cross_staff = "X",
-    shape_IsCustomLine = "C",
-    expression_dynamic = "D",
-    expression_not_dynamic = "E",
-    expression_all = "F",
-    measure_attached = "M",
-    shape_IsGlissando = "G",
-    shape_IsHairpin = "H",
-    entry_lyrics = "L",
-    midi_continuous = "O",
-    midi_entry = "I",
-    entry_position = "N",
-    notehead_mods = "J",
-    secondary_beam_breaks = "K",
-    shape_IsSlur = "S",
-    shape_IsEntryBased = "P",
-    shape_GetBeatAttached = "B",
-    shape_all = "V",
-    staff_styles = "Y",
-    entry_tuplets = "T",
-    user_selected = "Z",
+local config = { -- user config data
+    layer_num = 0,
     last_selected = 0, -- last selected menu item number (0-based)
     window_pos_x = false,
     window_pos_y = false,
     ignore_duplicates = 0,
-    layer_num = 0,
 }
+for _, v in ipairs(dialog_options) do -- add HOTKEYS to CONFIG
+    config[v[1]] = v[2] -- map NAME key onto HOTKEY
+end
 
 local function dialog_set_position(dialog)
     if config.window_pos_x and config.window_pos_y then
@@ -183,6 +164,17 @@ local function delete_selected(delete_type)
         chords:LoadAllForRegion(rgn)
         for chord in eachbackwards(chords) do
             if chord then chord:DeleteData() end
+        end
+    --
+    elseif delete_type == "notes" then -- NOTES
+        for entry in eachentrysaved(rgn, layer_num) do
+            if entry:IsNote() then note_entry.make_rest(entry) end
+        end
+        for m, s in eachcell(rgn) do
+            local c = finale.FCNoteEntryCell(m, s)
+            c:Load()
+            c:ReduceEntries()
+            c:Save()
         end
     --
     elseif delete_type == "measure_attached" then -- MEASURE-ATTACHED EXPRESSIONS type
@@ -324,10 +316,10 @@ local function reassign_keys(parent, selected)
     for _, v in ipairs(dialog_options) do -- add all options with keycodes
         dialog:CreateEdit(0, y - offset, v[1]):SetText(config[v[1]]):SetWidth(20)
             :AddHandleCommand(function(self)
-                local str = self:GetText():sub(-1):upper()
-                self:SetText(str):SetKeyboardFocus()
+                local s = self:GetText():sub(-1):upper()
+                self:SetText(s):SetKeyboardFocus()
             end)
-        dialog:CreateStatic(25, y):SetText(v[2]):SetWidth(x_wide)
+        dialog:CreateStatic(25, y):SetText(v[3]):SetWidth(x_wide)
         y = y + y_step
     end
     y = y + 7
@@ -339,7 +331,7 @@ local function reassign_keys(parent, selected)
     dialog_set_position(dialog)
     dialog:RegisterHandleOkButtonPressed(function(self)
         local assigned = {}
-        for i, v in ipairs(dialog_options) do
+        for _, v in ipairs(dialog_options) do
             local key = self:GetControl(v[1]):GetText()
             if key == "" then key = "?" end -- not null
             config[v[1]] = key -- save for another possible run-through
@@ -348,26 +340,27 @@ local function reassign_keys(parent, selected)
                 if assigned[key] then -- previously assigned
                     is_duplicate = true
                     if not errors[key] then errors[key] = { assigned[key] } end
-                    table.insert(errors[key], i)
+                    table.insert(errors[key], v[3])
                 else
-                    assigned[key] = i -- flag key assigned
+                    assigned[key] = v[3] -- flag key assigned
                 end
             end
         end
         if is_duplicate then -- list reassignment duplications
             local msg = ""
             for k, v in pairs(errors) do
+                if msg ~= "" then msg = msg .. "\n\n" end
                 msg = msg .. "Key \"" .. k .. "\" is assigned to: "
                 for i, w in ipairs(v) do
                     if i > 1 then msg = msg .. " and " end
-                    msg = msg .. "\"" .. dialog_options[w][2] .. "\""
+                    msg = msg .. "\"" .. w .. "\""
                 end
-                msg = msg .. "\n\n"
             end
-            finenv.UI():AlertError(msg, "Duplicate Key Assignment")
+            dialog:CreateChildUI():AlertError(msg, "Duplicate Key Assignment")
         end
     end)
     local ok = (dialog:ExecuteModal(parent) == finale.EXECMODAL_OK)
+    refocus_document = true
     return ok, is_duplicate
 end
 
@@ -393,17 +386,21 @@ local function user_chooses()
             local join = finenv.UI():IsOnMac() and "\t" or ":  "
             key_list:Clear()
             for _, v in ipairs(dialog_options) do
-                key_list:AddString(config[v[1]] .. join .. v[2])
+                key_list:AddString(config[v[1]] .. join .. v[3])
             end
             key_list:SetSelectedItem(config.last_selected or 0)
         end
         local function change_keys()
             local ok, is_duplicate = true, true
             local selected = dialog_options[key_list:GetSelectedItem() + 1][1]
-            while ok and is_duplicate do -- wait for valid choice in reassign_keystrokes()
+            while ok and is_duplicate do -- wait for valid choice in reassign_keys()
                 ok, is_duplicate = reassign_keys(dialog, selected)
             end
-            if ok then fill_key_list() end
+            if ok then
+                fill_key_list() -- update hotkey choices
+            else -- "forget" the rejected choices
+                configuration.get_user_settings(script_name, config)
+            end
         end
 
     fill_key_list()
@@ -425,7 +422,6 @@ local function user_chooses()
                 save_layer = val
             end
         end)
-
     dialog:CreateStatic(x_off + 60, y):SetWidth(x_off):SetText("(0 = all)")
     y = y + y_step + 2
     dialog:CreateButton(0, y):SetText("Reassign Hotkeys"):SetWidth(x_off * 2)


### PR DESCRIPTION
An accretion of small upgrades. Added __note__  deletion (by layer within selection);  Minor neatening: unified Hotkey config choice with `dialog_options` table; “forget” rejected hokey modifications; neater text response in `reassign_keys()`; `CreateChildUI()` for and refocus after child dialog.