### PR TITLE
Four scripts finaleplugin.Notes update

### DIFF
--- a/src/measure_span.lua
+++ b/src/measure_span.lua
@@ -3,10 +3,10 @@ function plugindef()
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "https://creativecommons.org/licenses/by/4.0/"
-    finaleplugin.Version = "v0.93c"
-    finaleplugin.Date = "2023/09/15"
+    finaleplugin.Version = "0.94"
+    finaleplugin.Date = "2024/04/30"
     finaleplugin.CategoryTags = "Measure, Time Signature, Meter"
-    finaleplugin.MinJWLuaVersion = 0.64
+    finaleplugin.MinJWLuaVersion = 0.70
     finaleplugin.AdditionalMenuOptions = [[
         Measure Span Join
         Measure Span Divide
@@ -25,48 +25,48 @@ function plugindef()
     ]]
     finaleplugin.ScriptGroupName = "Measure Span"
     finaleplugin.ScriptGroupDescription = "Divide single measures or join measure pairs by changing time signatures"
-    finaleplugin.Notes = [[ 
-        This script changes the "span" of every measure in the currently selected music by 
-        manipulating its time signature, either dividing it into two or combining it with the 
-        following measure. Many measures with different time signatures can be modified at once.
-
-        == JOIN ==
-
-        Combine each pair of measures in the selection into one by combining their time signatures. 
-        If they have the same time signature either double the numerator ([3/4][3/4] -> [6/4]) or 
-        halve the denominator ([3/4][3/4] -> [3/2]). If the time signatures are different, choose to either 
-        COMPOSITE them ([2/4][3/8] -> [2/4 + 3/8]) or CONSOLIDATE them ([2/4][3/8] -> [7/8]). 
+    finaleplugin.Notes = [[
+        Select any number of measures and this script changes their "span" by 
+        manipulating the time signatures, either dividing each one into two or combining 
+        pairs of measures together. 
+        
+        __Join__  
+        Combine each pair of measures in the selection by combining their time signatures. 
+        If they have the same time signature either double the numerator ([3/4][3/4] → [6/4]) or 
+        halve the denominator ([3/4][3/4] → [3/2]). If the time signatures are different, choose to either 
+        _Composite_ them ([2/4][3/8] → [2/4 + 3/8]) or _Consolidate_ them ([2/4][3/8] → [7/8]). 
         (Consolidation loses current beam groupings). You can choose that a consolidated "display" 
-        time signature is created automatically when compositing meters. "JOIN" only works on an even number of measures.
-
-        == DIVIDE ==
-
+        time signature is created automatically when compositing meters. 
+        _Join_ only works on an even number of measures. 
+        
+        __Divide__  
         Divide every selected measure into two, changing the time signature by either halving the 
-        numerator ([6/4] -> [3/4][3/4]) or doubling the denominator ([6/4] -> [6/8][6/8]). 
+        numerator ([6/4] → [3/4][3/4]) or doubling the denominator ([6/4] → [6/8][6/8]). 
         If the measure has an odd number of beats, choose whether to put more beats in the first 
-        measure (5->3+2) or the second (5->2+3). Measures containing composite meters will be divided 
-        after the first composite group, or if there is only one group, after its first element.
-
-        == IN ALL CASES ==
-
-        Incomplete measures will be filled with rests before Join/Divide. Measures containing too many 
-        notes will be trimmed to the "real" duration of the time signature. 
-        Time signatures "for display only" will be removed. 
-        Measures are either deleted or shifted in every operation so smart shapes on 
-        either side of the area need to be "restored". 
-        Selecting a SPAN of "5" will look for smart shapes to restore from 5 
+        measure (5→3+2) or the second (5→2+3). Measures containing composite meters will be divided 
+        after the first composite group, or if there is only one group, after its first element. 
+        
+        __In All Cases__  
+        Incomplete measures will be filled with rests before __Join__ or __Divide__. Measures containing 
+        too many notes will be trimmed to the "real" duration of the time signature. 
+        __Display only__ time signatures  are erased. 
+        Measures are either deleted or shifted in every operation so smart shapes 
+        spanning the selected music need to be "restored". 
+        Selecting a __Span__ of __5__ will look for smart shapes to restore from 5 
         measures before until 5 after the selected region. 
-        (This takes noticeably longer than a SPAN of "2").
-
-        == OPTIONS ==
-
-        To configure script settings select the "Measure Span Options..." menu item, or else hold down 
-        the SHIFT or ALT (option) key when invoking "Join" or "Divide".
+        (This takes noticeably longer than a __Span__ of __2__). 
+        
+        __Options__  
+        To configure script settings select the _Measure Span Options..._ menu 
+        or hold down [Shift] when using __Join__ or __Divide__.
     ]]
-    return "Measure Span Options...", "Measure Span Options", "Change the default behaviour of the Measure Span script"
+    return "Measure Span Options...",
+        "Measure Span Options",
+        "Change the default behaviour of the Measure Span script"
 end
 
 span_action = span_action or "options"
+
 local config = {
     halve_numerator =   true, -- halve the numerator on DIVIDE otherwise double the denominator
     odd_more_first  =   true, -- if dividing odd beats, more beats in FIRST measure (otherwise in the second)
@@ -84,10 +84,12 @@ local config = {
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
 local layer = require("library.layer")
-local script_name = "measure_span"
-configuration.get_user_settings(script_name, config, true)
+local utils = require("library.utils")
+local library = require("library.general_library")
+local script_name = library.calc_script_name()
+local refocus_document = false -- set to true if utils.show_notes_dialog is used
 
-function dialog_set_position(dialog)
+local function dialog_set_position(dialog)
     if config.window_pos_x and config.window_pos_y then
         dialog:StorePosition()
         dialog:SetRestorePositionOnlyData(config.window_pos_x, config.window_pos_y)
@@ -95,80 +97,76 @@ function dialog_set_position(dialog)
     end
 end
 
-function dialog_save_position(dialog)
+local function dialog_save_position(dialog)
     dialog:StorePosition()
     config.window_pos_x = dialog.StoredX
     config.window_pos_y = dialog.StoredY
     configuration.save_user_settings(script_name, config)
 end
 
-function user_options()
+local function user_options()
     local x_grid = { 15, 70, 190, 210, 305, 110 }
     local i_width = 142
     local y = 0
 
-    local dlg = mixin.FCXCustomLuaWindow():SetTitle(plugindef())
+    local dlg = mixin.FCXCustomLuaWindow():SetTitle(finaleplugin.ScriptGroupName)
         local function yd(diff)
             diff = diff or 15 -- average horizontal line shift
             y = y + diff
         end
-        local function cstat(cx, cy, ctext, cwide, chigh)
+        local function cstat(cx, cy, ctext, cwide, chigh, cname)
             cx = (type(cx) == "string") and tonumber(cx) or x_grid[cx]
-            local stat = dlg:CreateStatic(cx, cy):SetText(ctext)
+            local stat = dlg:CreateStatic(cx, cy, cname):SetText(ctext)
             if cwide then stat:SetWidth(cwide) end
             if chigh then stat:SetHeight(chigh) end
-            return stat
         end
         local function ccheck(cx, cy, cname, cwide, check, ctext, chigh)
             cx = x_grid[cx]
-            local chk = dlg:CreateCheckbox(cx, cy, cname):SetWidth(cwide):SetText(ctext):SetCheck(check)
+            local chk = dlg:CreateCheckbox(cx, cy, cname):SetWidth(cwide)
+                :SetText(ctext):SetCheck(check)
             if chigh then chk:SetHeight(chigh) end
         end
         local function chl(cx, cy, cwide)
             dlg:CreateHorizontalLine(cx, cy, cwide)
         end
 
-    local shadow = cstat("1", y + 1, "DIVIDE EACH MEASURE INTO TWO:", x_grid[4])
-    if shadow.SetTextColor then shadow:SetTextColor(180, 180, 180) end
-    cstat("0", y, "DIVIDE EACH MEASURE INTO TWO:", x_grid[4])
+    cstat(1, y + 1, "DIVIDE EACH MEASURE INTO TWO:", x_grid[4], nil, "div1")
     yd(20)
     cstat(1, y, "Halve the numerator:", x_grid[3])
-    ccheck(3, y, "1", i_width, (config.halve_numerator and 1 or 0), " [6/4] -> [3/4][3/4]")
+    ccheck(3, y, "1", i_width, (config.halve_numerator and 1 or 0), " [6/4] → [3/4][3/4]")
     yd()
     cstat(2, y, "OR")
     yd()
     cstat(1, y, "Double the denominator:", x_grid[3])
-    ccheck(3, y, "2", i_width, (config.halve_numerator and 0 or 1), " [6/4] -> [6/8][6/8]")
+    ccheck(3, y, "2", i_width, (config.halve_numerator and 0 or 1), " [6/4] → [6/8][6/8]")
     yd(25)
     chl(1, y, x_grid[5])
     yd(10)
     cstat(1, y, "If halving a numerator with an ODD number of beats:", x_grid[5])
     yd(17)
     cstat(1, y, "More beats in first measure:", x_grid[4] + 20)
-    ccheck(3, y, "3", i_width, (config.odd_more_first and 1 or 0), " 3 -> 2 + 1 etc.")
+    ccheck(3, y, "3", i_width, (config.odd_more_first and 1 or 0), " 3 → 2 + 1 etc.")
     yd()
     cstat(2, y, "OR")
     yd()
     cstat(1, y, "More beats in second measure:", x_grid[4] + 20)
-    ccheck(3, y, "4", i_width, (config.odd_more_first and 0 or 1), " 3 -> 1 + 2 etc.")
+    ccheck(3, y, "4", i_width, (config.odd_more_first and 0 or 1), " 3 → 1 + 2 etc.")
     yd(27)
     chl(0, y, x_grid[3] + i_width)
     chl(0, y + 2, x_grid[3] + i_width)
     chl(0, y + 3, x_grid[3] + i_width)
     yd(13)
-    shadow = cstat("1", y + 1, "JOIN PAIRS OF MEASURES:", x_grid[3])
-    if shadow.SetTextColor then shadow:SetTextColor(180, 180, 180) end
-    cstat("0", y, "JOIN PAIRS OF MEASURES:", x_grid[3])
+    cstat(1, y + 1, "JOIN PAIRS OF MEASURES:", x_grid[3], nil, "div2")
     yd(20)
     cstat(1, y, "If both measures have the same time signature ...", x_grid[5])
     yd(17)
     cstat(1, y, "Double the numerator:", x_grid[3])
-    ccheck(3, y, "5", i_width, (config.double_join and 1 or 0), " [3/8][3/8] -> [6/8]")
+    ccheck(3, y, "5", i_width, (config.double_join and 1 or 0), " [3/8][3/8] → [6/8]")
     yd()
     cstat(2, y, "OR")
     yd()
     cstat(1, y, "Halve the denominator:", x_grid[3])
-    ccheck(3, y, "6", i_width, (config.double_join and 0 or 1), " [3/8][3/8] -> [3/4]")
+    ccheck(3, y, "6", i_width, (config.double_join and 0 or 1), " [3/8][3/8] → [3/4]")
     yd(25)
     chl(1, y, x_grid[5])
     yd(5)
@@ -176,33 +174,37 @@ function user_options()
     yd(17)
     cstat(1, y, "Consolidate time signatures:", x_grid[4])
     ccheck(3, y, "8", i_width, (config.composite_join and 0 or 1),
-        " [2/4][3/8] -> [7/8]\n (lose beaming groups)", 30)
+        " [2/4][3/8] → [7/8]\n (lose beaming groups)", 30)
     yd(17)
     cstat(2, y, "OR")
     yd(17)
     cstat(1, y, "Composite time signatures:", x_grid[3])
     ccheck(3, y, "7", i_width, (config.composite_join and 1 or 0),
-        " [2/4][3/8] -> [2/4+3/8]\n (keep beaming groups)", 30)
+        " [2/4][3/8] → [2/4+3/8]\n (keep beaming groups)", 30)
     yd(35)
     ccheck(1, y, "display_meter", x_grid[5] + 10, (config.display_meter and 1 or 0),
-        " Create \"display\" time signature when compositing\n [2/4][3/8] -> [2/4+3/8] displaying \"7/8\" )", 30)
+        " Create \"display\" time signature when compositing\n "
+        .. "[2/4][3/8] → [2/4+3/8] displaying \"7/8\" )", 30
+    )
     yd(36)
     chl(0, y, x_grid[3] + i_width)
     chl(0, y + 2, x_grid[3] + i_width)
     chl(0, y + 3, x_grid[3] + i_width)
     yd(12)
     cstat("0", y, "Preserve smart shapes within\n(Larger spans take longer)", x_grid[3], 30)
-    local popup = dlg:CreatePopup(x_grid[3] - 27, y - 1, "extend"):SetWidth(40):SetSelectedItem(config.shape_extend - 2)
+    local popup = dlg:CreatePopup(x_grid[3] - 27, y - 1, "shape_extend")
+        :SetWidth(40):SetSelectedItem(config.shape_extend - 2)
     for i = 2, 10 do
         popup:AddString(i)
     end
     cstat("206", y, "measure span")
     yd(38)
-    cstat("0", y, "ON COMPLETION:", i_width)
+    cstat("0", y, "ON COMPLETION:", i_width, nil, "div3")
     ccheck(6, y, "note_spacing", i_width, (config.note_spacing and 1 or 0), "Respace notes")
-    dlg:CreateButton(x_grid[5], y):SetText("?"):SetWidth(20)
+    dlg:CreateButton(x_grid[5], y, "q"):SetText("?"):SetWidth(20)
         :AddHandleCommand(function()
-            finenv.UI():AlertInfo(finaleplugin.Notes:gsub(" %s+", " "), "About " .. finaleplugin.ScriptGroupName)
+            utils.show_notes_dialog(dlg, "About " .. finaleplugin.ScriptGroupName)
+            refocus_document = true
         end)
     yd(18)
     ccheck(6, y, "rebeam", i_width + 40, (config.rebeam and 1 or 0), "Rebeam note groups")
@@ -211,29 +213,41 @@ function user_options()
 
     -- radio button action
     local function radio_change(id, check) -- for checkboxes "1" to "8"
-        local matching_id = (id % 2 == 0) and (id - 1) or (id + 1)
-        dlg:GetControl(tostring(matching_id)):SetCheck((check + 1) % 2) -- "ON" <-> "OFF"
+        local toggle = (id % 2 == 0) and (id - 1) or (id + 1)
+        dlg:GetControl(tostring(toggle)):SetCheck((check + 1) % 2) -- "ON" <-> "OFF"
     end
-    for id = 1, 8 do -- add to 8 buttons
-        dlg:GetControl(tostring(id)):AddHandleCommand(function(self) radio_change(id, self:GetCheck()) end)
+    for id = 1, 8 do -- add to HandleCommand to 8 buttons
+        dlg:GetControl(tostring(id))
+            :AddHandleCommand(function(self) radio_change(id, self:GetCheck()) end)
     end
     dlg:CreateOkButton():SetText("Save")
     dlg:CreateCancelButton()
     dialog_set_position(dlg)
     dlg:RegisterHandleOkButtonPressed(function(self)
-        for k, v in pairs({halve_numerator = "1", odd_more_first = "3", double_join = "5", composite_join = "7"}) do
+        for k, v in pairs{
+                halve_numerator = "1", odd_more_first = "3",
+                double_join =     "5", composite_join = "7"
+            } do
             config[k] = (self:GetControl(v):GetCheck() == 1)
         end
-        for _, v in ipairs ( {"display_meter", "note_spacing", "repaginate", "rebeam"} ) do
+        for _, v in ipairs{"display_meter", "note_spacing", "repaginate", "rebeam"} do
             config[v] = (self:GetControl(v):GetCheck() == 1)
         end
-        config.shape_extend = (self:GetControl("extend"):GetSelectedItem() + 2)
-        dialog_save_position(self) -- save window position and config choices
+        config.shape_extend = (self:GetControl("shape_extend"):GetSelectedItem() + 2)
+    end)
+    dlg:RegisterCloseWindow(function(self) dialog_save_position(self) end)
+    dlg:RegisterInitWindow(function()
+        local div1 = dlg:GetControl("div1")
+        local bold = div1:CreateFontInfo():SetBold(true)
+        div1:SetFont(bold)
+        dlg:GetControl("div2"):SetFont(bold)
+        dlg:GetControl("div3"):SetFont(bold)
+        dlg:GetControl("q"):SetFont(bold)
     end)
     return (dlg:ExecuteModal(nil) == finale.EXECMODAL_OK)
 end
 
-function repaginate()
+local function repaginate()
     local gen_prefs = finale.FCGeneralPrefs()
     gen_prefs:LoadFirst()
     local saved = {}
@@ -261,10 +275,9 @@ function repaginate()
 end
 
 function copy_measure_values(measure_1, measure_2)
-    local props_copy = {"PositioningNotesMode", "Barline", "SpaceAfter",
-        "SpaceBefore", "UseTimeSigForDisplay" }
-    for _, v in ipairs(props_copy) do
-        measure_2[v] = measure_1[v]
+    for _, v in ipairs({ "PositioningNotesMode", "Barline",
+        "SpaceAfter", "SpaceBefore", "UseTimeSigForDisplay" }) do
+            measure_2[v] = measure_1[v]
     end
     measure_1.Barline = finale.BARLINE_NORMAL
     measure_1.SpaceAfter = 0
@@ -272,7 +285,7 @@ function copy_measure_values(measure_1, measure_2)
     measure_2:Save()
 end
 
-function pad_or_truncate_cells(region, measure_num, measure_duration, check_measure)
+local function pad_or_truncate_cells(region, measure_num, measure_duration, check_measure)
     local cell_rgn = mixin.FCMMusicRegion()
     cell_rgn:SetRegion(region)
         :SetStartMeasure(measure_num):SetEndMeasure(measure_num) -- one measure wide
@@ -334,7 +347,7 @@ end
     }
 ]]
 
-function clear_composite(time_sig, top, bottom)
+local function clear_composite(time_sig, top, bottom)
     if time_sig.CompositeTop and top > 0 then
         time_sig:RemoveCompositeTop(top)
     end
@@ -343,7 +356,7 @@ function clear_composite(time_sig, top, bottom)
     end
 end
 
-function extract_composite_to_array(time_sig)
+local function extract_composite_to_array(time_sig)
     local comp_array = {}
     if time_sig.CompositeTop then
         comp_array.top = { comp = time_sig:CreateCompositeTop(), count = 0, groups = { } }
@@ -366,7 +379,7 @@ function extract_composite_to_array(time_sig)
     return comp_array
 end
 
-function flatten_comp_numerators(comp)
+local function flatten_comp_numerators(comp)
     local small_denom = finale.BREVE -- find smallest denominator in the composite
     for group = 1, #comp.bottom.groups do
         local dur = comp.bottom.groups[group]
@@ -384,7 +397,7 @@ function flatten_comp_numerators(comp)
     return total_top, small_denom
 end
 
-function make_display_meter(fc_measure, comp)
+local function make_display_meter(fc_measure, comp)
     if config.display_meter then -- only if requested
         fc_measure.UseTimeSigForDisplay = true
         local display_sig = fc_measure:GetTimeSignatureForDisplay()
@@ -394,7 +407,7 @@ function make_display_meter(fc_measure, comp)
     end
 end
 
-function new_composite_top(time_sig, group_array, first, last, from_element)
+local function new_composite_top(time_sig, group_array, first, last, from_element)
     if last == 0 then last = #group_array end
     local comp_top = finale.FCCompositeTimeSigTop()
     for g = first, last do
@@ -408,7 +421,7 @@ function new_composite_top(time_sig, group_array, first, last, from_element)
     time_sig:SaveNewCompositeTop(comp_top)
 end
 
-function new_composite_bottom(time_sig, group_array, first, last)
+local function new_composite_bottom(time_sig, group_array, first, last)
     if last == 0 then last = #group_array end
     local comp_bottom = finale.FCCompositeTimeSigBottom()
     for g = first, last do
@@ -420,13 +433,13 @@ function new_composite_bottom(time_sig, group_array, first, last)
     time_sig:SaveNewCompositeBottom(comp_bottom)
 end
 
-function measure_extend_count(measure_num)
+local function measure_extend_count(measure_num)
     local measures = finale.FCMeasures()
     measures:LoadAll()
     return math.max(measures.Count, (measure_num + config.shape_extend))
 end
 
-function shift_divided_measure_shapes(rgn, measure_num, new_duration)
+local function shift_divided_measure_shapes(rgn, measure_num, new_duration)
     local extend_rgn = mixin.FCMMusicRegion()
     extend_rgn:SetRegion(rgn)
         :SetStartMeasure(measure_num - config.shape_extend)
@@ -437,19 +450,19 @@ function shift_divided_measure_shapes(rgn, measure_num, new_duration)
             local seg = { L = shape:GetTerminateSegmentLeft(), R = shape:GetTerminateSegmentRight() }
             local m = { L = seg.L.Measure, R = seg.R.Measure }
             if m.L <= measure_num then -- only affect shapes that straddle the inserted measure
-                local re_save = false
+                local save_new = false
                 if m.R > measure_num then
                     seg.R.Measure = m.R + 1 -- crosses measure boundary
-                    re_save = true
+                    save_new = true
                 end
-                for _, i in ipairs( {"L", "R"} ) do
+                for _, i in ipairs{"L", "R"} do
                     if m[i] == measure_num and seg[i].MeasurePos >= new_duration then
                         seg[i].Measure = m[i] + 1
                         seg[i].MeasurePos = seg[i].MeasurePos - new_duration
-                        re_save = true
+                        save_new = true
                     end
                 end
-                if re_save then
+                if save_new then
                     local save_id = shape.ItemNo
                     shape:SaveNewEverything(nil, nil)
                     shape:Load(save_id) -- delete the original non-"fixed" version
@@ -460,23 +473,22 @@ function shift_divided_measure_shapes(rgn, measure_num, new_duration)
     end
 end
 
-function shift_divided_measure_expressions(measure_num, old_width, measure)
-    local dur = { measure[1]:GetDuration(), measure[2]:GetDuration() }
+local function shift_divided_measure_expressions(measure_num, old_width, dur_1, dur_2)
     local exps = finale.FCExpressions()
     exps:LoadAllForItem(measure_num)
     for exp in eachbackwards(exps) do
-        if exp.StaffGroupID > 0 then
+        if exp.StaffGroupID > 0 then -- has staff list
             local save_new = false
-            if exp.MeasurePos > 0 then -- beat-attached
-                if exp.MeasurePos >= dur[1] then
-                    exp.MeasurePos = exp.MeasurePos - dur[1]
+            if exp.MeasurePos > 0 then -- attached to beat
+                if exp.MeasurePos >= dur_1 then
+                    exp.MeasurePos = exp.MeasurePos - dur_1
                     save_new = true
                 end
             elseif exp.HorizontalPos > 0 then -- attached to start of measure
-                -- GUESSTIMATE of horizontal division between the divided measures
-                local divider = ( old_width * dur[1] / (dur[1] + dur[2]) ) + 20
+                -- GUESSTIMATE of horizontal division between the split measures
+                local divider = (old_width * dur_1 / (dur_1 + dur_2)) * 1.1
                 if exp.HorizontalPos > divider then
-                    exp.HorizontalPos = exp.HorizontalPos - divider
+                    exp.HorizontalPos = exp.HorizontalPos - math.floor(divider)
                     save_new = true
                 end
             end
@@ -491,7 +503,7 @@ function shift_divided_measure_expressions(measure_num, old_width, measure)
     end
 end
 
-function divide_measures(selection)
+local function divide_measures(selection)
     local pair_rgn = mixin.FCMMusicRegion()
     pair_rgn:SetRegion(selection):SetFullMeasureStack()
 
@@ -563,37 +575,37 @@ function divide_measures(selection)
         end
         measure[1]:Save()
         measure[2]:Save()
-        shift_divided_measure_shapes(pair_rgn, measure_num, measure[1]:GetDuration())
+        local dur_1 = measure[1]:GetDuration()
+        shift_divided_measure_shapes(pair_rgn, measure_num, dur_1)
         pair_rgn:SetEndMeasure(measure_num + 1):RebarMusic(finale.REBARSTOP_REGIONEND, config.rebeam, false)
-        shift_divided_measure_expressions(measure_num, old_width, measure)
+        shift_divided_measure_expressions(measure_num, old_width, dur_1, measure[2]:GetDuration())
     end
 end
 
-function compress_smart_shape_ends(rgn, measure_num, measure_duration)
+local function compress_smart_shape_ends(rgn, measure_num, measure_duration)
     local extend_rgn = mixin.FCMMusicRegion()
     extend_rgn:SetRegion(rgn)
         :SetStartMeasure(measure_num - config.shape_extend)
         :SetEndMeasure(measure_extend_count(measure_num + 2))
-
     for mark in loadallforregion(finale.FCSmartShapeMeasureMarks(), extend_rgn) do
         local shape = mark:CreateSmartShape()
         if shape and not shape.EntryBased then
-            local seg = { L = shape:GetTerminateSegmentLeft(), R = shape:GetTerminateSegmentRight() }
-            local m = { L = seg.L.Measure, R = seg.R.Measure }
-            if m.L == measure_num + 1 then
-                seg.L.Measure = m.L - 1
-                seg.L.MeasurePos = seg.L.MeasurePos + measure_duration
+            local seg_L, seg_R = shape:GetTerminateSegmentLeft(), shape:GetTerminateSegmentRight()
+            local m_L,   m_R   = seg_L.Measure, seg_R.Measure
+            if m_L == measure_num + 1 then
+                seg_L.Measure = m_L - 1
+                seg_L.MeasurePos = seg_L.MeasurePos + measure_duration
             end
-            if m.R == measure_num + 1 then
-                seg.R.Measure = m.R - 1
-                seg.R.MeasurePos = seg.R.MeasurePos + measure_duration
+            if m_R == measure_num + 1 then
+                seg_R.Measure = m_R - 1
+                seg_R.MeasurePos = seg_R.MeasurePos + measure_duration
             end
             shape:Save()
         end
     end
 end
 
-function save_shapes_for_joining(rgn, measure_num)
+local function save_shapes_for_joining(rgn, measure_num)
     local shapes = {}
     local extend_rgn = mixin.FCMMusicRegion()
     extend_rgn:SetRegion(rgn)
@@ -603,34 +615,33 @@ function save_shapes_for_joining(rgn, measure_num)
     for mark in loadallforregion(finale.FCSmartShapeMeasureMarks(), extend_rgn) do
         local shape = mark:CreateSmartShape()
         if shape and not shape.EntryBased then
-            local seg = { L = shape:GetTerminateSegmentLeft(), R = shape:GetTerminateSegmentRight() }
-            local m = { L = seg.L.Measure, R = seg.R.Measure }
-            if m.L <= measure_num + 2 and m.R > measure_num then
-                table.insert(shapes, { shape.ItemNo, m.L, m.R, seg.L.MeasurePos, seg.R.MeasurePos })
+            local seg_L, seg_R = shape:GetTerminateSegmentLeft(), shape:GetTerminateSegmentRight()
+            local m_L,   m_R   = seg_L.Measure, seg_R.Measure
+            if m_L <= measure_num + 2 and m_R > measure_num then
+                table.insert(shapes, { shape.ItemNo, m_L, m_R, seg_L.MeasurePos, seg_R.MeasurePos })
             end
         end
     end
     return shapes
 end
 
-function restore_joined_shapes(shapes, measure_num, dur)
+local function restore_joined_shapes(shapes, measure_num, dur)
     local shape = finale.FCSmartShape()
     for _, v in ipairs(shapes) do
         shape:Load(v[1])
-        local l_seg = shape:GetTerminateSegmentLeft()
-        local r_seg = shape:GetTerminateSegmentRight()
-        if v[2] == measure_num + 1 then l_seg.MeasurePos = v[4] + dur end
-        if v[2] >= measure_num + 1 then l_seg.Measure = v[2] - 1
-        else l_seg.Measure = v[2] end
-
-        r_seg.Measure = v[3] - 1
+        local seg_L = shape:GetTerminateSegmentLeft()
+        if v[2] == measure_num + 1 then seg_L.MeasurePos = v[4] + dur end
+        if v[2] >= measure_num + 1 then seg_L.Measure = v[2] - 1
+        else seg_L.Measure = v[2]
+        end
+        shape:GetTerminateSegmentRight().Measure = v[3] - 1
         shape:SaveNewEverything(nil, nil)
         shape:Load(v[1]) -- delete the original non-"fixed" shape
         shape:DeleteData()
     end
 end
 
-function shift_joined_expressions(measure_num, m_offset, m_width)
+local function shift_joined_expressions(measure_num, m_offset, m_width)
     local exps = finale.FCExpressions()
     exps:LoadAllForItem(measure_num + 1) -- the "joining" second measure
     for exp in eachbackwards(exps) do
@@ -643,11 +654,11 @@ function shift_joined_expressions(measure_num, m_offset, m_width)
     end
 end
 
-function join_measures(selection)
+local function join_measures(selection)
     if (selection.EndMeasure - selection.StartMeasure) % 2 ~= 1 then
-        local msg = "Please select an EVEN number of measures for the \"Measure Span Join\" action"
+        local msg = "Please select an EVEN number\nof measures for the\n\"Measure Span Join\" action"
         finenv.UI():AlertError(msg, "User Error")
-        return
+        return false
     end
     local join_rgn = mixin.FCMMusicRegion()
     join_rgn:SetRegion(selection)
@@ -732,22 +743,31 @@ function join_measures(selection)
         join_rgn:SetStartMeasure(measure_num):SetEndMeasure(measure_num)
         restore_joined_shapes(saved_shapes, measure_num, measure_dur[1])
     end
+    return true
 end
 
-function measure_span()
-    local mod_down = finenv.QueryInvokedModifierKeys and
-        (finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT)
-         or finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_SHIFT)
-        )
+local function refocus() -- has utils.show_notes_dialog been invoked?
+    if refocus_document then finenv.UI():ActivateDocumentWindow() end
+end
+
+local function measure_span()
+    configuration.get_user_settings(script_name, config, true)
+    local qim = finenv.QueryInvokedModifierKeys
+    local mod_down = qim and (qim(finale.CMDMODKEY_ALT) or qim(finale.CMDMODKEY_SHIFT))
     if mod_down or (span_action == "options") then
         local ok = user_options()
-        if not ok or (span_action == "options") then return end
+        if not ok or (span_action == "options") then refocus() return end -- user cancelled
     end
     local selection = mixin.FCMMusicRegion()
-    selection:SetRegion(finenv.Region()):SetStartMeasurePosLeft():SetEndMeasurePosRight()
+    selection:SetRegion(finenv.Region())
+        :SetStartMeasurePosLeft():SetEndMeasurePosRight()
         :SetFullMeasureStack()
     if selection:IsEmpty() then
-        finenv.UI():AlertError("Please select some music before running this script", "Error")
+        finenv.UI():AlertError(
+            "Please select some music before running this script",
+            finaleplugin.ScriptGroupName .. "Error"
+        )
+        refocus()
         return
     end
 
@@ -756,8 +776,9 @@ function measure_span()
         divide_measures(selection) -- adds extra measures
         end_m = end_m + (end_m - selection.StartMeasure + 1)
     elseif span_action == "join" then
-        join_measures(selection) -- removes joined measures
-        end_m = end_m - ((end_m - selection.StartMeasure + 1) / 2)
+        if join_measures(selection) then -- removes joined measures
+            end_m = end_m - ((end_m - selection.StartMeasure + 1) / 2)
+        end
     end
     selection.EndMeasure = end_m
     if config.note_spacing then
@@ -767,6 +788,7 @@ function measure_span()
     if config.repaginate then repaginate() end
     -- restore original selection with new end measure
     selection:SetRegion(finenv.Region()):SetEndMeasure(end_m):SetInDocument()
+    refocus()
 end
 
 measure_span()

--- a/src/tuplet_chooser.lua
+++ b/src/tuplet_chooser.lua
@@ -3,8 +3,8 @@ function plugindef()
     finaleplugin.Author = "Carl Vine"
     finaleplugin.AuthorURL = "https://carlvine.com/lua/"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "v0.70.1"
-    finaleplugin.Date = "2023/11/15"
+    finaleplugin.Version = "0.74"
+    finaleplugin.Date = "2024/04/17"
     finaleplugin.AdditionalMenuOptions = [[
         Tuplet Chooser Repeat
     ]]
@@ -17,106 +17,72 @@ function plugindef()
     finaleplugin.AdditionalPrefixes = [[
         no_dialog = true
     ]]
-    finaleplugin.MinJWLuaVersion = 0.62
+    finaleplugin.MinJWLuaVersion = 0.70
     finaleplugin.ScriptGroupName = "Tuplet Chooser"
     finaleplugin.ScriptGroupDescription = "Change the condition of tuplets in the current selection by layer"
     finaleplugin.Notes = [[
-        This script changes the tuplets in the current selection in 18 ways. 
-        It shows an ordered list of options, 
-        each line starting with a configurable "hotkey". 
-        Activate the script, type the hotkey and hit [Enter] or [Return]. 
-        The action may also be limited by layer.
+        This script changes tuplets in the current selection in 
+        24 ways on all or nominated layers. 
+        It provides an ordered list of options,
+        each line starting with a configurable _hotkey_. 
+        Start the script, type the _hotkey_ and hit [Return]. 
 
-        To repeat the same tuplet change as last time without a confirmation dialog, 
-        hold down the SHIFT key when starting the script 
-        or select the "Tuplet Chooser Repeat" menu.
-
-        The layer number is "clamped" to a single character so to change 
-        layer just type a new number - 'delete' key not needed.
+        To repeat the same tuplet change as last time without a 
+        confirmation dialog, select the __Tuplet Chooser Repeat__ menu 
+        or hold down [Shift] when starting the script. 
 	]]
-    return  "Tuplet Chooser...", "Tuplet Chooser",
+    return  "Tuplet Chooser...",
+            "Tuplet Chooser",
             "Change the condition of tuplets in the current selection by layer"
 end
 
-local info_notes = [[
-This script changes the tuplets in the current selection in 18 ways. 
-It shows an ordered list of options, 
-each line starting with a configurable "hotkey". 
-Activate the script, type the hotkey and hit [Enter] or [Return]. 
-The action may also be limited by layer.  
-]] .. "\n" .. [[
-To repeat the same tuplet change as last time without a confirmation dialog, 
-hold down the SHIFT key when starting the script 
-or select the "Tuplet Chooser Repeat" menu.  
-]] .. "\n" .. [[
-The layer number is "clamped" to a single character so to change 
-layer just type a new number - 'delete' key not needed.
-]]
-
 no_dialog = no_dialog or false
-local dialog_options = { -- key, text description (ordered)
-    { "avoid", "Avoid Staff" },
-    { "not_avoid", "Don't Avoid Staff" },
-    { "flat", "Flat" },
-    { "not_flat", "Not Flat" },
-    { "flip", "Flip" },
-    { "invisible", "Invisible" },
-    { "visible", "Visible" },
-    { "TUPLETBRACKET_ALWAYS",       "Bracket: Always" },
-    { "TUPLETBRACKET_NEVERBEAMEDONBEAMSIDE", "Bracket: Opp. Beamed Side" },
-    { "TUPLETBRACKET_UNBEAMEDONLY", "Bracket: Unbeamed Only" },
-    { "TUPLETPLACEMENT_ABOVE", "Place: Above" },
-    { "TUPLETPLACEMENT_BELOW", "Place: Below" },
-    { "TUPLETPLACEMENT_MANUAL", "Place: Manual" },
-    { "TUPLETPLACEMENT_NOTESIDE", "Place: Note Side" },
-    { "TUPLETPLACEMENT_STEMSIDE", "Place: Stem Side" },
-    { "TUPLETSHAPE_NONE",     "Shape: None" },
-    { "TUPLETSHAPE_BRACKET",  "Shape: Bracket" },
-    { "TUPLETSHAPE_SLUR",     "Shape: Slur" },
-    { "TUPLETNUMBER_NONE",    "Number: None" },
-    { "TUPLETNUMBER_REGULAR", "Number: Regular" },
-    { "TUPLETNUMBER_RATIO",   "Number: Ratio" },
-    { "TUPLETNUMBER_RATIOANDNOTE",      "Number: Ratio+Note" },
-    { "TUPLETNUMBER_RATIOANDNOTE_BOTH", "Number: Ratio+Note Both" },
-    { "reset", "Reset (Default Preferences)" },
+
+local dialog_options = { -- NAME key; HOTKEY; text description (ordered)
+    { "avoid",                      "A", "Avoid Staff" },
+    { "not_avoid",                  "D", "Don't Avoid Staff" },
+    { "flat",                       "F", "Flat" },
+    { "not_flat",                   "N", "Not Flat" },
+    { "flip",                       "X", "Flip" },
+    { "invisible",                  "I", "Invisible" },
+    { "visible",                    "V", "Visible" },
+    { "TUPLETBRACKET_ALWAYS",       "K", "Bracket: Always" },
+    { "TUPLETBRACKET_NEVERBEAMEDONBEAMSIDE", "O", "Bracket: Opp. Beamed Side" },
+    { "TUPLETBRACKET_UNBEAMEDONLY", "U", "Bracket: Unbeamed Only" },
+    { "TUPLETPLACEMENT_ABOVE",      "Y", "Place: Above" },
+    { "TUPLETPLACEMENT_BELOW",      "B", "Place: Below" },
+    { "TUPLETPLACEMENT_MANUAL",     "H", "Place: Manual" },
+    { "TUPLETPLACEMENT_NOTESIDE",   "J", "Place: Note Side" },
+    { "TUPLETPLACEMENT_STEMSIDE",   "G", "Place: Stem Side" },
+    { "TUPLETSHAPE_NONE",           "0", "Shape: None" },
+    { "TUPLETSHAPE_BRACKET",        "1", "Shape: Bracket" },
+    { "TUPLETSHAPE_SLUR",           "2", "Shape: Slur" },
+    { "TUPLETNUMBER_NONE",          "Q", "Number: None" },
+    { "TUPLETNUMBER_REGULAR",       "W", "Number: Regular" },
+    { "TUPLETNUMBER_RATIO",         "E", "Number: Ratio" },
+    { "TUPLETNUMBER_RATIOANDNOTE",  "R", "Number: Ratio+Note" },
+    { "TUPLETNUMBER_RATIOANDNOTE_BOTH", "T", "Number: Ratio+Note Both" },
+    { "reset",                      "Z", "Reset (Default Preferences)" }
 }
 
-local config = { -- keystroke assignments and window position
-    avoid =  "A",
-    not_avoid = "D",
-    flat = "F",
-    not_flat = "N",
-    flip = "X",
-    invisible = "I",
-    visible = "V",
-    TUPLETPLACEMENT_ABOVE = "Y",
-    TUPLETPLACEMENT_BELOW = "B",
-    TUPLETPLACEMENT_MANUAL = "H",
-    TUPLETPLACEMENT_STEMSIDE = "G",
-    TUPLETPLACEMENT_NOTESIDE = "J",
-    TUPLETBRACKET_UNBEAMEDONLY = "U",
-    TUPLETBRACKET_ALWAYS = "K",
-    TUPLETBRACKET_NEVERBEAMEDONBEAMSIDE = "O",
-    TUPLETSHAPE_NONE = "0",
-    TUPLETSHAPE_BRACKET = "1",
-    TUPLETSHAPE_SLUR = "2",
-    TUPLETNUMBER_NONE = "Q",
-    TUPLETNUMBER_REGULAR = "W",
-    TUPLETNUMBER_RATIO = "E",
-    TUPLETNUMBER_RATIOANDNOTE = "R",
-    TUPLETNUMBER_RATIOANDNOTE_BOTH = "T",
-    reset = "R",
+local config = { -- user CONFIG
     layer_num = 0,
     ignore_duplicates = 0,
     last_selected = 0, -- last selected menu item number (0-based)
     window_pos_x = false,
     window_pos_y = false,
 }
+for _, v in ipairs(dialog_options) do -- add HOTKEYS to CONFIG
+    config[v[1]] = v[2] -- map NAME key onto HOTKEY
+end
 
 local configuration = require("library.configuration")
 local mixin = require("library.mixin")
 local layer = require("library.layer")
-local script_name = "tuplet_chooser"
+local utils = require("library.utils")
+local library = require("library.general_library")
+local script_name = library.calc_script_name()
+local refocus_document = false -- set to true if utils.show_notes_dialog is used
 
 local function dialog_set_position(dialog)
     if config.window_pos_x and config.window_pos_y then
@@ -133,35 +99,36 @@ local function dialog_save_position(dialog)
     configuration.save_user_settings(script_name, config)
 end
 
-local function change_tuplet_state(state)
+local function change_tuplet_state()
+    local state = dialog_options[config.last_selected + 1][1]
     for entry in eachentry(finenv.Region(), config.layer_num) do
         if entry:IsStartOfTuplet() then
             for tuplet in eachbackwards(entry:CreateTuplets()) do
-                if state == "visible" or state == "invisible" then
+                if state:find("visible") then
                     tuplet.Visible = (state == "visible")
-                elseif state == "flat" or state == "not_flat" then
+                elseif state:find("flat") then
                     tuplet.AlwaysFlat = (state == "flat")
-                elseif state == "avoid" or state == "not_avoid" then
+                elseif state:find("avoid") then
                     tuplet.AvoidStaff = (state == "avoid")
                 elseif state == "reset" then
                     tuplet:PrefsReset(true)
                 elseif state == "flip" then
                     local placement = tuplet.PlacementMode
-                    for _, v in ipairs({
+                    for _, v in ipairs{
                             {finale.TUPLETPLACEMENT_STEMSIDE, finale.TUPLETPLACEMENT_NOTESIDE},
                             {finale.TUPLETPLACEMENT_ABOVE,    finale.TUPLETPLACEMENT_BELOW}
-                        }) do
-                        if     placement == v[1] then tuplet.PlacementMode = v[2]
-                        elseif placement == v[2] then tuplet.PlacementMode = v[1]
+                        } do
+                        if     placement == v[1] then tuplet.PlacementMode = v[2] break
+                        elseif placement == v[2] then tuplet.PlacementMode = v[1] break
                         end
                     end
-                elseif state:find("TUPLETPLACEMENT") then
-                    tuplet.PlacementMode = finale[state]
-                elseif state:find("TUPLETBRACKET") then
+                elseif state:find("BRACKET_") then
                     tuplet.BracketMode = finale[state]
-                elseif state:find("TUPLETSHAPE") then
+                elseif state:find("PLACEMENT_") then
+                    tuplet.PlacementMode = finale[state]
+                elseif state:find("SHAPE_") then
                     tuplet.ShapeStyle = finale[state]
-                elseif state:find("TUPLETNUMBER") then
+                elseif state:find("NUMBER_") then
                     tuplet.NumberStyle = finale[state]
                 end
                 tuplet:Save()
@@ -170,7 +137,7 @@ local function change_tuplet_state(state)
     end
 end
 
-local function reassign_keystrokes(index)
+local function reassign_keystrokes(parent, index)
     local y_step, x_wide = 17, 180
     local offset = finenv.UI():IsOnMac() and 3 or 0
     local is_duplicate, errors = false, {}
@@ -179,10 +146,10 @@ local function reassign_keystrokes(index)
     for _, v in ipairs(dialog_options) do -- add all options with keycodes
         dialog:CreateEdit(0, y - offset, v[1]):SetText(config[v[1]]):SetWidth(20)
             :AddHandleCommand(function(self)
-                local str = self:GetText():upper()
-                self:SetText(str:sub(-1)):SetKeyboardFocus()
+                local str = self:GetText():sub(-1):upper()
+                self:SetText(str):SetKeyboardFocus()
             end)
-        dialog:CreateStatic(25, y):SetText(v[2]):SetWidth(x_wide)
+        dialog:CreateStatic(25, y):SetText(v[3]):SetWidth(x_wide)
         y = y + y_step
     end
     y = y + 7
@@ -196,7 +163,7 @@ local function reassign_keystrokes(index)
     dialog_set_position(dialog)
     dialog:RegisterHandleOkButtonPressed(function(self)
         local assigned = {}
-        for i, v in ipairs(dialog_options) do
+        for _, v in ipairs(dialog_options) do
             local key = self:GetControl(v[1]):GetText()
             if key == "" then key = "?" end -- not null
             config[v[1]] = key -- save for another possible run-through
@@ -205,26 +172,27 @@ local function reassign_keystrokes(index)
                 if assigned[key] then -- previously assigned
                     is_duplicate = true
                     if not errors[key] then errors[key] = { assigned[key] } end
-                    table.insert(errors[key], i)
+                    table.insert(errors[key], v[3])
                 else
-                    assigned[key] = i -- flag key assigned
+                    assigned[key] = v[3] -- flag key assigned
                 end
             end
         end
         if is_duplicate then -- list reassignment duplications
             local msg = ""
             for k, v in pairs(errors) do
+                if msg ~= "" then msg = msg .. "\n\n" end
                 msg = msg .. "Key \"" .. k .. "\" is assigned to: "
                 for i, w in ipairs(v) do
                     if i > 1 then msg = msg .. " and " end
-                    msg = msg .. "\"" .. dialog_options[w][2] .. "\""
+                    msg = msg .. "\"" .. w .. "\""
                 end
-                msg = msg .. "\n\n"
             end
-            finenv.UI():AlertError(msg, "Duplicate Key Assignment")
+            dialog:CreateChildUI():AlertError(msg, "Duplicate Key Assignment")
         end
     end)
-    local ok = (dialog:ExecuteModal(nil) == finale.EXECMODAL_OK)
+    local ok = (dialog:ExecuteModal(parent) == finale.EXECMODAL_OK)
+    refocus_document = true
     return ok, is_duplicate
 end
 
@@ -232,64 +200,71 @@ local function user_chooses()
     local max = layer.max_layers()
     local offset = finenv.UI():IsOnMac() and 3 or 0
     local y_step = 17
-    local box_wide = 220
+    local box_wide = 200
     local box_high = (#dialog_options * y_step) + 4
-    info_notes = info_notes:gsub("  \n",  "\n"):gsub(" %s+", " "):gsub("\n ", "\n")
+    local dialog = mixin.FCXCustomLuaWindow():SetTitle(finaleplugin.ScriptGroupName)
     local function show_info()
-        finenv.UI():AlertInfo(info_notes, "About " .. finaleplugin.ScriptGroupName)
+        utils.show_notes_dialog(dialog, "About " .. finaleplugin.ScriptGroupName, 400, 140)
+        refocus_document = true
     end
-    local dialog = mixin.FCXCustomLuaWindow():SetTitle(plugindef())
     dialog:CreateStatic(0, 0):SetText("Change Tuplets To:"):SetWidth(box_wide)
-    dialog:CreateButton(box_wide - 20, 0):SetText("?"):SetWidth(20)
+    dialog:CreateButton(box_wide - 20, 0, "q"):SetText("?"):SetWidth(20)
         :AddHandleCommand(function() show_info() end)
     local key_list = dialog:CreateListBox(0, 22):SetWidth(box_wide):SetHeight(box_high)
-
+        -- local functions
         local function fill_key_list()
             local join = finenv.UI():IsOnMac() and "\t" or ": "
             key_list:Clear()
             for _, option in ipairs(dialog_options) do -- add options with keycodes
-                key_list:AddString(config[option[1]] .. join .. option[2])
+                key_list:AddString(config[option[1]] .. join .. option[3])
             end
             key_list:SetSelectedItem(config.last_selected or 0)
         end
         local function change_keys()
             local ok, is_duplicate = true, true
             while ok and is_duplicate do -- wait for good choice in reassign()
-                ok, is_duplicate = reassign_keystrokes(key_list:GetSelectedItem() + 1)
+                ok, is_duplicate = reassign_keystrokes(dialog, key_list:GetSelectedItem() + 1)
             end
-            if ok then fill_key_list() end
+            if ok then
+                fill_key_list()
+            else -- reinstall hotkeys from user config
+                configuration.get_user_settings(script_name, config)
+            end
         end
 
     fill_key_list()
     local x_off = box_wide / 4
-    local y = box_high + 32
-    dialog:CreateButton(x_off, y):SetText("Reassign Hotkeys")
+    local y = box_high + 29
+    dialog:CreateButton(x_off, y):SetText("Change Hotkeys")
         :AddHandleCommand(function() change_keys() end):SetWidth(x_off * 2)
-    y = y + 25
-    dialog:CreateStatic(50, y):SetWidth(x_off * 2):SetText("Layer 1-" .. max .. ":")
+    y = y + 22
+    dialog:CreateStatic(42, y):SetWidth(x_off * 2):SetText("Layer 1-" .. max .. ":")
     local save_layer = config.layer_num
     local layer_num = dialog:CreateEdit(x_off * 2, y - offset)
-        :SetWidth(30):SetText(save_layer)
+        :SetWidth(20):SetText(save_layer)
         :AddHandleCommand(function(self) -- key command replacements
             local val = self:GetText():lower()
-            if val:find("[^0-4]") then
+            if val:find("[^0-" .. max .. "]") then
                 if val:find("[?q]") then show_info()
                 elseif val:find("r") then change_keys()
                 end
-                self:SetText(save_layer):SetKeyboardFocus()
             elseif val ~= "" then
                 val = val:sub(-1)
-                self:SetText(val)
-                save_layer = val
+                save_layer = val:sub(-1)
             end
+            self:SetText(save_layer):SetKeyboardFocus()
         end)
 
-    dialog:CreateStatic(x_off * 2 + 34, y):SetWidth(80):SetText("(0 = all)")
+    dialog:CreateStatic(x_off * 2 + 20, y):SetWidth(80):SetText("(0 = all)")
     dialog:CreateOkButton():SetText("Select")
     dialog:CreateCancelButton()
     dialog_set_position(dialog)
-    dialog:RegisterInitWindow(function() key_list:SetKeyboardFocus() end)
-    dialog:RegisterHandleOkButtonPressed(function(_self)
+    dialog:RegisterInitWindow(function()
+        key_list:SetKeyboardFocus()
+        local q = dialog:GetControl("q")
+        q:SetFont(q:CreateFontInfo():SetBold(true))
+    end)
+    dialog:RegisterHandleOkButtonPressed(function()
         config.last_selected = key_list:GetSelectedItem() -- save list choice (0-based)
         config.layer_num = layer_num:GetInteger()
     end)
@@ -299,14 +274,13 @@ end
 
 local function tuplets_change()
     configuration.get_user_settings(script_name, config, true)
-    local qimk = finenv.QueryInvokedModifierKeys
-    local mod_key = qimk and (qimk(finale.CMDMODKEY_ALT) or qimk(finale.CMDMODKEY_SHIFT))
+    local qim = finenv.QueryInvokedModifierKeys
+    local mod_key = qim and (qim(finale.CMDMODKEY_ALT) or qim(finale.CMDMODKEY_SHIFT))
 
     if no_dialog or mod_key or user_chooses() then
-        local state = dialog_options[config.last_selected + 1][1]
-        change_tuplet_state(state)
+        change_tuplet_state()
     end
-    finenv.UI():ActivateDocumentWindow()
+    if refocus_document then finenv.UI():ActivateDocumentWindow() end
 end
 
 tuplets_change()


### PR DESCRIPTION
`finaleplugin.Notes` in these 4 scripts has been updated for better __Markdown__ rendering and __RTF__ display using `utils.show_notes_dialog()`. If they use config.get_user_settings() then derive `script_name` from `general_library` instead of literal string. Some other code amendments here and there.