### PR TITLE
Fix notes

### DIFF
--- a/src/measure_insert_and_shift_regions.lua
+++ b/src/measure_insert_and_shift_regions.lua
@@ -13,8 +13,8 @@ function plugindef()
         v1.0.1      First release
     ]]
     finaleplugin.Notes = [[
-        This script will insert or delete one or more measures; it will then adjust the start and
-        end measures of the current and subsequent measure number regions. 
+        This script will insert or delete one or more measures; it will then adjust the start
+        and end measures of the current and subsequent measure number regions. 
 
         It can also optionally:
 


### PR DESCRIPTION
@rpatters1 There's a bug in the bundler that affects Notes which have the word 'end' at the start of a line -- the bundler thinks it's the end of `plugindef`, even if there's space before the word.

I don't have time to fix the bug right now but will look into it soon; this just fixes the notes in one of my scripts so that it bundles properly.