### PR TITLE
Improve inject() in bundler

### DIFF
--- a/.github/actions/bundle/dist/index.js
+++ b/.github/actions/bundle/dist/index.js
@@ -6975,17 +6975,22 @@ const injectExtras = (name, contents) => {
     return parts.prolog + parts.plugindef + parts.epilog;
 };
 exports.injectExtras = injectExtras;
-const inject = (contents, injection) => {
+const inject = (plugindef, injection) => {
     if (injection) {
-        const returnRegex = /^(\s*)return/gm;
-        const endRegex = /^(\s*)*end/gm;
-        const returnMatch = returnRegex.exec(contents);
-        const endMatch = endRegex.exec(contents);
-        const index = Math.min(returnMatch ? returnMatch.index : Infinity, endMatch ? endMatch.index : Infinity);
-        return contents.slice(0, index) + injection + '\n' + contents.slice(index);
+        const getLastIndex = (regex) => {
+            let match, result = Infinity;
+            while ((match = regex.exec(plugindef))) {
+                result = match.index;
+            }
+            return result;
+        };
+        const endIndex = getLastIndex(/^(\s*)end(\s*)$/gm);
+        const returnIndex = getLastIndex(/^(\s*)return/gm);
+        const index = Math.min(endIndex, returnIndex);
+        return plugindef.slice(0, index) + injection + '\n' + plugindef.slice(index);
     }
     else {
-        return contents;
+        return plugindef;
     }
 };
 const getHashURL = (name) => {

--- a/.github/actions/bundle/src/inject-extras.test.ts
+++ b/.github/actions/bundle/src/inject-extras.test.ts
@@ -347,6 +347,56 @@ return true
         expect(result).toEqual(expected);
     });
 
+    it('should find the last occurrence of end', () => {
+        const name = 'test.lua';
+        const contents = `
+function plugindef()
+    finaleplugin.Foo = [[
+        end
+    ]]
+end
+`;
+
+        const expected = `
+function plugindef()
+    finaleplugin.Foo = [[
+        end
+    ]]
+    finaleplugin.HashURL = "https://raw.githubusercontent.com/finale-lua/lua-scripts/master/hash/test.hash"
+end
+`;
+
+        const result = injectExtras(name, contents);
+        expect(result).toEqual(expected);
+    });
+
+
+    it('should find the last occurrence of return', () => {
+        const name = 'test.lua';
+        const contents = `
+function plugindef()
+    finaleplugin.Foo = [[
+        return
+    ]]
+    return "Foo"
+end
+`;
+
+        const expected = `
+function plugindef()
+    finaleplugin.Foo = [[
+        return
+    ]]
+    finaleplugin.HashURL = "https://raw.githubusercontent.com/finale-lua/lua-scripts/master/hash/test.hash"
+    return "Foo"
+end
+`;
+
+        const result = injectExtras(name, contents);
+        expect(result).toEqual(expected);
+    });
+
+
     it('should return the unaltered contents if the search criteria is not found', () => {
         const name = 'test.lua';
         const contents = `

--- a/.github/actions/bundle/src/inject-extras.ts
+++ b/.github/actions/bundle/src/inject-extras.ts
@@ -15,21 +15,23 @@ export const injectExtras = (name: string, contents: string): string => {
     return parts.prolog + parts.plugindef + parts.epilog;
 }
 
-const inject = (contents: string, injection: string): string => {
+const inject = (plugindef: string, injection: string): string => {    
     if (injection) {
-        const returnRegex = /^(\s*)return/gm;
-        const endRegex = /^(\s*)*end/gm;
+        const getLastIndex = (regex: RegExp): number => {
+            let match, result = Infinity;
+            while ((match = regex.exec(plugindef))) {
+                result = match.index;
+            }
+            return result;
+        }
 
-        const returnMatch = returnRegex.exec(contents);
-        const endMatch = endRegex.exec(contents);
-
-        const index = Math.min(
-            returnMatch ? returnMatch.index : Infinity,
-            endMatch ? endMatch.index : Infinity
-        );
-        return contents.slice(0, index) + injection + '\n' + contents.slice(index);
+        const endIndex = getLastIndex(/^(\s*)end(\s*)$/gm);
+        const returnIndex = getLastIndex(/^(\s*)return/gm);        
+        
+        const index = Math.min(endIndex, returnIndex);
+        return plugindef.slice(0, index) + injection + '\n' + plugindef.slice(index);
     } else {
-        return contents;
+        return plugindef;
     }
 }
 


### PR DESCRIPTION
@rpatters1 Not sure if you wanted to review this.

The `inject()` function in the bunder, which inserts `HashURL` and `RTFNotes`, was assuming that there would only be one line in `plugindef()` that starts with `return` and one line that starts with `end`. This is not necessarily true, since a line of text in `Notes`, for example, could start with either of these. (And the `Notes` in the script I recently added did!)

This PR changes `inject()` to get the last matching token. There's still an edge case here if `plugindef()` does not include a `return` statement (since it's not technically required) but does have a line starting with `return` in `Notes`. But since this repo seems to have an unofficial requirement for a proper `plugindef()` function with a `return`, I'm not worried about this.