### PR TITLE
Minor tweaks

### DIFF
--- a/src/lyrics_openai_hyphenation.lua
+++ b/src/lyrics_openai_hyphenation.lua
@@ -53,7 +53,7 @@ local https = osutils.internet
 
 local config =
 {
-    api_model = "gpt-4",
+    api_model = "gpt-4o",
     temperature = 0.2, -- fairly deterministic
     add_hyphens_prompt = [[
 Hyphenate the following text, delimiting words with spaces and syllables with hyphens.

--- a/src/playback_unmute_all_staves.lua
+++ b/src/playback_unmute_all_staves.lua
@@ -1,18 +1,23 @@
 function plugindef()
-    finaleplugin.RequireSelection = true
+    finaleplugin.RequireSelection = false
     finaleplugin.Author = "Nick Mazuk"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.3"
-    finaleplugin.Date = "March 16, 2023"
+    finaleplugin.Version = "1.0.4"
+    finaleplugin.Date = "June 12, 2024"
     finaleplugin.CategoryTags = "Playback"
     finaleplugin.AuthorURL = "https://nickmazuk.com"
     finaleplugin.Notes = [[
-        Run this script and all staves will be unmuted.
+        Run this script and all staves will be unmuted and all solos will be cleared.
     ]]
     return "Unmute all staves", "Unmute all staves", "Unmutes all staves"
 end
 
 local layer = require("library.layer")
+
+function set_layer_playback_data(layer_playback_data)
+    layer_playback_data.Play = true
+    layer_playback_data.Solo = false
+end
 
 function playback_unmute_all_staves()
     local full_doc_region = finale.FCMusicRegion()
@@ -24,10 +29,10 @@ function playback_unmute_all_staves()
         staff:Load(staff_number)
         local playback_data = staff:CreateInstrumentPlaybackData()
         for this_layer = 1, layer.max_layers() do
-            playback_data:GetNoteLayerData(this_layer).Play = true
+            set_layer_playback_data(playback_data:GetNoteLayerData(this_layer))
         end
-        playback_data:GetChordLayerData().Play = true
-        playback_data:GetMidiExpressionLayerData().Play = true
+        set_layer_playback_data(playback_data:GetChordLayerData())
+        set_layer_playback_data(playback_data:GetMidiExpressionLayerData())
         playback_data:Save()
     end
 end


### PR DESCRIPTION
- modified `playback_unmute_all.lua` to reset solos as well as mute settings. Otherwise some tracks could stay muted if solos were set.
- Update `lyrics_openai_hyphenation.lua` to default to latest ChatGPT model (`gpt-4o`).
