### PR TITLE
more complete articulation reset

### DIFF
--- a/src/articulation_reset_positioning.lua
+++ b/src/articulation_reset_positioning.lua
@@ -1,8 +1,8 @@
 function plugindef()
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.1"
-    finaleplugin.Date = "February 28, 2020"
+    finaleplugin.Version = "1.1"
+    finaleplugin.Date = "July 29, 2024"
     finaleplugin.CategoryTags = "Articulation"
     finaleplugin.MinFinaleVersionRaw = 0x1a000000
     finaleplugin.MinJWLuaVersion = 0.58
@@ -16,6 +16,8 @@ logic to manage the stacking context.
     return "Reset Articulation Positions", "Reset Articulation Positions", "Resets the position of all selected articulations."
 end
 
+local articulation = require("library/articulation")
+
 -- Before Finale 26, the automatic positioning of articulations was calculated by Finale and stored as the default offset
 -- values of the assignment. Starting with Finale 26, the automatic positioning of articulations is inherent in the
 -- coded behavior of Finale. The assignment only contains offsets from the default position. Therefore, resetting
@@ -27,10 +29,9 @@ end
 function articulation_reset_positioning()
     for note_entry in eachentry(finenv.Region()) do
         local articulations = note_entry:CreateArticulations()
-        for articulation in each(articulations) do
-            local artic_def = articulation:CreateArticulationDef()
-            articulation:ResetPos(artic_def)
-            articulation:Save()
+        for artic_assign in each(articulations) do
+            articulation.reset_to_default(artic_assign)
+            artic_assign:Save()
         end
     end
 end

--- a/src/library/articulation.lua
+++ b/src/library/articulation.lua
@@ -71,4 +71,22 @@ function articulation.calc_main_character_dimensions(artic_def)
     return text_mets:CalcWidthEVPUs(), text_mets:CalcHeightEVPUs()
 end
 
+--[[
+% reset_to_default
+
+Implements all calls necessary to reset the articulation to default positioning. These settings achieve
+the same result as hitting the Clear key for the Articulation in the Finale UI.
+
+@artic (FCArticulation)
+@artic_def (FCArticulationDef) optional definition for this articulation (calculated if not supplied)
+]]
+
+function articulation.reset_to_default(artic, artic_def)
+    artic_def = artic_def or artic:CreateArticulationDef()
+    artic.StackingMode = finale.ARTICSTACKING_USEDEFINITION
+    artic.PlacementMode = finale.ARTICPLACEMENT_AUTOMATIC
+    artic:ResetPos(artic_def)
+end
+
+
 return articulation


### PR DESCRIPTION
The reset articulation script was not completely resetting its position to the default (based on the definition). This PR rectifies it as well as moving the reset function to the articulation library.