### PR TITLE
Massage MusicXML v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ mobdebug.lua
 
 src/**/personal*
 dist/**/personal*
+personal/*
 
 .vscode/settings.json
 */**/.vscode

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -791,7 +791,6 @@ function document_options_to_musescore()
             file:close()
             local files_to_process = {}
             for folder, filename in utils.eachfile(selected_directory, true) do
-                print(folder, filename)
                 if (filename:sub(-MUSX_EXTENSION:len()) == MUSX_EXTENSION) or (filename:sub(-MUS_EXTENSION:len()) == MUS_EXTENSION) then
                     table.insert(files_to_process, {name = filename, folder = folder})
                 end

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -62,7 +62,7 @@ local utils = require("library.utils")
 
 do_folder = do_folder or false
 
-local logfile_name = "FinaleMuseScoreSettingsExportLog.txt"
+local LOGFILE_NAME <const> = "FinaleMuseScoreSettingsExportLog.txt"
 
 local MUSX_EXTENSION <const> = ".musx"
 local MUS_EXTENSION <const> = ".mus"
@@ -708,9 +708,10 @@ function create_status_dialog(selected_directory, files_to_process)
     dialog:RegisterHandleTimer(function(self, timer)
         assert(timer == TIMER_ID, "incorrect timer id value " .. timer)
         if #files_to_process <= 0 then
-            self:GetControl("folder"):SetText(selected_directory)
-            self:GetControl("file_path"):SetText("Export complete.")
             self:StopTimer(TIMER_ID)
+            self:GetControl("folder"):SetText(selected_directory)
+            self:GetControl("file_path_label"):SetText("Log:")
+            self:GetControl("file_path"):SetText(LOGFILE_NAME .. " (export complete)")
             currently_processing = selected_directory
             log_message("processing complete")
             self:GetControl("cancel"):SetText("Close")
@@ -782,7 +783,7 @@ function document_options_to_musescore()
         end
         local selected_directory = select_directory()
         if selected_directory then
-            logfile_path = text.convert_encoding(selected_directory, text.get_utf8_codepage(), text.get_default_codepage()) .. logfile_name
+            logfile_path = text.convert_encoding(selected_directory, text.get_utf8_codepage(), text.get_default_codepage()) .. LOGFILE_NAME
             local file <close> = io.open(logfile_path, "w")
             if not file then
                 error("unable to create logfile " .. logfile_path)

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -510,7 +510,7 @@ Does nothing for plugin versions before RGP Lua 0.68.
 ]]
 function utils.eachfile(directory_path, recursive)
     if finenv.MajorVersion <= 0 and finenv.MinorVersion < 68 then
-        return function() return nil end
+        error("utils.eachfile requires at least RGP Lua v0.68.", 2)
     end
 
     recursive = recursive or false
@@ -535,7 +535,7 @@ function utils.eachfile(directory_path, recursive)
                             coroutine.yield(subdir, subfile)
                         end
                     end
-                elseif lfs_file:sub(1, 2) ~= "._" then -- skip macOS resource files
+                elseif (mode == "file" or mode == "link") and lfs_file:sub(1, 2) ~= "._" then -- skip macOS resource files
                     coroutine.yield(directory_path, utf8_file)
                 end
             end

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -467,4 +467,80 @@ function utils.win_mac(windows_value, mac_value)
     return mac_value
 end
 
+--[[
+% split_file_path
+
+Splits a file path into folder, file name, and extension.
+
+@ full_path (string) The full file path in a Lua string.
+: (string) the folder path always including the final delimeter slash (macOS) or backslash (Windows). This may be an empty string.
+: (string) the filename without its extension
+: (string) the extension including its leading "." or an empty string if no extension.
+]]
+function utils.split_file_path(full_path)
+    local path_name = finale.FCString()
+    local file_name = finale.FCString()
+    local file_path = finale.FCString(full_path)
+    file_path:SplitToPathAndFile(path_name, file_name)
+    -- do not use FCString.ExtractFileExtension() because it has a hard-coded limit of 7 characters (!)
+    local extension = file_name.LuaString:match("^.+(%..+)$")
+    extension = extension or ""
+    if #extension > 0 then
+        file_name:TruncateAt(file_name:FindLast(extension))
+    end
+    path_name:AssureEndingPathDelimiter()
+    return path_name.LuaString, file_name.LuaString, extension
+end
+
+--[[
+% eachfile
+
+Iterates a file path using lfs and feeds each directory and file name to a function.
+The directory names fed to the iterator function always contain path delimeters at the end.
+The following are skipped.
+
+- "." and ".."
+- any file name starting withn "._" (These are macOS resource forks and can be seen on Windows as well when searching a macOS shared drive.)
+
+Does nothing for plugin versions before RGP Lua 0.68.
+
+@ directory_path (string) the directory path to search, encoded utf8.
+@ [recursive)] (boolean) true if subdirectories should always be searched. Defaults to false.
+: (function) iterator function to be used in for loop.
+]]
+function utils.eachfile(directory_path, recursive)
+    if finenv.MajorVersion <= 0 and finenv.MinorVersion < 68 then
+        return function() return nil end
+    end
+
+    recursive = recursive or false
+
+    local lfs = require('lfs')
+    local text = require('luaosutils').text
+
+    local fcstr = finale.FCString(directory_path)
+    fcstr:AssureEndingPathDelimiter()
+    directory_path = fcstr.LuaString
+
+    local lfs_directory_path = text.convert_encoding(directory_path, text.get_utf8_codepage(), text.get_default_codepage())
+
+    return coroutine.wrap(function()
+        for lfs_file in lfs.dir(lfs_directory_path) do
+            if lfs_file ~= "." and lfs_file ~= ".." then
+                local utf8_file = text.convert_encoding(lfs_file, text.get_default_codepage(), text.get_utf8_codepage())
+                local mode = lfs.attributes(lfs_directory_path .. lfs_file, "mode")
+                if mode == "directory" then
+                    if recursive then
+                        for subdir, subfile in utils.eachfile(directory_path .. utf8_file, recursive) do
+                            coroutine.yield(subdir, subfile)
+                        end
+                    end
+                elseif lfs_file:sub(1, 2) ~= "._" then -- skip macOS resource files
+                    coroutine.yield(directory_path, utf8_file)
+                end
+            end
+        end
+    end)
+end
+
 return utils

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -502,7 +502,7 @@ The following are skipped.
 - "." and ".."
 - any file name starting withn "._" (These are macOS resource forks and can be seen on Windows as well when searching a macOS shared drive.)
 
-Does nothing for plugin versions before RGP Lua 0.68.
+Generates a runtime error for plugin versions before RGP Lua 0.68.
 
 @ directory_path (string) the directory path to search, encoded utf8.
 @ [recursive)] (boolean) true if subdirectories should always be searched. Defaults to false.

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -467,7 +467,7 @@ function process_one_file(input_file)
 
     log_message("***** START OF PROCESSING *****")
     remove_processing_instructions(input_file, output_file)
-    local musicxml = tinyxml2.XMLDocument()
+    local musicxml <close> = tinyxml2.XMLDocument()
     local result = musicxml:LoadFile(output_file)
     if abort_if(result ~= tinyxml2.XML_SUCCESS, "error parsing XML: " .. musicxml:ErrorStr()) then
         return
@@ -518,7 +518,7 @@ function process_files(file_list, logfile_folder)
         process_one_file(file_info.folder .. file_info.name)
     end
 
-    finenv.UI():AlertInfo(error_occured and "Processed with errors" or "Processed without errors", "Complete")
+    finenv.UI():AlertInfo(error_occured and ("Processed with errors. See " .. logfile_path) or "Processed without errors", "Complete")
 end
 
 function process_directory(path_name)

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -42,13 +42,13 @@ function plugindef()
         Due to a limitation in the xml parser, all xml processing instructions are removed. These are metadata that neither
         Dorico nor MuseScore use, so their removal should not affect importing into those programs.
 
-        When tracking a Finale document, certain situations will cause the script to log errors and stop processing a measure/staff cell
-        for floating rests. Perhaps the most common are
+        When tracking a Finale document, certain situations will cause the script to log warnings and stop processing a measure/staff cell
+        for floating rests. The most common are
 
         - cross staff notes
         - beams over barlines made with the Beam Over Barline plugin
 
-        The script is as conservative as possible, so generally you can ignore these errors. Your best bet is to import the resulting massaged
+        The script is as conservative as possible, so generally you can ignore these warnings. Your best bet is to import the resulting massaged
         xml file and see if you prefer it to the original. The log file is named `FinaleMassageMusicXMLLog.txt` and is to be found in the base
         folder from which you started processing.
     ]]

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -474,7 +474,7 @@ function process_one_file(input_file)
         return false
     end
 
-    log_message("***** START OF PROCESSING *****")
+    log_message("\n\n***** START OF PROCESSING *****")
     remove_processing_instructions(input_file, output_file)
     local musicxml <close> = tinyxml2.XMLDocument()
     local result = musicxml:LoadFile(output_file)

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -2,13 +2,13 @@ function plugindef()
     finaleplugin.RequireDocument = false
     finaleplugin.RequireSelection = false
     finaleplugin.NoStore = true
-    finaleplugin.Author = "Robert Patterson (folder scanning added by Carl Vine)"
+    finaleplugin.Author = "Robert Patterson and Carl Vine"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.7"
+    finaleplugin.Version = "2.0"
     finaleplugin.Date = "October 6, 2024"
     finaleplugin.LoadLuaOSUtils = true
     finaleplugin.CategoryTags = "Document"
-    finaleplugin.MinJWLuaVersion = 0.74
+    finaleplugin.MinJWLuaVersion = 0.75
     finaleplugin.AdditionalMenuOptions = [[
         Massage MusicXML Single File...
     ]]
@@ -21,7 +21,7 @@ function plugindef()
     finaleplugin.AdditionalPrefixes = [[
         do_single_file = true
     ]]
-    finaleplugin.ScriptGroupName = "Massage MusicXML"
+    finaleplugin.ScriptGroupName = "Staff Explode"
     finaleplugin.Notes = [[
         This script reads musicxml files exported from Finale and modifies them to
         improve importing into Dorico or MuseScore. The best process is as follows:
@@ -34,6 +34,10 @@ function plugindef()
         Here is a list of some of the changes the script makes:
 
         - 8va/8vb and 15ma/15mb symbols are extended to include the last note and extended left to include leading grace notes.
+        - Remove "real" whole rests from fermata measures. This issue arises when the fermata was attached to a "real" whole rest.
+        The fermata is retained in the MusicXML, but the whole rest it removed. This makes for a better import.
+        - When a parallel `.musx` or `.mus` file is found, changes all rests in the MusicXML to floating if they were floating rests
+        in the original Finale file.
 
         Due to a limitation in the xml parser, all xml processing instructions are removed. These are metadata that neither
         Dorico nor MuseScore use, so their removal should not affect importing into those programs.
@@ -43,30 +47,71 @@ function plugindef()
         "Massage a folder of MusicXML files to improve importing to Dorico and MuseScore."
 end
 
-do_single_file = do_single_file or false
-local xml_extension = ".musicxml"
-local add_to_filename = " massaged"
+local lfs = require("lfs")
+local text = require("luaosutils").text
 
-local function alert_error(file_list)
-    local msg = (#file_list > 1 and "These files do not " or "This file does not ")
-        .. "appear to be MusicXML exported from Finale:\n\n"
-        .. table.concat(file_list, "\n")
-    finenv.UI():AlertError(msg, plugindef())
+local utils = require("library.utils")
+
+do_single_file = do_single_file or false
+local XML_EXTENSION <const> = ".musicxml"
+local ADD_TO_FILENAME <const> = " massaged"
+local EDU_PER_QUARTER <const> = 1024
+
+local LOGFILE_NAME <const> = "FinaleMassageMusicXMLLog.txt"
+local logfile_path
+local error_occured = false
+local currently_processing
+local current_staff
+local current_measure
+
+function log_message(msg, is_error)
+    if is_error then
+        error_occured = true
+    end
+    local log_entry = "[" .. os.date("%Y-%m-%d %H:%M:%S") .. "] " .. currently_processing .. " "
+    if current_staff > 0 and current_measure > 0 then
+        local staff_text = (function()
+            local retval = "p" .. current_staff
+            local staff = finale:FCStaff()
+            if staff:Load(finale.FCMusicRegion():CalcStaffNumber(current_staff)) then
+                local name = staff:CreateTrimmedFullNameString()
+                retval = retval .. "[" .. name.LuaString .. "]"
+            end
+            return retval
+        end)()
+        log_entry = log_entry .. "(" .. staff_text .. " m" .. current_measure .. ") "
+    end
+    if is_error then
+        log_entry = log_entry .. "ERROR: "
+    end
+    log_entry = log_entry .. msg
+    if finenv.ConsoleIsAvailable then
+        print(log_entry)
+    end
+    local file <close> = io.open(logfile_path, "a")
+    if not file then
+        error("unable to append to logfile " .. logfile_path)
+    end
+    file:write(log_entry .. "\n")
+    file:close()
 end
 
 local function remove_processing_instructions(input_name, output_name)
-    local input_file <close> = io.open(input_name, "r")
+    local input_file <close> = io.open(text.convert_encoding(input_name, text.get_utf8_codepage(), text.get_default_codepage()), "r")
     if not input_file then
         error("Cannot open file: " .. input_name)
     end
     local lines = {} -- assemble the output file line by line
+    local number_removed = 0
     for line in input_file:lines() do
         if line:match("^%s*<%?xml") or not line:match("^%s*<%?.*%?>") then
             table.insert(lines, line)
+        else
+            number_removed = number_removed + 1
         end
     end
     input_file:close()
-    local output_file <close> = io.open(output_name, "w")
+    local output_file <close> = io.open(text.convert_encoding(output_name, text.get_utf8_codepage(), text.get_default_codepage()), "w")
     if not output_file then
         error("Cannot open file for writing: " .. output_name)
     end
@@ -74,6 +119,9 @@ local function remove_processing_instructions(input_name, output_name)
         output_file:write(line .. "\n")
     end
     output_file:close()
+    if number_removed > 0 then
+        log_message("removed " .. number_removed .. " processing instructions.")
+    end
 end
 
 function fix_octave_shift(xml_measure)
@@ -89,6 +137,7 @@ function fix_octave_shift(xml_measure)
                     if next_note and not next_note:FirstChildElement("rest") then
                         xml_measure:DeleteChild(xml_direction)
                         xml_measure:InsertAfterChild(next_note, direction_copy)
+                        log_message("extended octave_shift element of size " .. octave_shift:IntAttribute("size", 8) .. " by one note.")
                     end
                 elseif shift_type == "up" or shift_type == "down" then
                     local sign = shift_type == "down" and 1 or -1
@@ -116,6 +165,7 @@ function fix_octave_shift(xml_measure)
                         else
                             xml_measure:InsertFirstChild(direction_copy)
                         end
+                        log_message("adjusted octave_shift element of size " .. octave_shift:IntAttribute("size", 8) .. " for preceding grace notes.")
                     end
                 end
             end
@@ -123,36 +173,224 @@ function fix_octave_shift(xml_measure)
     end
 end
 
-function process_xml(score_partwise)
-    for xml_part in xmlelements(score_partwise, "part") do
-        for xml_measure in xmlelements(xml_part, "measure") do
-            fix_octave_shift(xml_measure)
+function fix_fermata_whole_rests(xml_measure)
+    if xml_measure:ChildElementCount("note") == 1 then
+        local xml_note = xml_measure:FirstChildElement("note")
+        if xml_note:FirstChildElement("rest") then
+            local note_type = xml_note:FirstChildElement("type")
+            if note_type and note_type:GetText() == "whole" then
+                for notations in xmlelements(xml_note, "notations") do
+                    if notations:FirstChildElement("fermata") then
+                        xml_note:DeleteChild(note_type)
+                        log_message("removed real whole rest under fermata.")
+                        break
+                    end
+                end
+            end
         end
     end
 end
 
-function process_one_file(input_file)
-    local path, filename, extension = input_file:match("^(.-)([^\\/]-)%.([^\\/%.]+)$")
-    if not path or not filename or not extension then
-        error("Invalid file path format")
+local duration_types = {
+    maxima = EDU_PER_QUARTER * 32,
+    long = EDU_PER_QUARTER * 16,
+    breve = EDU_PER_QUARTER * 8,
+    whole = EDU_PER_QUARTER * 4,
+    half = EDU_PER_QUARTER * 2,
+    quarter = EDU_PER_QUARTER * 1,
+    eighth = EDU_PER_QUARTER / 2,
+    ["16th"] = EDU_PER_QUARTER / 4,
+    ["32nd"] = EDU_PER_QUARTER / 8,
+    ["64th"] = EDU_PER_QUARTER / 16,
+    ["128th"] = EDU_PER_QUARTER / 32,
+    ["256th"] = EDU_PER_QUARTER / 64,
+    ["512th"] = EDU_PER_QUARTER / 128,
+    ["1024th"] = EDU_PER_QUARTER / 256,
+}
+
+function process_xml_with_finale_document(xml_measure, staff_slot, measure, duration_unit)
+    local region = finale.FCMusicRegion()
+    region.StartSlot = staff_slot
+    region.StartMeasure = measure
+    region:SetStartMeasurePosLeft()
+    region.EndSlot = staff_slot
+    region.EndMeasure = measure
+    region:SetEndMeasurePosRight()
+    local next_note
+    if staff_slot == 5 and measure == 296 then
+       --require('mobdebug').start()
     end
-    local output_file = path .. filename .. add_to_filename .. xml_extension
+    for entry in eachentry(region) do
+        if entry.Visible then -- Dolet does not create note elements for invisible entries
+            if not next_note then
+                next_note = xml_measure:FirstChildElement("note")
+            else
+                next_note = next_note:NextSiblingElement("note")
+            end
+            if not next_note then
+                log_message("xml notes do not match open document", true)
+                return false
+            end
+            local note_type_node = next_note:FirstChildElement("type")
+            local note_type_duration = note_type_node and duration_types[note_type_node:GetText()]
+            local num_dots = next_note:ChildElementCount("dot")
+            note_type_duration = note_type_duration * (2 - 1 / (2 ^ num_dots))
+            if not note_type_duration or note_type_duration ~= entry.Duration then
+                -- try actual durations
+                local duration_node = next_note:FirstChildElement("duration")
+                local xml_duration = (duration_node and duration_node:DoubleText() or 0) * duration_unit
+                xml_duration = math.floor(xml_duration*10000 + 0.5) / 10000
+                if xml_duration ~= entry.ActualDuration then
+                    log_message("xml durations do not match document: [" .. entry.ActualDuration .. ", " .. xml_duration .. "])", true)
+                    return false
+                end    
+            end
+            -- refloat floating rests
+            if entry:IsRest() then
+                local rest_element = next_note:FirstChildElement("rest")
+                if not rest_element then
+                    log_message("xml corresponding note value in document is not a rest", true)
+                    return false
+                end
+                if entry.FloatingRest then
+                    local function delete_element(element_name)
+                        local element = rest_element:FirstChildElement(element_name)
+                        if element then
+                            rest_element:DeleteChild(element)
+                            return true
+                        end
+                        return false
+                    end
+                    local deleted_pitch = delete_element("display-step")
+                    local deleted_octave = delete_element("display-octave")
+                    if deleted_pitch or deleted_octave then
+                        log_message("refloated rest of duration " ..
+                            entry.Duration / EDU_PER_QUARTER .. " quarter notes.")
+                    end
+                end
+            end
+            -- skip over extra notes in chords
+            local chord_check = next_note:NextSiblingElement("note")
+            while chord_check and chord_check:FirstChildElement("chord") do
+                next_note = chord_check
+                chord_check = chord_check:NextSiblingElement("note")
+            end
+        end
+    end
+    return true
+end
+
+function process_xml(score_partwise, document)
+    if not document then
+        log_message("WARNNG: corresponding Finale document not found")
+    end
+    current_staff = 0
+    for xml_part in xmlelements(score_partwise, "part") do
+        current_staff = current_staff + 1
+        current_measure = 0
+        local duration_unit = EDU_PER_QUARTER
+        for xml_measure in xmlelements(xml_part, "measure") do
+            local divisions = tinyxml2.XMLHandle(xml_measure)
+                :FirstChildElement("attributes")
+                :FirstChildElement("divisions")
+                :ToElement()
+            if divisions then
+                duration_unit = EDU_PER_QUARTER / divisions:DoubleText(1)
+            end
+            current_measure = current_measure + 1
+            if document then
+                process_xml_with_finale_document(xml_measure, current_staff, current_measure, duration_unit)
+            end
+            fix_octave_shift(xml_measure)
+            fix_fermata_whole_rests(xml_measure)
+        end
+    end
+    current_staff = 0
+    current_measure = 0
+end
+
+-- return document, close_required, switchback_required
+function open_finale_document(document_path)
+    local documents = finale.FCDocuments()
+    documents:LoadAll()
+    for document in each(documents) do
+        local this_path = finale.FCString()
+        document:GetPath(this_path)
+        if this_path:IsEqual(document_path) then
+            local switchback_required = false
+            if not document:IsCurrent() then
+                document:SwitchTo()
+                document:DisplayVisually()
+                switchback_required = true
+            end
+            return document, false, switchback_required
+        else
+            print(this_path, document_path)
+        end
+    end
+    local document = finale.FCDocument()
+    if not document:Open(finale.FCString(document_path), true, nil, false, false, true) then
+        log_message("unable to open corresponding Finale document", true)
+        return nil, false, false
+    end
+    return document, true, true
+end
+
+function process_one_file(input_file)
+    currently_processing = input_file
+    current_staff = 0
+    current_measure = 0
+
+    local path, filename, extension = utils.split_file_path(input_file)
+    assert(#path > 0 and #filename > 0 and #extension > 0, "invalid file path format")
+    local output_file = path .. filename .. ADD_TO_FILENAME .. XML_EXTENSION
+    local document_path = (function()
+        local function exist(try_path)
+            local attr = lfs.attributes(text.convert_encoding(try_path, text.get_utf8_codepage(), text.get_utf8_codepage()))
+            return attr and attr.mode == "file"
+        end
+        local try_path = path .. filename .. ".musx"
+        if exist(try_path) then return try_path end
+        try_path = path .. filename .. ".mus"
+        if exist(try_path) then return try_path end
+        return nil
+    end)()
+    
+    local document, close_required, switchback_required
+    if document_path then
+        document, close_required, switchback_required = open_finale_document(document_path)
+    end
+
+    log_message("***** START OF PROCESSING *****")
 
     remove_processing_instructions(input_file, output_file)
     local musicxml = tinyxml2.XMLDocument()
     local result = musicxml:LoadFile(output_file)
     if result ~= tinyxml2.XML_SUCCESS then
-        os.remove(output_file) -- delete erroneous file
-        return input_file -- XML error
+        log_message("file does not appear to be exported from Finale", true)
+        os.remove(text.convert_encoding(output_file, text.get_utf8_codepage(), text.get_default_codepage())) -- delete erroneous file
+        return
     end
     local score_partwise = musicxml:FirstChildElement("score-partwise")
     if not score_partwise then
-        os.remove(output_file) -- delete erroneous file
-        return input_file -- massaging failed
+        log_message("file does not appear to be exported from Finale", true)
+        os.remove(text.convert_encoding(output_file, text.get_utf8_codepage(), text.get_default_codepage())) -- delete erroneous file
+        return
     end
-    process_xml(score_partwise)
-    musicxml:SaveFile(output_file)
-    return ""
+    process_xml(score_partwise, document)
+    if musicxml:SaveFile(output_file) then
+        log_message("successfully saved massaged file")
+    else
+        log_message("unable to save massaged file: " .. musicxml:ErrorStr(), true)
+    end
+    if document then
+        if close_required then
+            document:CloseCurrentDocumentAndWindow()
+        end
+        if switchback_required then
+            document:SwitchBack()
+        end
+    end
 end
 
 function process_directory(path_name)
@@ -160,41 +398,43 @@ function process_directory(path_name)
     folder_dialog:SetWindowTitle(finale.FCString("Select Folder of MusicXML Files:"))
     folder_dialog:SetFolderPath(path_name)
     if not folder_dialog:Execute() then
-        return nil -- user cancelled
+        return false -- user cancelled
     end
     local selected_directory = finale.FCString()
     folder_dialog:GetFolderPath(selected_directory)
-    local src_dir = selected_directory.LuaString
+    folder_dialog:AssureEndingPathDelimiter()
 
-    -- scan the directory, identifying valid candidate files
-    local error_list = {}
-    local lfs = require("lfs")
-    for file in lfs.dir(src_dir) do
-        if file ~= "." and file ~= ".." and file:sub(-xml_extension:len()) == xml_extension then
-            local file_error = process_one_file(src_dir .. "/" .. file)
-            if file_error ~= "" then
-                table.insert(error_list, file_error)
-            end
+    create_logfile(selected_directory.LuaString)
 
+    for dir_name, file_name in utils.eachfile(selected_directory.LuaString) do
+        if file_name:sub(-XML_EXTENSION:len()) == XML_EXTENSION then
+            process_one_file(dir_name .. file_name)
         end
     end
-    if #error_list > 0 then
-        alert_error(error_list)
-    end
+    return true
 end
 
 function do_open_dialog(path_name)
     local open_dialog = finale.FCFileOpenDialog(finenv.UI())
     open_dialog:SetWindowTitle(finale.FCString("Select a MusicXML File:"))
-    open_dialog:AddFilter(finale.FCString("*" .. xml_extension), finale.FCString("MusicXML File"))
+    open_dialog:AddFilter(finale.FCString("*" .. XML_EXTENSION), finale.FCString("MusicXML File"))
     open_dialog:SetInitFolder(path_name)
-    open_dialog:AssureFileExtension(xml_extension)
+    open_dialog:AssureFileExtension(XML_EXTENSION)
     if not open_dialog:Execute() then
         return nil
     end
     local selected_file_name = finale.FCString()
     open_dialog:GetFileName(selected_file_name)
     return selected_file_name.LuaString
+end
+
+function create_logfile(path_name)
+    logfile_path = text.convert_encoding(path_name, text.get_utf8_codepage(), text.get_default_codepage()) .. LOGFILE_NAME
+    local file <close> = io.open(logfile_path, "w")
+    if not file then
+        error("unable to create logfile " .. logfile_path, 2)
+    end
+    file:close()
 end
 
 function music_xml_massage_export()
@@ -205,18 +445,25 @@ function music_xml_massage_export()
     if document then -- extract active pathname
         document:GetPath(path_name)
         path_name:SplitToPathAndFile(path_name, nil)
+    else
+        path_name:SetMusicFolderPath()
     end
+    path_name:AssureEndingPathDelimiter()
 
+    local massaged = false
     if do_single_file then
         local xml_file = do_open_dialog(path_name)
         if xml_file then
-            local file_error = process_one_file(xml_file)
-            if file_error ~= "" then
-                alert_error{file_error}
-            end
+            create_logfile(utils.split_file_path(xml_file))
+            process_one_file(xml_file)
+            massaged = true
         end
     else
-        process_directory(path_name)
+        massaged = process_directory(path_name)
+    end
+    
+    if massaged then
+        finenv.UI():AlertInfo(error_occured and "Processed with errors" or "Processed without errors", "Complete")
     end
 end
 

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -374,9 +374,9 @@ function process_one_file(input_file)
         if condition then
             log_message(msg, true)
             os.remove(text.convert_encoding(output_file, text.get_utf8_codepage(), text.get_default_codepage())) -- delete erroneous file
+            close_document()
             return true
         end
-        close_document()
         return false
     end
 


### PR DESCRIPTION
Bug fixes:

- Now correctly skips all notes in a chord so that a chord does not end up with the first note under the ottava and the remaining notes not under it. (This can cause havoc on a Dorico import.)
- Path name text encoding issues are resolved. (This was mainly a Windows issue.)

Enhancements:

- Refactored UI
- Folder search now recursively searches subfolders.
- Added a pass for removing "real" whole rests under fermatas.
- Added a pass for refloating rests that are floating in the original Finale document. (This requires the Finale document to be in the same folder with the `.musicxml` file and have the same file name.)

I am leaving support for compressed `.mxl` files to a future version.

I will wait for comments from @cv-on-hub  and @ThistleSifter before merging this, at least for a while.