### PR TITLE
Refactor ziputils

### DIFF
--- a/docs/rgp-lua/finenv-properties.md
+++ b/docs/rgp-lua/finenv-properties.md
@@ -82,6 +82,18 @@ end
 
 ---
 
+#### EmbeddedLuaOSUtils\* (read-only property)
+
+If this property is true, it signifies that the `luaosutils` library is embedded in this version
+of _RGP Lua_ and can be successfully accessed with a `require` statement. You are also guaranteed
+that the minimum version of the embedded `luaosutils` is `2.2.0`.
+
+```lua
+local luaosutils = finenv.EmbeddedLuaOSUtils and require('luaosutils')
+```
+
+---
+
 #### EndUndoBlock\* (function)
 
 Ends the currently active Undo/Redo block in Finale (if any). Finale will only store Undo/Redo blocks that contain edit changes to the documents. These calls cannot be nested. If your script will make further changes to the document after this call, it should call `StartNewUndoBlock()` again before making them. Otherwise, Finale's Undo stack could become corrupted.

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -54,11 +54,10 @@ end
 
 -- luacheck: ignore 11./global_dialog
 
-local text = require("luaosutils").text
-
 local mixin = require("library.mixin")
 local enigma_string = require("library.enigma_string")
 local utils = require("library.utils")
+local client = require("library.client")
 
 do_folder = do_folder or false
 
@@ -68,7 +67,7 @@ local MUSX_EXTENSION <const> = ".musx"
 local MUS_EXTENSION <const> = ".mus"
 local TEXT_EXTENSION <const> = ".mss"
 local PART_EXTENSION <const> = ".part" .. TEXT_EXTENSION
-local MSS_VERSION <const> = "4.40"
+local MSS_VERSION <const> = "4.50"
 
 -- hard-coded scaling values
 local EVPU_PER_INCH <const> = 288
@@ -380,6 +379,7 @@ function write_note_related_prefs(style_element)
     set_element_text(style_element, "graceNoteMag", size_prefs.GraceNoteSize / 100)
     set_element_text(style_element, "concertPitch", part_scope_prefs.DisplayInConcertPitch)
     set_element_text(style_element, "multiVoiceRestTwoSpaceOffset", math.abs(layer_one_prefs.RestOffset) >= 4)
+    set_element_text(style_element, "mergeMatchingRests", misc_prefs.ConsolidateRestsAcrossLayers)
 end
 
 function write_smart_shape_prefs(style_element)
@@ -783,7 +783,7 @@ function document_options_to_musescore()
         end
         local selected_directory = select_directory()
         if selected_directory then
-            logfile_path = text.convert_encoding(selected_directory, text.get_utf8_codepage(), text.get_default_codepage()) .. LOGFILE_NAME
+            logfile_path = client.encode_with_client_codepage(selected_directory) .. LOGFILE_NAME
             local file <close> = io.open(logfile_path, "w")
             if not file then
                 error("unable to create logfile " .. logfile_path)

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -4,8 +4,8 @@ function plugindef()
     finaleplugin.NoStore = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.1"
-    finaleplugin.Date = "October 6, 2024"
+    finaleplugin.Version = "1.0.2"
+    finaleplugin.Date = "October 20, 2024"
     finaleplugin.CategoryTags = "Document"
     finaleplugin.MinJWLuaVersion = 0.75
     finaleplugin.Notes = [[

--- a/src/library/client.lua
+++ b/src/library/client.lua
@@ -232,7 +232,6 @@ function client.execute(command)
             return process.execute(command)
         end
     end
-    print("popen " .. command)
     local handle = io.popen(command)
     if not handle then return nil end
     local retval = handle:read("*a")

--- a/src/library/enigmaxml.lua
+++ b/src/library/enigmaxml.lua
@@ -53,10 +53,7 @@ older `.mus` format.
 ]]
 function enigmaxml.extract_enigmaxml(filepath)
     local not_supported_message
-    if not client.supports("luaosutils") and false then --finenv.UI():IsOnWindows() then
-        -- io.popen doesn't work with our Windows PowerShell commands
-        not_supported_message = "enigmaxma.extract_enigmaxml requires embedded luaosutils"
-    elseif finenv.TrustedMode == finenv.TrustedModeType.UNTRUSTED then
+    if finenv.TrustedMode == finenv.TrustedModeType.UNTRUSTED then
         not_supported_message = "enigmaxml.extract_enigmaxml must run in Trusted mode."
     elseif not finaleplugin.ExecuteExternalCode then
         not_supported_message = "enigmaxml.extract_enigmaxml must have finaleplugin.ExecuteExternalCode set to true."

--- a/src/library/enigmaxml.lua
+++ b/src/library/enigmaxml.lua
@@ -1,0 +1,114 @@
+--[[
+$module enigmaxml
+
+EnigmaXML is the underlying file format of a Finale `.musx` file. It is undocumented
+by MakeMusic and must be extracted from the `.musx` file. There is an effort to document
+it underway at the [EnigmaXML Documentation](https://github.com/Project-Attacca/enigmaxml-documentation)
+repository.
+]] --
+local enigmaxml = {}
+
+local utils = require("library.utils")
+local client = require("library.client")
+local ziputils = require("library.ziputils")
+
+-- symmetrical encryption/decryption function for EnigmaXML
+local function crypt_enigmaxml_buffer(buffer)
+    -- do not use <const> because this library must be loadable by Lua 5.2 (JW Lua)
+    local INITIAL_STATE = 0x28006D45 -- this value was determined empirically
+    local state = INITIAL_STATE
+    local result = {}
+    
+    for i = 1, #buffer do
+        -- BSD rand()
+        if (i - 1) % 0x20000 == 0 then
+            state = INITIAL_STATE
+        end
+        state = (state * 0x41c64e6d + 0x3039) & 0xFFFFFFFF  -- Simulate 32-bit overflow
+        local upper = state >> 16
+        local c = upper + math.floor(upper / 255)
+        
+        local byte = string.byte(buffer, i)
+        byte = byte ~ (c & 0xFF)  -- XOR operation on the byte
+        
+        table.insert(result, string.char(byte))
+    end
+    
+    return table.concat(result)
+end
+
+--[[
+% extract_enigmaxml
+
+EnigmaXML is the underlying file format of a Finale `.musx` file. It is undocumented
+by MakeMusic and must be extracted from the `.musx` file. There is an effort to document
+it underway at the [EnigmaXML Documentation](https://github.com/finale-lua/ziputils-documentation)
+repository.
+
+This function extracts the EnigmaXML buffer from a `.musx` file. Note that it does not work with Finale's
+older `.mus` format.
+
+@ filepath (string) utf8-encoded file path to a `.musx` file.
+: (string) utf8-encoded buffer of xml data containing the EnigmaXml extracted from the `.musx`.
+]]
+function enigmaxml.extract_enigmaxml(filepath)
+    local not_supported_message
+    if not client.supports("luaosutils") and false then --finenv.UI():IsOnWindows() then
+        -- io.popen doesn't work with our Windows PowerShell commands
+        not_supported_message = "enigmaxma.extract_enigmaxml requires embedded luaosutils"
+    elseif finenv.TrustedMode == finenv.TrustedModeType.UNTRUSTED then
+        not_supported_message = "enigmaxml.extract_enigmaxml must run in Trusted mode."
+    elseif not finaleplugin.ExecuteExternalCode then
+        not_supported_message = "enigmaxml.extract_enigmaxml must have finaleplugin.ExecuteExternalCode set to true."
+    end
+    if not_supported_message then
+        error(not_supported_message, 2)
+    end
+    local _, _, extension = utils.split_file_path(filepath)
+    if extension ~= ".musx" then
+        error(filepath .. " is not a .musx file.", 2)
+    end
+
+    -- Steps to extract:
+    --      Unzip the `.musx` (which is `.zip` in disguise)
+    --      Run the `score.dat` file through `crypt_enigmaxml_buffer` to get a gzip archive of the EnigmaXML file.
+    --      Gunzip the extracted EnigmaXML gzip archive into a string and return it.
+    
+    local os_filepath = client.encode_with_client_codepage(filepath)
+    local output_dir, zipcommand = ziputils.calc_temp_output_path(os_filepath)
+    if not client.execute(zipcommand) then
+        error(zipcommand .. " failed")
+    end
+
+    -- do not use <close> because this library must be loadable by Lua 5.2 (JW Lua)
+    local file = io.open(output_dir .. "/score.dat", "rb")
+    if not file then
+        error("unable to read " .. output_dir .. "/score.dat")
+    end
+    local buffer = file:read("*all")
+    file:close()
+
+    local delcommand = ziputils.calc_rmdir_command(output_dir)
+    client.execute(delcommand)
+
+    buffer = crypt_enigmaxml_buffer(buffer)
+    if ziputils.calc_is_gzip(buffer) then
+        local gzip_path = ziputils.calc_temp_output_path()
+        local gzip_file = io.open(gzip_path, "wb")
+        if not gzip_file then
+            error("unable to create " .. gzip_file)
+        end
+        gzip_file:write(buffer)
+        gzip_file:close()
+        local gunzip_command = ziputils.calc_gunzip_command(gzip_path)
+        buffer = client.execute(gunzip_command)
+        client.execute(ziputils.calc_delete_file_command(gzip_path))
+        if not buffer or buffer == "" then
+            error(gunzip_command .. " failed")
+        end
+    end
+    
+    return buffer
+end
+
+return enigmaxml

--- a/src/library/enigmaxml.lua
+++ b/src/library/enigmaxml.lua
@@ -40,16 +40,11 @@ end
 --[[
 % extract_enigmaxml
 
-EnigmaXML is the underlying file format of a Finale `.musx` file. It is undocumented
-by MakeMusic and must be extracted from the `.musx` file. There is an effort to document
-it underway at the [EnigmaXML Documentation](https://github.com/finale-lua/ziputils-documentation)
-repository.
-
 This function extracts the EnigmaXML buffer from a `.musx` file. Note that it does not work with Finale's
 older `.mus` format.
 
 @ filepath (string) utf8-encoded file path to a `.musx` file.
-: (string) utf8-encoded buffer of xml data containing the EnigmaXml extracted from the `.musx`.
+: (string) buffer of EnigmaXml data extracted from the `.musx`. (The xml declaration specifies the encoding, but expect it to be utf8.)
 ]]
 function enigmaxml.extract_enigmaxml(filepath)
     local not_supported_message
@@ -67,7 +62,7 @@ function enigmaxml.extract_enigmaxml(filepath)
     end
 
     -- Steps to extract:
-    --      Unzip the `.musx` (which is `.zip` in disguise)
+    --      Unzip the `.musx` (which is a `.zip` archive in disguise)
     --      Run the `score.dat` file through `crypt_enigmaxml_buffer` to get a gzip archive of the EnigmaXML file.
     --      Gunzip the extracted EnigmaXML gzip archive into a string and return it.
     

--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -330,7 +330,7 @@ the .json files for each font. The table is in the format:
 ]]
 
 function library.get_smufl_font_list()
-    local osutils = finenv.EmbeddedLuaOSUtils and require("luaosutils")
+    local osutils = client.supports("luaosutils") and require("luaosutils")
     local font_names = {}
     local add_to_table = function(for_user)
         local smufl_directory = calc_smufl_directory(for_user)
@@ -339,13 +339,9 @@ function library.get_smufl_font_list()
             if osutils then
                 return osutils.process.list_dir(smufl_directory, options)
             end
-            -- Starting in 0.67, io.popen may fail due to being untrusted.
+            -- Starting in 0.67, execute may fail due to being untrusted.
             local cmd = finenv.UI():IsOnWindows() and "dir " or "ls "
-            local handle = io.popen(cmd .. options .. " \"" .. smufl_directory .. "\"")
-            if not handle then return "" end
-            local retval = handle:read("*a")
-            handle:close()
-            return retval
+            return client.execute(cmd .. options .. " \"" .. smufl_directory .. "\"") or ""
         end
         local is_font_available = function(dir)
             local fc_dir = finale.FCString()

--- a/src/library/utils.lua
+++ b/src/library/utils.lua
@@ -533,6 +533,7 @@ function utils.eachfile(directory_path, recursive)
     fcstr:AssureEndingPathDelimiter()
     directory_path = fcstr.LuaString
 
+    -- direcly call text.convert_encoding to avoid dependency on library.utils
     local lfs_directory_path = text.convert_encoding(directory_path, text.get_utf8_codepage(), text.get_default_codepage())
 
     return coroutine.wrap(function()

--- a/src/library/ziputils.lua
+++ b/src/library/ziputils.lua
@@ -10,8 +10,6 @@ to this version of PowerShell.
 - The macOS version uses `unzip` and `gunzip`.
 - Except as noted, the necessary tools are pre-installed with a typical installation of any version
 of the OS that supports 64-bit Finale.
-- The PowerShell commands are not compatible with `io.popen`, so Windows callers should check `client.supports("luaosutils")`
-before calling `client.execute` with these commands.
 
 Thie library expects strings to be client-encoded.  On macOS, client encoding is always utf8,
 but on Windows it can be any number of encodings depending on the locale settings and version of Windows.

--- a/src/library/ziputils.lua
+++ b/src/library/ziputils.lua
@@ -108,11 +108,14 @@ function ziputils.calc_gunzip_command(archive_path)
         return "gunzip -c " .. archive_path
     else
         local command = table.concat({
-            "$fs = New-Object IO.Filestream('%s',([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read))",
-            "$gz = New-Object IO.Compression.GzipStream($fs,[IO.Compression.CompressionMode]::Decompress)",
-            "$sr = New-Object IO.StreamReader($gz)",
-            "while (-not $sr.EndOfStream) { Write-Output $sr.ReadLine() }",
-            "$sr.Close()"
+            "$fs = New-Object IO.FileStream('%s', [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::Read)",
+            "$gz = New-Object IO.Compression.GzipStream($fs, [IO.Compression.CompressionMode]::Decompress)",
+            "$buffer = New-Object byte[] 4096",  -- Define a buffer size (e.g., 4096 bytes)
+            "while (($read = $gz.Read($buffer, 0, $buffer.Length)) -gt 0) {",
+            "    [Console]::OpenStandardOutput().Write($buffer, 0, $read)",
+            "}",
+            "$gz.Close()",
+            "$fs.Close()"
         }, "; ")
         command = string.format(command, archive_path)
         return string.format("powershell -c \"%s\"", command)

--- a/src/library/ziputils.lua
+++ b/src/library/ziputils.lua
@@ -5,49 +5,36 @@ Functions for unzipping files. (Future may include zipping as well.)
 
 Dependencies:
 
-- The Windows version uses `PowerShell`.
+- The Windows version uses `PowerShell 5`. Users of Windows 8.1 must manually upgrade
+to this version of PowerShell.
 - The macOS version uses `unzip` and `gunzip`.
-- In both cases the necessary tools are pre-installed with a typical installation of any version
+- Except as noted, the necessary tools are pre-installed with a typical installation of any version
 of the OS that supports 64-bit Finale.
+- The PowerShell commands are not compatible with `io.popen`, so Windows callers should check `client.supports("luaosutils")`
+before calling `client.execute` with these commands.
 
-Pay careful attention to the comments about how strings are encoded. They are either encoded
-**platform** or **utf8**. On macOS, platform encoding is always utf8, but on Windows it can
-be any number of encodings depending on the locale settings and version of Windows. You can use
-`luaosutils.text` to convert them back and forth. (Use the `get_default_codepage` function to get
-the platform encoding.) The `luaosutils.process.execute` function requires platform encoding as do
-`lfs` and all built-in Lua `os` and `io` functions that take strings as input.
-
-Note that many functions require later versions of RGP Lua that include `luaosutils`
-and/or `lfs`. But the these dependencies are embedded in each function so that any version
-of Lua for Finale can at least load the library.
+Thie library expects strings to be client-encoded.  On macOS, client encoding is always utf8,
+but on Windows it can be any number of encodings depending on the locale settings and version of Windows.
+You can use `client.encode_with_client_codepage` to convert a utf8 string to client encoding.
+The `client.execute` function requires client encoding as do `lfs` and all built-in
+Lua `os` and `io` functions that take strings as input.
 ]] --
 local ziputils = {}
 
-local utils = require("library.utils")
-
--- This variable allows us to check if we are supported when we load and the functions
--- can throw out based on it.
-local not_supported_message
-if finenv.MajorVersion <= 0 and finenv.MinorVersion < 68 then
-    not_supported_message = "ziputils requires at least RGP Lua v0.68."
-elseif finenv.TrustedMode == finenv.TrustedModeType.UNTRUSTED then
-    not_supported_message = "ziputils must run in Trusted mode."
-elseif not finaleplugin.ExecuteExternalCode then
-    not_supported_message = "ziputils.extract_enigmaxml must have finaleplugin.ExecuteExternalCode set to true."
-end
+local client = require("library.client")
 
 --[[
 % calc_rmdir_command
 
 Returns the platform-dependent command to remove a directory. It can be passed
-to `luaosutils.process.execute`.
+to `client.execute`.
 
 **WARNING** The command, if executed, permanently deletes the contents of the directory.
 You would normally call this on the temporary directory name from `calc_temp_output_path`.
 But it works on any directory.
 
-@ path_to_remove (string) platform-encoded path of directory to remove.
-: (string) platform-encoded command string to execute.
+@ path_to_remove (string) client-encoded path of directory to remove.
+: (string) client-encoded command string to execute.
 ]]
 function ziputils.calc_rmdir_command(path_to_remove)
     return (finenv.UI():IsOnMac() and "rm -r " or "cmd /c rmdir /s /q ") .. path_to_remove
@@ -57,19 +44,18 @@ end
 % calc_delete_file_command
 
 Returns the platform-dependent command to delete a file. It can be passed
-to `luaosutils.process.execute`.
+to `client.execute`.
 
 **WARNING** The command, if executed, permanently deletes the file.
 You would normally call this on the temporary directory name from `calc_temp_output_path`.
 But it works on any directory.
 
-@ path_to_remove (string) platform-encoded path of directory to remove.
-: (string) platform-encoded command string to execute.
+@ path_to_remove (string) client-encoded path of directory to remove.
+: (string) client-encoded command string to execute.
 ]]
 function ziputils.calc_delete_file_command(path_to_remove)
     return (finenv.UI():IsOnMac() and "rm " or "cmd /c del ") .. path_to_remove
 end
-
 
 --[[
 % calc_temp_output_path
@@ -77,41 +63,35 @@ end
 Returns a path that can be used as a temporary target for unzipping. The caller may create it
 either as a file or a directory, because it is guaranteed not to exist when it is returned and it does
 not have a terminating path delimiter. Also returns a platform-dependent unzip command that can be
-passed to `luaosutils.process.execute` to unzip the input archive into the temporary name as a directory.
+passed to `client.execute` to unzip the input archive into the temporary name as a directory.
 
 This function requires `luaosutils`.
 
-@ [archive_path] (string) platform-encoded filepath to the zip archive that is included in the zip command.
-: (string) platform-encoded temporary path generated by the system.
-: (string) platform-encoded unzip command that can be used to unzip a multifile archived directory structure into the temporary path.
+@ [archive_path] (string) client-encoded filepath to the zip archive that is included in the zip command.
+: (string) client-encoded temporary path generated by the system.
+: (string) client-encoded unzip command that can be used to unzip a multifile archived directory structure into the temporary path.
 ]]
 function ziputils.calc_temp_output_path(archive_path)
-    if not_supported_message then
-        error(not_supported_message, 2)
-    end
-
     archive_path = archive_path or ""
-
-    local process = require("luaosutils").process
 
     local output_dir = os.tmpname()
     local rmcommand = ziputils.calc_delete_file_command(output_dir)
-    process.execute(rmcommand)
+    client.execute(rmcommand)
 
     local zipcommand
     if finenv.UI():IsOnMac() then
         zipcommand = "unzip \"" .. archive_path .. "\" -d " .. output_dir
     else
-        zipcommand = [[
-            $archivePath = '%s'
-            $outputDir = '%s'
-            $zipPath = $archivePath + '.zip'
-            Copy-Item -Path $archivePath -Destination $zipPath
-            Expand-Archive -Path $zipPath -DestinationPath $outputDir
-            Remove-Item -Path $zipPath
-        ]]
+        zipcommand = table.concat({
+            "$archivePath = '%s'",
+            "$outputDir = '%s'",
+            "$zipPath = $archivePath + '.zip'",
+            "Copy-Item -Path $archivePath -Destination $zipPath",
+            "Expand-Archive -Path $zipPath -DestinationPath $outputDir",
+            "Remove-Item -Path $zipPath",
+        }, "; ")
         zipcommand = string.format(zipcommand, archive_path, output_dir)
-        zipcommand = string.format("powershell -c & { %s }", zipcommand)
+        zipcommand = string.format("powershell -c \"%s\"", zipcommand)
     end
     return output_dir, zipcommand
 end
@@ -120,24 +100,24 @@ end
 % calc_gunzip_command
 
 Returns the platform-dependent command to gunzip a file to `stdout`. It can be passed
-to `luaosutils.process.execute`, which will then return the text directly.
+to `client.execute`, which will then return the text directly.
 
-@ archive_path (string) platform-encoded path of source gzip archive.
-: (string) platform-encoded command string to execute.
+@ archive_path (string) client-encoded path of source gzip archive.
+: (string) client-encoded command string to execute.
 ]]
 function ziputils.calc_gunzip_command(archive_path)
     if finenv.UI():IsOnMac() then
         return "gunzip -c " .. archive_path
     else
-        local command = [[
-            $fs = New-Object IO.Filestream('%s',([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read))
-            $gz = New-Object IO.Compression.GzipStream($fs,[IO.Compression.CompressionMode]::Decompress)
-            $sr = New-Object IO.StreamReader($gz)
-            while (-not $sr.EndOfStream) { Write-Output $sr.ReadLine() }
-            $sr.Close()
-        ]]
+        local command = table.concat({
+            "$fs = New-Object IO.Filestream('%s',([IO.FileMode]::Open),([IO.FileAccess]::Read),([IO.FileShare]::Read))",
+            "$gz = New-Object IO.Compression.GzipStream($fs,[IO.Compression.CompressionMode]::Decompress)",
+            "$sr = New-Object IO.StreamReader($gz)",
+            "while (-not $sr.EndOfStream) { Write-Output $sr.ReadLine() }",
+            "$sr.Close()"
+        }, "; ")
         command = string.format(command, archive_path)
-        return string.format("powershell -c & { %s }", command)
+        return string.format("powershell -c \"%s\"", command)
     end
 end
 
@@ -152,97 +132,6 @@ Detects if an input buffer is a gzip archive.
 function ziputils.calc_is_gzip(buffer)
     local byte1, byte2, byte3, byte4 = string.byte(buffer, 1, 4)
     return byte1 == 0x1F and byte2 == 0x8B and byte3 == 0x08 and byte4 == 0x00
-end
-
--- symmetrical encryption/decryption function for EnigmaXML
-local function crypt_enigmaxml_buffer(buffer)
-    local INITIAL_STATE <const> = 0x28006D45 -- this value was determined empirically
-    local state = INITIAL_STATE
-    local result = {}
-    
-    for i = 1, #buffer do
-        -- BSD rand()
-        if (i - 1) % 0x20000 == 0 then
-            state = INITIAL_STATE
-        end
-        state = (state * 0x41c64e6d + 0x3039) & 0xFFFFFFFF  -- Simulate 32-bit overflow
-        local upper = state >> 16
-        local c = upper + math.floor(upper / 255)
-        
-        local byte = string.byte(buffer, i)
-        byte = byte ~ (c & 0xFF)  -- XOR operation on the byte
-        
-        table.insert(result, string.char(byte))
-    end
-    
-    return table.concat(result)
-end
-
---[[
-% extract_enigmaxml
-
-EnigmaXML is the underlying file format of a Finale `.musx` file. It is undocumented
-by MakeMusic and must be extracted from the `.musx` file. There is an effort to document
-it underway at the [EnigmaXML Documentation](https://github.com/finale-lua/ziputils-documentation)
-repository.
-
-This function extracts the EnigmaXML buffer from a `.musx` file. Note that it does not work with Finale's
-older `.mus` format.
-
-@ filepath (string) utf8-encoded file path to a `.musx` file.
-: (string) utf8-encoded buffer of xml data containing the EnigmaXml extracted from the `.musx`.
-]]
-function ziputils.extract_enigmaxml(filepath)
-    if not_supported_message then
-        error(not_supported_message, 2)
-    end
-    local _, _, extension = utils.split_file_path(filepath)
-    if extension ~= ".musx" then
-        error(filepath .. " is not a .musx file.", 2)
-    end
-
-    -- Steps to extract:
-    --      Unzip the `.musx` (which is `.zip` in disguise)
-    --      Run the `score.dat` file through `crypt_enigmaxml_buffer` to get a gzip archive of the EnigmaXML file.
-    --      Gunzip the extracted EnigmaXML gzip archive into a string and return it.
-
-    local text = require("luaosutils").text
-    local process = require("luaosutils").process
-    
-    local os_filepath = text.convert_encoding(filepath, text.get_utf8_codepage(), text.get_default_codepage())
-    local output_dir, zipcommand = ziputils.calc_temp_output_path(os_filepath)
-    if not process.execute(zipcommand) then
-        error(zipcommand .. " failed")
-    end
-
-    local file <close> = io.open(output_dir .. "/score.dat", "rb")
-    if not file then
-        error("unable to read " .. output_dir .. "/score.dat")
-    end
-    local buffer = file:read("*all")
-    file:close()
-
-    local delcommand = ziputils.calc_rmdir_command(output_dir)
-    process.execute(delcommand)
-
-    buffer = crypt_enigmaxml_buffer(buffer)
-    if ziputils.calc_is_gzip(buffer) then
-        local gzip_path = ziputils.calc_temp_output_path()
-        local gzip_file <close> = io.open(gzip_path, "wb")
-        if not gzip_file then
-            error("unable to create " .. gzip_file)
-        end
-        gzip_file:write(buffer)
-        gzip_file:close()
-        local gunzip_command = ziputils.calc_gunzip_command(gzip_path)
-        buffer = process.execute(gunzip_command)
-        process.execute(ziputils.calc_delete_file_command(gzip_path))
-        if not buffer or buffer == "" then
-            error(gunzip_command .. "failed")
-        end
-    end
-    
-    return buffer
 end
 
 return ziputils

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -58,10 +58,10 @@ function plugindef()
 end
 
 local lfs = require("lfs")
-local text = require("luaosutils").text
 
 local utils = require("library.utils")
 local mixin = require("library.mixin")
+local client = require("library.client")
 
 do_single_file = do_single_file or false
 local XML_EXTENSION <const> = ".musicxml"
@@ -111,7 +111,7 @@ function log_message(msg, is_error)
 end
 
 local function remove_processing_instructions(input_name, output_name)
-    local input_file <close> = io.open(text.convert_encoding(input_name, text.get_utf8_codepage(), text.get_default_codepage()), "r")
+    local input_file <close> = io.open(client.encode_with_client_codepage(input_name), "r")
     if not input_file then
         error("Cannot open file: " .. input_name)
     end
@@ -125,8 +125,7 @@ local function remove_processing_instructions(input_name, output_name)
         end
     end
     input_file:close()
-    local output_file <close> = io.open(
-    text.convert_encoding(output_name, text.get_utf8_codepage(), text.get_default_codepage()), "w")
+    local output_file <close> = io.open(client.encode_with_client_codepage(output_name), "w")
     if not output_file then
         error("Cannot open file for writing: " .. output_name)
     end
@@ -437,8 +436,7 @@ function process_one_file(input_file)
     local output_file = path .. filename .. ADD_TO_FILENAME .. XML_EXTENSION
     local document_path = (function()
         local function exist(try_path)
-            local attr = lfs.attributes(text.convert_encoding(try_path, text.get_utf8_codepage(),
-                text.get_default_codepage()))
+            local attr = lfs.attributes(client.encode_with_client_codepage(try_path))
             return attr and attr.mode == "file"
         end
         local try_path = path .. filename .. ".musx"
@@ -467,7 +465,7 @@ function process_one_file(input_file)
     local function abort_if(condition, msg)
         if condition then
             log_message(msg, true)
-            os.remove(text.convert_encoding(output_file, text.get_utf8_codepage(), text.get_default_codepage())) -- delete erroneous file
+            os.remove(client.encode_with_client_codepage(output_file)) -- delete erroneous file
             close_document()
             return true
         end
@@ -543,7 +541,7 @@ function process_files(file_list, selected_path)
     dialog:CreateCancelButton("cancel")
     -- registrations
     dialog:RegisterInitWindow(function(self)
-        logfile_path = text.convert_encoding(selected_path, text.get_utf8_codepage(), text.get_default_codepage()) .. LOGFILE_NAME
+        logfile_path = client.encode_with_client_codepage(selected_path) .. LOGFILE_NAME
         local file <close> = io.open(logfile_path, "w")
         if not file then
             error("unable to create logfile " .. logfile_path)


### PR DESCRIPTION
- refactor `ziputils` into `ziputils` and `enigmaxml` libraries
- refactor both to use `client` library for managing dependencies like `luaosutils`
- refactor PowerShell commands to work with `io.popen` as well as `luaosutils.process.execute`
- PowerShell script for `calc_gunzip_command` now returns raw decompressed bytes in `stdout`.
- other minor changes as part of refactor

I wonder is the reason `"%s"` works now (and `& { %s }` doesn't) is because all the commands are on a single line now. (This is to accommodate `io.popen` which apparently doesn't work with embedded newlines.)
