### PR TITLE
Mss bugfixes

### DIFF
--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -190,10 +190,10 @@ function muse_font_efx(font_info)
         retval = retval | 0x02
     end
     if font_info.Underline then
-        retval = retval | 0x03
+        retval = retval | 0x04
     end
     if font_info.Strikethrough then
-        retval = retval | 0x04
+        retval = retval | 0x08
     end
     return retval
 end

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -266,7 +266,7 @@ function write_page_prefs(style_element)
     set_element_text(style_element, "pageWidth", page_prefs.PageWidth / EVPU_PER_INCH)
     set_element_text(style_element, "pageHeight", page_prefs.PageHeight / EVPU_PER_INCH)
     set_element_text(style_element, "pagePrintableWidth",
-        (page_prefs.PageWidth - page_prefs.LeftPageRightMargin - page_prefs.LeftPageRightMargin) / EVPU_PER_INCH)
+        (page_prefs.PageWidth - page_prefs.LeftPageLeftMargin - page_prefs.LeftPageRightMargin) / EVPU_PER_INCH)
     set_element_text(style_element, "pageEvenLeftMargin", page_prefs.LeftPageLeftMargin / EVPU_PER_INCH)
     set_element_text(style_element, "pageOddLeftMargin",
         (page_prefs.UseFacingPages and page_prefs.RightPageLeftMargin or page_prefs.LeftPageLeftMargin) / EVPU_PER_INCH)

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -281,7 +281,7 @@ function write_page_prefs(style_element)
     set_element_text(style_element, "firstSystemIndentationValue", page_prefs.FirstSystemLeft / EVPU_PER_SPACE)
     local page_percent = page_prefs.PageScaling / 100
     local staff_percent = (page_prefs.SystemStaffHeight / (EVPU_PER_SPACE * 4 * 16)) * (page_prefs.SystemScaling / 100)
-    set_element_text(style_element, "Spatium", (EVPU_PER_SPACE * staff_percent * page_percent) / EVPU_PER_MM)
+    set_element_text(style_element, "spatium", (EVPU_PER_SPACE * staff_percent * page_percent) / EVPU_PER_MM)
     if default_music_font.IsSMuFLFont then
         set_element_text(style_element, "musicalSymbolFont", default_music_font.Name)
         set_element_text(style_element, "musicalTextFont", default_music_font.Name .. " Text")

--- a/src/document_options_to_musescore.lua
+++ b/src/document_options_to_musescore.lua
@@ -4,8 +4,8 @@ function plugindef()
     finaleplugin.NoStore = true
     finaleplugin.Author = "Robert Patterson"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "1.0.2"
-    finaleplugin.Date = "October 20, 2024"
+    finaleplugin.Version = "1.0.3"
+    finaleplugin.Date = "December 31, 2024"
     finaleplugin.CategoryTags = "Document"
     finaleplugin.MinJWLuaVersion = 0.75
     finaleplugin.Notes = [[

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -544,10 +544,9 @@ function process_one_file(path, full_file_name)
     if abort_if(not score_partwise, "file does not appear to be exported from Finale") then
         return
     end
-    local encoding_element = tinyxml2.XMLHandle(score_partwise)
-        :FirstChildElement("identification")
-        :FirstChildElement("encoding")
-        :ToElement()
+    local information_element = tinyxml2.XMLHandle(score_partwise):FirstChildElement("identification"):ToElement()
+    local encoding_element = tinyxml2.XMLHandle(information_element):FirstChildElement("encoding"):ToElement()
+    
     local software_element = encoding_element and encoding_element:FirstChildElement("software")
     local encoding_date_element = encoding_element and encoding_element:FirstChildElement("encoding-date")
     if abort_if(not software_element or not encoding_date_element, "missing required element 'software' and/or 'encoding-date'") then
@@ -561,9 +560,9 @@ function process_one_file(path, full_file_name)
         finaleplugin.Version .. " for " .. (finenv.UI():IsOnMac() and "Mac" or "Windows"))
     local original_encoding_date = encoding_date_element:GetText()
     encoding_date_element:SetText(os.date("%Y-%m-%d"))
-    local miscellaneous_element = encoding_element:FirstChildElement("miscellaneous")
+    local miscellaneous_element = information_element:FirstChildElement("miscellaneous")
     if not miscellaneous_element then
-        miscellaneous_element = encoding_element:InsertNewChildElement("miscellaneous")
+        miscellaneous_element = information_element:InsertNewChildElement("miscellaneous")
     end
     local function insert_miscellaneous_field(name, value)
         local element = miscellaneous_element:InsertNewChildElement("miscellaneous-field")

--- a/src/musicxml_massage_export.lua
+++ b/src/musicxml_massage_export.lua
@@ -5,8 +5,8 @@ function plugindef()
     finaleplugin.NoStore = true
     finaleplugin.Author = "Robert Patterson and Carl Vine"
     finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
-    finaleplugin.Version = "2.5.1"
-    finaleplugin.Date = "November 7, 2024"
+    finaleplugin.Version = "2.5.2"
+    finaleplugin.Date = "December 31, 2024"
     finaleplugin.LoadLuaOSUtils = true
     finaleplugin.CategoryTags = "Document"
     finaleplugin.MinJWLuaVersion = 0.77


### PR DESCRIPTION
Fix various bugs uncovered as part of the dev process for [denigma](https://github.com/rpatters1/denigma).

- massage script was adding miscellaneous fields to wrong element
- mss script was calculating `pagePrintableWidth` incorrectly.
- mss script was setting incorrect bits for underline and strikethru font styles.
- use consistent case for `spatium` node. (MuseScore has supported the lower case version for a while, even though it does not write it as of 4.4.4.)
